### PR TITLE
Add single configuration loader

### DIFF
--- a/auth_aksk_options.go
+++ b/auth_aksk_options.go
@@ -27,10 +27,10 @@ type AKSKAuthOptions struct {
 	BssDomain   string
 	BssDomainID string
 
-	AccessKey string //Access Key
-	SecretKey string //Secret key
+	AccessKey string // Access Key
+	SecretKey string // Secret key
 
-	// AgencyNmae is the name of agnecy
+	// AgencyName is the name of agency
 	AgencyName string
 
 	// AgencyDomainName is the name of domain who created the agency

--- a/auth_options.go
+++ b/auth_options.go
@@ -82,11 +82,6 @@ type AuthOptions struct {
 	// authentication token ID.
 	TokenID string `json:"-"`
 
-	// AccessKey provide key for AK/SK auth
-	AccessKey string
-	// SecretKey provide key for AK/SK auth
-	SecretKey string
-
 	// AgencyName is the name of agency
 	AgencyName string `json:"-"`
 
@@ -95,6 +90,39 @@ type AuthOptions struct {
 
 	// DelegatedProject is the name of delegated project
 	DelegatedProject string `json:"-"`
+}
+
+// ToTokenV2CreateMap allows AuthOptions to satisfy the AuthOptionsBuilder
+// interface in the v2 tokens package
+func (opts AuthOptions) ToTokenV2CreateMap() (map[string]interface{}, error) {
+	// Populate the request map.
+	authMap := make(map[string]interface{})
+
+	if opts.Username != "" {
+		if opts.Password != "" {
+			authMap["passwordCredentials"] = map[string]interface{}{
+				"username": opts.Username,
+				"password": opts.Password,
+			}
+		} else {
+			return nil, ErrMissingInput{Argument: "Password"}
+		}
+	} else if opts.TokenID != "" {
+		authMap["token"] = map[string]interface{}{
+			"id": opts.TokenID,
+		}
+	} else {
+		return nil, ErrMissingInput{Argument: "Username"}
+	}
+
+	if opts.TenantID != "" {
+		authMap["tenantId"] = opts.TenantID
+	}
+	if opts.TenantName != "" {
+		authMap["tenantName"] = opts.TenantName
+	}
+
+	return map[string]interface{}{"auth": authMap}, nil
 }
 
 func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[string]interface{}, error) {

--- a/auth_options.go
+++ b/auth_options.go
@@ -82,7 +82,12 @@ type AuthOptions struct {
 	// authentication token ID.
 	TokenID string `json:"-"`
 
-	// AgencyNmae is the name of agnecy
+	// AccessKey provide key for AK/SK auth
+	AccessKey string
+	// SecretKey provide key for AK/SK auth
+	SecretKey string
+
+	// AgencyName is the name of agency
 	AgencyName string `json:"-"`
 
 	// AgencyDomainName is the name of domain who created the agency
@@ -90,39 +95,6 @@ type AuthOptions struct {
 
 	// DelegatedProject is the name of delegated project
 	DelegatedProject string `json:"-"`
-}
-
-// ToTokenV2CreateMap allows AuthOptions to satisfy the AuthOptionsBuilder
-// interface in the v2 tokens package
-func (opts AuthOptions) ToTokenV2CreateMap() (map[string]interface{}, error) {
-	// Populate the request map.
-	authMap := make(map[string]interface{})
-
-	if opts.Username != "" {
-		if opts.Password != "" {
-			authMap["passwordCredentials"] = map[string]interface{}{
-				"username": opts.Username,
-				"password": opts.Password,
-			}
-		} else {
-			return nil, ErrMissingInput{Argument: "Password"}
-		}
-	} else if opts.TokenID != "" {
-		authMap["token"] = map[string]interface{}{
-			"id": opts.TokenID,
-		}
-	} else {
-		return nil, ErrMissingInput{Argument: "Username"}
-	}
-
-	if opts.TenantID != "" {
-		authMap["tenantId"] = opts.TenantID
-	}
-	if opts.TenantName != "" {
-		authMap["tenantName"] = opts.TenantName
-	}
-
-	return map[string]interface{}{"auth": authMap}, nil
 }
 
 func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[string]interface{}, error) {

--- a/openstack/auth_env.go
+++ b/openstack/auth_env.go
@@ -23,7 +23,7 @@ To use this function, first set the OS_* environment variables (for example,
 by sourcing an `openrc` file), then:
 
 	opts, err := openstack.AuthOptionsFromEnv()
-	provider, err := openstack.OldAuthenticatedClient(opts)
+	provider, err := openstack.AuthenticatedClient(opts)
 */
 func AuthOptionsFromEnv(envs ...*env) (golangsdk.AuthOptions, error) {
 	e := NewEnv(defaultPrefix)
@@ -31,40 +31,19 @@ func AuthOptionsFromEnv(envs ...*env) (golangsdk.AuthOptions, error) {
 		e = envs[0]
 	}
 
-	authURL := e.GetEnv("AUTH_URL")
-	token := e.GetEnv("TOKEN", "TOKEN_ID")
-	username := e.GetEnv("USERNAME")
-	userID := e.GetEnv("USERID", "USER_ID")
-	password := e.GetEnv("PASSWORD")
-	projectID := e.GetEnv("PROJECT_ID", "TENANT_ID")
-	projectName := e.GetEnv("PROJECT_NAME", "TENANT_NAME")
-	domainID := e.GetEnv("DOMAIN_ID")
-	domainName := e.GetEnv("DOMAIN_NAME")
-
-	access := noEnv.GetEnv("AWS_ACCESS_KEY_ID")
-	if access == "" {
-		access = e.GetEnv("ACCESS_KEY", "ACCESS_KEY_ID")
-	}
-	secret := noEnv.GetEnv("AWS_ACCESS_KEY_SECRET")
-	if secret == "" {
-		secret = e.GetEnv("SECRET_KEY", "ACCESS_KEY_SECRET")
-	}
-
 	ao := golangsdk.AuthOptions{
-		IdentityEndpoint: authURL,
-		Username:         username,
-		UserID:           userID,
-		Password:         password,
-		DomainID:         domainID,
-		DomainName:       domainName,
-		TenantID:         projectID,
-		TenantName:       projectName,
-		TokenID:          token,
-		AccessKey:        access,
-		SecretKey:        secret,
-		AgencyName:       e.GetEnv("AGENCY_NAME"),
-		AgencyDomainName: e.GetEnv("AGENCY_DOMAIN_NAME"),
-		DelegatedProject: e.GetEnv("DELEGATED_PROJECT"),
+		IdentityEndpoint: e.GetEnv("AUTH_URL"),
+		Username:         e.GetEnv("USERNAME"),
+		UserID:           e.GetEnv("USERID", "USER_ID"),
+		Password:         e.GetEnv("PASSWORD"),
+		DomainID:         e.GetEnv("DOMAIN_ID"),
+		DomainName:       e.GetEnv("DOMAIN_NAME"),
+		TenantID:         e.GetEnv("PROJECT_ID", "TENANT_ID"),
+		TenantName:       e.GetEnv("PROJECT_NAME", "TENANT_NAME"),
+		TokenID:          e.GetEnv("TOKEN", "TOKEN_ID"),
+		AgencyName:       e.GetEnv("AGENCY_NAME", "TARGET_AGENCY_NAME"),
+		AgencyDomainName: e.GetEnv("AGENCY_DOMAIN_NAME", "TARGET_DOMAIN_NAME"),
+		DelegatedProject: e.GetEnv("DELEGATED_PROJECT", "TARGET_DOMAIN_NAME"),
 	}
 	return ao, nil
 }

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -91,8 +91,8 @@ Example:
 		Region: os.Getenv("OS_REGION_NAME"),
 	})
 */
-func AuthenticatedClient(options golangsdk.AuthOptions) (*golangsdk.ProviderClient, error) {
-	client, err := NewClient(options.IdentityEndpoint)
+func AuthenticatedClient(options golangsdk.AuthOptionsProvider) (*golangsdk.ProviderClient, error) {
+	client, err := NewClient(options.GetIdentityEndpoint())
 	if err != nil {
 		return nil, err
 	}

--- a/openstack/loader.go
+++ b/openstack/loader.go
@@ -77,8 +77,6 @@ func NewEnv(prefix string) Env {
 	return &env{Prefix: prefix}
 }
 
-var noEnv = NewEnv("")
-
 func (e *env) GetPrefix() string {
 	return e.Prefix
 }
@@ -88,6 +86,15 @@ func (e *env) CloudFromEnv() *Cloud {
 	verify := true
 	if v := e.GetEnv("INSECURE"); v != "" {
 		verify = v != "1" && v != "true"
+	}
+	aws := NewEnv("AWS_")
+	access := aws.GetEnv("ACCESS_KEY_ID")
+	if access == "" {
+		access = e.GetEnv("ACCESS_KEY", "ACCESS_KEY_ID", "AK")
+	}
+	secret := aws.GetEnv("ACCESS_KEY_SECRET")
+	if secret == "" {
+		secret = e.GetEnv("SECRET_KEY", "ACCESS_KEY_SECRET", "SK")
 	}
 	cloud := &Cloud{
 		Cloud:   e.GetEnv("CLOUD"),
@@ -107,8 +114,8 @@ func (e *env) CloudFromEnv() *Cloud {
 			DomainName:        authOpts.DomainName,
 			DomainID:          authOpts.DomainID,
 			DefaultDomain:     e.GetEnv("DEFAULT_DOMAIN"),
-			AccessKey:         authOpts.AccessKey,
-			SecretKey:         authOpts.SecretKey,
+			AccessKey:         access,
+			SecretKey:         secret,
 			AgencyName:        authOpts.AgencyName,
 			AgencyDomainName:  authOpts.AgencyDomainName,
 			DelegatedProject:  authOpts.DelegatedProject,

--- a/openstack/loader.go
+++ b/openstack/loader.go
@@ -60,9 +60,15 @@ func fileList(name string) []string {
 
 // This is helper for env-prefixed loading
 type Env interface {
+	// CloudFromEnv constructs cloud configuration with values from <prefixed> env vars
 	CloudFromEnv() *Cloud
+	// GetEnv finds first non-empty <prefixed> env variable to be used
 	GetEnv(keys ...string) string
+	// GetPrefix returns used prefix
 	GetPrefix() string
+
+	// AuthenticatedClient is the main meaning on `Env`, providing prefix-based
+	// way to get authenticated client
 	AuthenticatedClient() (*golangsdk.ProviderClient, error)
 }
 
@@ -70,6 +76,7 @@ type env struct {
 	Prefix string
 }
 
+// NewEnv create new <prefixed> env loader
 func NewEnv(prefix string) Env {
 	if prefix != "" && !strings.HasSuffix(prefix, "_") {
 		prefix += "_"

--- a/openstack/loader.go
+++ b/openstack/loader.go
@@ -1,0 +1,560 @@
+package openstack
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/utils"
+)
+
+const (
+	defaultEnvVarKey = "envvars"
+	defaultPrefix    = "OS_"
+)
+
+var (
+	yamlSuffixes = []string{".yaml", ".yml"}
+	jsonSuffixes = []string{".json"}
+
+	configFiles = fileList("clouds")
+	secureFiles = fileList("secure")
+	vendorFiles = fileList("clouds-public")
+)
+
+func configSearchPath() []string {
+	home, _ := os.UserHomeDir()
+	cwd, _ := filepath.Abs(filepath.Dir(os.Args[0]))
+	userConfigDir, _ := filepath.Abs(filepath.Join(home, ".config/openstack"))
+	unixConfigDir, _ := filepath.Abs("/etc/openstack")
+	return []string{
+		cwd,
+		userConfigDir,
+		unixConfigDir,
+	}
+}
+
+func fileList(name string) []string {
+	paths := configSearchPath()
+	var suffixes []string
+	suffixes = append(suffixes, yamlSuffixes...)
+	suffixes = append(suffixes, jsonSuffixes...)
+	size := len(suffixes) * len(paths)
+	files := make([]string, size, size)
+	i := 0
+	for _, path := range paths {
+		for _, suffix := range suffixes {
+			files[i] = filepath.Join(path, name+suffix)
+			i++
+		}
+	}
+	return files
+}
+
+// This is helper for env-prefixed loading
+type Env interface {
+	CloudFromEnv() *Cloud
+	GetEnv(keys ...string) string
+	GetPrefix() string
+	AuthenticatedClient() (*golangsdk.ProviderClient, error)
+}
+
+type env struct {
+	Prefix string
+}
+
+func NewEnv(prefix string) Env {
+	if prefix != "" && !strings.HasSuffix(prefix, "_") {
+		prefix += "_"
+	}
+	return &env{Prefix: prefix}
+}
+
+var noEnv = NewEnv("")
+
+func (e *env) GetPrefix() string {
+	return e.Prefix
+}
+
+func (e *env) CloudFromEnv() *Cloud {
+	authOpts, _ := AuthOptionsFromEnv(e)
+	verify := true
+	if v := e.GetEnv("INSECURE"); v != "" {
+		verify = v != "1" && v != "true"
+	}
+	cloud := &Cloud{
+		Cloud:   e.GetEnv("CLOUD"),
+		Profile: e.GetEnv("PROFILE"),
+		AuthInfo: authInfo{
+			AuthURL:           authOpts.IdentityEndpoint,
+			Token:             authOpts.TokenID,
+			Username:          authOpts.Username,
+			UserID:            authOpts.UserID,
+			Password:          authOpts.Password,
+			ProjectName:       authOpts.TenantName,
+			ProjectID:         authOpts.TenantID,
+			UserDomainName:    e.GetEnv("USER_DOMAIN_NAME"),
+			UserDomainID:      e.GetEnv("USER_DOMAIN_ID"),
+			ProjectDomainName: e.GetEnv("PROJECT_DOMAIN_NAME"),
+			ProjectDomainID:   e.GetEnv("PROJECT_DOMAIN_ID"),
+			DomainName:        authOpts.DomainName,
+			DomainID:          authOpts.DomainID,
+			DefaultDomain:     e.GetEnv("DEFAULT_DOMAIN"),
+			AccessKey:         authOpts.AccessKey,
+			SecretKey:         authOpts.SecretKey,
+			AgencyName:        authOpts.AgencyName,
+			AgencyDomainName:  authOpts.AgencyDomainName,
+			DelegatedProject:  authOpts.DelegatedProject,
+		},
+		AuthType:           AuthType(e.GetEnv("AUTH_TYPE")),
+		RegionName:         e.GetEnv("REGION_NAME", "REGION_ID"),
+		EndpointType:       e.GetEnv("ENDPOINT_TYPE"),
+		Interface:          e.GetEnv("INTERFACE"),
+		IdentityAPIVersion: e.GetEnv("IDENTITY_API_VERSION"),
+		VolumeAPIVersion:   e.GetEnv("VOLUME_API_VERSION"),
+		Verify:             &verify,
+		CACertFile:         e.GetEnv("CA_CERT", "CA_CERT_FILE"),
+		ClientCertFile:     e.GetEnv("CLIENT_CERT", "CLIENT_CERT_FILE"),
+		ClientKeyFile:      e.GetEnv("CLIENT_KEY", "CLIENT_KEY_FILE"),
+	}
+	return cloud
+}
+
+// GetEnv returns first non-empty value of given environment variables
+func (e *env) GetEnv(keys ...string) string {
+	for _, key := range keys {
+		if value := os.Getenv(e.Prefix + key); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+// VendorConfig represents a collection of PublicCloud entries in clouds-public.yaml file.
+// The format of the clouds-public.yml is documented at
+// https://docs.openstack.org/python-openstackclient/latest/configuration/
+type VendorConfig struct {
+	Clouds map[string]Cloud `yaml:"public-clouds" json:"public-clouds"`
+}
+
+// Config represents a collection of Cloud entries in a clouds.yaml file.
+// The format of clouds.yaml is documented at
+// https://docs.openstack.org/os-client-config/latest/user/configuration.html.
+type Config struct {
+	DefaultCloud string           `yaml:"-" json:"-"`
+	Clouds       map[string]Cloud `yaml:"clouds" json:"clouds"`
+}
+
+// AuthType represents a valid method of authentication: `password`, `token`, `aksk` or `agency`
+type AuthType string
+
+// authInfo represents the auth section of a cloud entry
+type authInfo struct {
+	// AuthURL is the keystone/identity endpoint URL.
+	AuthURL string `yaml:"auth_url,omitempty" json:"auth_url,omitempty"`
+
+	// Token is a pre-generated authentication token.
+	Token string `yaml:"token,omitempty" json:"token,omitempty"`
+
+	// Username is the username of the user.
+	Username string `yaml:"username,omitempty" json:"username,omitempty"`
+
+	// UserID is the unique ID of a user.
+	UserID string `yaml:"user_id,omitempty" json:"user_id,omitempty"`
+
+	// Password is the password of the user.
+	Password string `yaml:"password,omitempty" json:"password,omitempty"`
+
+	// ProjectName is the common/human-readable name of a project.
+	// Users can be scoped to a project.
+	// ProjectName on its own is not enough to ensure a unique scope. It must
+	// also be combined with either a ProjectDomainName or ProjectDomainID.
+	// ProjectName cannot be combined with ProjectID in a scope.
+	ProjectName string `yaml:"project_name,omitempty" json:"project_name,omitempty"`
+
+	// ProjectID is the unique ID of a project.
+	// It can be used to scope a user to a specific project.
+	ProjectID string `yaml:"project_id,omitempty" json:"project_id,omitempty"`
+
+	// UserDomainName is the name of the domain where a user resides.
+	// It is used to identify the source domain of a user.
+	UserDomainName string `yaml:"user_domain_name,omitempty" json:"user_domain_name,omitempty"`
+
+	// UserDomainID is the unique ID of the domain where a user resides.
+	// It is used to identify the source domain of a user.
+	UserDomainID string `yaml:"user_domain_id,omitempty" json:"user_domain_id,omitempty"`
+
+	// ProjectDomainName is the name of the domain where a project resides.
+	// It is used to identify the source domain of a project.
+	// ProjectDomainName can be used in addition to a ProjectName when scoping
+	// a user to a specific project.
+	ProjectDomainName string `yaml:"project_domain_name,omitempty" json:"project_domain_name,omitempty"`
+
+	// ProjectDomainID is the name of the domain where a project resides.
+	// It is used to identify the source domain of a project.
+	// ProjectDomainID can be used in addition to a ProjectName when scoping
+	// a user to a specific project.
+	ProjectDomainID string `yaml:"project_domain_id,omitempty" json:"project_domain_id,omitempty"`
+
+	// DomainName is the name of a domain which can be used to identify the
+	// source domain of either a user or a project.
+	// If UserDomainName and ProjectDomainName are not specified, then DomainName
+	// is used as a default choice.
+	// It can also be used be used to specify a domain-only scope.
+	DomainName string `yaml:"domain_name,omitempty" json:"domain_name,omitempty"`
+
+	// DomainID is the unique ID of a domain which can be used to identify the
+	// source domain of either a user or a project.
+	// If UserDomainID and ProjectDomainID are not specified, then DomainID is
+	// used as a default choice.
+	// It can also be used be used to specify a domain-only scope.
+	DomainID string `yaml:"domain_id,omitempty" json:"domain_id,omitempty"`
+
+	// DefaultDomain is the domain ID to fall back on if no other domain has
+	// been specified and a domain is required for scope.
+	DefaultDomain string `yaml:"default_domain,omitempty" json:"default_domain,omitempty"`
+
+	// AK/SK auth means
+	AccessKey string `yaml:"ak,omitempty" json:"ak,omitempty"`
+	SecretKey string `yaml:"sk,omitempty" json:"sk,omitempty"`
+
+	// OTC Agency config
+	AgencyName string `yaml:"agency_name,omitempty" json:"agency_name,omitempty"`
+	// AgencyDomainName is the name of domain who created the agency
+	AgencyDomainName string `yaml:"target_domain_id,omitempty" json:"target_domain_id,omitempty"`
+	// DelegatedProject is the name of delegated project
+	DelegatedProject string `yaml:"target_project_name,omitempty" json:"target_project_name,omitempty"`
+}
+
+// Cloud represents an entry in a clouds.yaml/public-clouds.yaml/secure.yaml file.
+type Cloud struct {
+	Cloud      string        `yaml:"cloud,omitempty" json:"cloud,omitempty"`
+	Profile    string        `yaml:"profile,omitempty" json:"profile,omitempty"`
+	AuthType   AuthType      `yaml:"auth_type,omitempty" json:"auth_type,omitempty"`
+	AuthInfo   authInfo      `yaml:"auth,omitempty" json:"auth,omitempty"`
+	RegionName string        `yaml:"region_name,omitempty" json:"region_name,omitempty"`
+	Regions    []interface{} `yaml:"regions,omitempty" json:"regions,omitempty"`
+
+	// EndpointType and Interface both specify whether to use the public, internal,
+	// or admin interface of a service. They should be considered synonymous, but
+	// EndpointType will take precedence when both are specified.
+	EndpointType string `yaml:"endpoint_type,omitempty" json:"endpoint_type,omitempty"`
+	Interface    string `yaml:"interface,omitempty" json:"interface,omitempty"`
+
+	// API Version overrides.
+	IdentityAPIVersion string `yaml:"identity_api_version,omitempty" json:"identity_api_version,omitempty"`
+	VolumeAPIVersion   string `yaml:"volume_api_version,omitempty" json:"volume_api_version,omitempty"`
+
+	// Verify whether or not SSL API requests should be verified.
+	Verify *bool `yaml:"verify,omitempty" json:"verify,omitempty"`
+
+	// CACertFile a path to a CA Cert bundle that can be used as part of
+	// verifying SSL API requests.
+	CACertFile string `yaml:"cacert,omitempty" json:"cacert,omitempty"`
+
+	// ClientCertFile a path to a client certificate to use as part of the SSL
+	// transaction.
+	ClientCertFile string `yaml:"cert,omitempty" json:"cert,omitempty"`
+
+	// ClientKeyFile a path to a client key to use as part of the SSL
+	// transaction.
+	ClientKeyFile string `yaml:"key,omitempty" json:"key,omitempty"`
+}
+
+func loadFile(path string) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func loadCloudFile(path string) (*Config, error) {
+	data, err := loadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	clouds := new(Config)
+	if err := yaml.Unmarshal(data, clouds); err != nil {
+		return nil, err
+	}
+	return clouds, err
+}
+
+func loadVendorFile(path string) (*VendorConfig, error) {
+	data, err := loadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	clouds := new(VendorConfig)
+	if err := yaml.Unmarshal(data, clouds); err != nil {
+		return nil, err
+	}
+	return clouds, err
+}
+
+func mergeWithVendor(config *Config, vendor *VendorConfig) (*Config, error) {
+	for k, cloud := range config.Clouds {
+		profile := cloud.Profile
+		if profile == "" {
+			profile = cloud.Cloud
+		}
+		if profile == "" {
+			continue
+		}
+		if v, ok := vendor.Clouds[profile]; ok {
+			merged, err := mergeClouds(&cloud, &v)
+			if err != nil {
+				log.Printf("error during merge with vendor file: %s", err)
+				return config, err
+			}
+			config.Clouds[k] = *merged
+		}
+	}
+	return config, nil
+}
+
+func mergeCloudConfigs(config, override *Config) (*Config, error) {
+	resultClouds := &Config{
+		Clouds: map[string]Cloud{},
+	}
+	for k, cfg := range config.Clouds {
+		if over, ok := override.Clouds[k]; ok {
+			cld, err := mergeClouds(cfg, over)
+			if err != nil {
+				return nil, err
+			}
+			resultClouds.Clouds[k] = *cld
+		} else {
+			resultClouds.Clouds[k] = cfg
+		}
+	}
+	return resultClouds, nil
+}
+
+func selectExisting(files []string) string {
+	for _, file := range files {
+		if _, err := os.Stat(file); err == nil {
+			return file
+		}
+	}
+	return ""
+}
+
+// mergeClouds merges two Config recursively (the authInfo also gets merged).
+// In case both Config define a value, the value in the 'override' cloud takes precedence
+func mergeClouds(cloud, override interface{}) (*Cloud, error) {
+	overrideJson, err := json.Marshal(override)
+	if err != nil {
+		return nil, err
+	}
+	cloudJson, err := json.Marshal(cloud)
+	if err != nil {
+		return nil, err
+	}
+	var overrideInterface interface{}
+	err = json.Unmarshal(overrideJson, &overrideInterface)
+	if err != nil {
+		return nil, err
+	}
+	var cloudInterface interface{}
+	err = json.Unmarshal(cloudJson, &cloudInterface)
+	if err != nil {
+		return nil, err
+	}
+	var mergedCloud Cloud
+	mergedInterface := utils.MergeInterfaces(overrideInterface, cloudInterface)
+	mergedJson, err := json.Marshal(mergedInterface)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(mergedJson, &mergedCloud); err != nil {
+		return nil, err
+	}
+	return &mergedCloud, nil
+}
+
+func mergeWithSecure(cloudConfig *Config, securePath string) *Config {
+	s, err := loadCloudFile(securePath)
+	if err != nil {
+		log.Printf("Failed to load %s as secure config", securePath)
+		return cloudConfig
+	}
+	cc, err := mergeCloudConfigs(cloudConfig, s)
+	if err != nil {
+		log.Printf("Failed to merge %s into cloud config", securePath)
+		return cloudConfig
+	}
+	return cc
+}
+
+func mergeWithVendors(cloudConfig *Config, vendorPath string) *Config {
+	v, err := loadVendorFile(vendorPath)
+	if err != nil {
+		log.Printf("Failed to load %s as vendor config", vendorPath)
+		return cloudConfig
+	}
+	cc, err := mergeWithVendor(cloudConfig, v)
+	if err != nil {
+		log.Printf("Failed to merge %s into vendor config", vendorPath)
+		return cloudConfig
+	}
+	return cc
+}
+
+// LoadCloudConfig utilize all existing cloud configurations to create cloud configuration:
+// env variables, clouds.yaml, secure.yaml, clouds-public.yaml
+func (e *env) loadOpenstackConfig() (*Config, error) {
+	var (
+		configs = make([]string, len(configFiles))
+		secure  = make([]string, len(secureFiles))
+		vendors = make([]string, len(vendorFiles))
+	)
+	copy(configs, configFiles)
+	copy(secure, secureFiles)
+	copy(vendors, vendorFiles)
+
+	// find config files
+	if c := e.GetEnv("CLIENT_CONFIG_FILE"); c != "" {
+		configs = utils.PrependString(c, configs)
+	}
+	configPath := selectExisting(configFiles)
+	if s := e.GetEnv("CLIENT_SECURE_FILE"); s != "" {
+		secure = utils.PrependString(s, secure)
+	}
+	securePath := selectExisting(secureFiles)
+	if v := e.GetEnv("CLIENT_VENDOR_FILE"); v != "" {
+		vendors = utils.PrependString(v, vendors)
+	}
+	vendorPath := selectExisting(vendors)
+
+	cloudConfig := &Config{
+		Clouds: map[string]Cloud{},
+	}
+
+	// load clouds.yaml
+	if configPath != "" {
+		c, err := loadCloudFile(configPath)
+		if err != nil {
+			log.Printf("Failed to load %s as cloud config", securePath)
+		}
+		if c != nil {
+			cloudConfig = c
+		}
+	}
+
+	// merge with secure.yaml
+	if securePath != "" {
+		cloudConfig = mergeWithSecure(cloudConfig, securePath)
+	}
+
+	// append cloud from envvars
+	envVarKey := e.GetEnv("CLOUD_NAME")
+	if envVarKey == "" {
+		envVarKey = defaultEnvVarKey
+	}
+	if _, ok := cloudConfig.Clouds[envVarKey]; ok {
+		return nil, fmt.Errorf("%sCLOUD_NAME=`%s` duplicates cloud defined in file", e.Prefix, envVarKey)
+	}
+	cloudConfig.Clouds[envVarKey] = *NewEnv(envVarKey).CloudFromEnv()
+
+	cloudName := e.GetEnv("CLOUD")
+	if cloudName == "" && len(cloudConfig.Clouds) == 1 {
+		for k := range cloudConfig.Clouds {
+			cloudName = k
+		}
+	}
+	cloudConfig.DefaultCloud = cloudName
+
+	// merge with clouds-public.yaml
+	if vendorPath != "" {
+		cloudConfig = mergeWithVendors(cloudConfig, vendorPath)
+	}
+	return cloudConfig, nil
+}
+
+func info2opts(authInfo *authInfo, authType AuthType) (*golangsdk.AuthOptions, error) {
+	// project scope
+	if authInfo.ProjectID != "" || authInfo.ProjectName != "" {
+		if authInfo.ProjectDomainName != "" {
+			authInfo.DomainName = authInfo.ProjectDomainName
+		}
+		if authInfo.ProjectDomainID != "" {
+			authInfo.ProjectID = authInfo.ProjectDomainID
+		}
+	}
+	// user scope
+	if authInfo.Username != "" || authInfo.UserID != "" {
+		if authInfo.UserDomainName != "" {
+			authInfo.DomainName = authInfo.UserDomainName
+		}
+		if authInfo.UserDomainID != "" {
+			authInfo.ProjectID = authInfo.UserDomainID
+		}
+	}
+
+	ao := &golangsdk.AuthOptions{
+		IdentityEndpoint: authInfo.AuthURL,
+		TokenID:          authInfo.Token,
+		Username:         authInfo.Username,
+		UserID:           authInfo.UserID,
+		Password:         authInfo.Password,
+	}
+
+	// If an auth_type of "token" was specified, then make sure
+	// Gophercloud properly authenticates with a token. This involves
+	// unsetting a few other auth options. The reason this is done
+	// here is to wait until all auth settings (both in clouds.yaml
+	// and via environment variables) are set and then unset them.
+	if strings.Contains(string(authType), "token") || strings.Contains(string(authType), "aksk") {
+		ao.Username = ""
+		ao.Password = ""
+		ao.UserID = ""
+		ao.DomainID = ""
+		ao.DomainName = ""
+	}
+
+	// Check for absolute minimum requirements.
+	if ao.IdentityEndpoint == "" {
+		err := golangsdk.ErrMissingInput{Argument: "auth_url"}
+		return nil, err
+	}
+	return ao, nil
+}
+
+// AuthenticatedClient create new client based on used env prefix
+// this uses LoadOpenstackConfig inside
+func (e *env) AuthenticatedClient() (*golangsdk.ProviderClient, error) {
+	config, err := e.loadOpenstackConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to authenticate client")
+	}
+	cloud, err := mergeClouds(
+		config.Clouds[config.DefaultCloud],
+		e.CloudFromEnv(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge cloud %s with env vars: %s", config.DefaultCloud, err)
+	}
+	opts, err := info2opts(&cloud.AuthInfo, cloud.AuthType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert authInfo to AuthOpts with env vars: %s", err)
+	}
+	client, err := AuthenticatedClient(*opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to authenticate client: %s", err)
+	}
+	return client, nil
+}

--- a/openstack/utils/utils.go
+++ b/openstack/utils/utils.go
@@ -1,7 +1,70 @@
 package utils
 
-func DeleteNotPassParams(params *map[string]interface{}, not_pass_params []string) {
-	for _, i := range not_pass_params {
+import (
+	"reflect"
+)
+
+func DeleteNotPassParams(params *map[string]interface{}, notPassParams []string) {
+	for _, i := range notPassParams {
 		delete(*params, i)
 	}
+}
+
+// merges two interfaces. In cases where a value is defined for both 'overridingInterface' and
+// 'inferiorInterface' the value in 'overridingInterface' will take precedence.
+func MergeInterfaces(overridingInterface, inferiorInterface interface{}) interface{} {
+	switch overriding := overridingInterface.(type) {
+	case map[string]interface{}:
+		interfaceMap, ok := inferiorInterface.(map[string]interface{})
+		if !ok {
+			return overriding
+		}
+		for k, v := range interfaceMap {
+			if overridingValue, ok := overriding[k]; ok {
+				overriding[k] = MergeInterfaces(overridingValue, v)
+			} else {
+				overriding[k] = v
+			}
+		}
+	case []interface{}:
+		list, ok := inferiorInterface.([]interface{})
+		if !ok {
+			return overriding
+		}
+		for i := range list {
+			overriding = append(overriding, list[i])
+		}
+		return overriding
+	case nil:
+		// mergeClouds(nil, map[string]interface{...}) -> map[string]interface{...}
+		v, ok := inferiorInterface.(map[string]interface{})
+		if ok {
+			return v
+		}
+	}
+	// We don't want to override with empty values
+	if reflect.DeepEqual(overridingInterface, nil) || reflect.DeepEqual(reflect.Zero(reflect.TypeOf(overridingInterface)).Interface(), overridingInterface) {
+		return inferiorInterface
+	} else {
+		return overridingInterface
+	}
+}
+
+func PrependString(item string, slice []string) []string {
+	newSize := len(slice) + 1
+	result := make([]string, newSize, newSize)
+	result[0] = item
+	for i, v := range slice {
+		result[i+1] = v
+	}
+	return result
+}
+
+func In(item interface{}, slice interface{}) bool {
+	for _, it := range slice.([]interface{}) {
+		if reflect.DeepEqual(item, it) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Add `loader.go` as central point for cloud config loading (as done in [openstacksdk/config/loader.py](https://github.com/openstack/openstacksdk/blob/master/openstack/config/loader.py))

Refactor `AuthOptionsFromEnv`

Fix miss-prints in related files