### PR TITLE
Add missing CCE cluster spec fields

### DIFF
--- a/openstack/cce/v3/clusters/results.go
+++ b/openstack/cce/v3/clusters/results.go
@@ -9,184 +9,189 @@ import (
 type ListCluster struct {
 	// API type, fixed value Cluster
 	Kind string `json:"kind"`
-	//API version, fixed value v3
+	// API version, fixed value v3
 	ApiVersion string `json:"apiVersion"`
-	//all Clusters
+	// all Clusters
 	Clusters []Clusters `json:"items"`
 }
 
 type Clusters struct {
 	// API type, fixed value Cluster
 	Kind string `json:"kind" required:"true"`
-	//API version, fixed value v3
+	// API version, fixed value v3
 	ApiVersion string `json:"apiversion" required:"true"`
-	//Metadata of a Cluster
+	// Metadata of a Cluster
 	Metadata MetaData `json:"metadata" required:"true"`
-	//specifications of a Cluster
+	// specifications of a Cluster
 	Spec Spec `json:"spec" required:"true"`
-	//status of a Cluster
+	// status of a Cluster
 	Status Status `json:"status"`
 }
 
-//Metadata required to create a cluster
+// Metadata required to create a cluster
 type MetaData struct {
-	//Cluster unique name
+	// Cluster unique name
 	Name string `json:"name"`
-	//Cluster unique Id
+	// Cluster unique Id
 	Id string `json:"uid"`
 	// Cluster tag, key/value pair format
 	Labels map[string]string `json:"labels,omitempty"`
-	//Cluster annotation, key/value pair format
+	// Cluster annotation, key/value pair format
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
-//Specifications to create a cluster
+// Specifications to create a cluster
 type Spec struct {
-	//Cluster Type: VirtualMachine, BareMetal, or Windows
+	// Cluster Type: VirtualMachine, BareMetal, or Windows
 	Type string `json:"type" required:"true"`
 	// Cluster specifications
 	Flavor string `json:"flavor" required:"true"`
-	// For the cluster version, please fill in v1.7.3-r10 or v1.9.2-r1. Currently only Kubernetes 1.7 and 1.9 clusters are supported.
+	// Cluster's baseline Kubernetes version. The latest version is recommended
 	Version string `json:"version,omitempty"`
-	//Cluster description
+	// Cluster description
 	Description string `json:"description,omitempty"`
-	//Public IP ID
+	// Public IP ID
 	PublicIP string `json:"publicip_id,omitempty"`
 	// Node network parameters
 	HostNetwork HostNetworkSpec `json:"hostNetwork" required:"true"`
-	//Container network parameters
+	// Container network parameters
 	ContainerNetwork ContainerNetworkSpec `json:"containerNetwork" required:"true"`
-	//Authentication parameters
+	// Authentication parameters
 	Authentication AuthenticationSpec `json:"authentication,omitempty"`
 	// Charging mode of the cluster, which is 0 (on demand)
 	BillingMode int `json:"billingMode,omitempty"`
-	//Extended parameter for a cluster
+	// Extended parameter for a cluster
 	ExtendParam map[string]string `json:"extendParam,omitempty"`
+	// KubernetesSvcIpRange Service CIDR block or the IP address range which the kubernetes clusterIp must fall within.
+	// This parameter is available only for clusters of v1.11.7 and later.
+	KubernetesSvcIpRange string `json:"kubernetesSvcIpRange,omitempty"`
+	// KubeProxyMode Service forwarding mode. One of `iptables`, `ipvs`
+	KubeProxyMode string `json:"kubeProxyMode,omitempty"`
 }
 
 // Node network parameters
 type HostNetworkSpec struct {
-	//The ID of the VPC used to create the node
+	// The ID of the VPC used to create the node
 	VpcId string `json:"vpc" required:"true"`
-	//The ID of the subnet used to create the node
+	// The ID of the subnet used to create the node
 	SubnetId string `json:"subnet" required:"true"`
 	// The ID of the high speed network used to create bare metal nodes.
 	// This parameter is required when creating a bare metal cluster.
 	HighwaySubnet string `json:"highwaySubnet,omitempty"`
-	//The ID of the Security Group used to create the node
+	// The ID of the Security Group used to create the node
 	SecurityGroup string `json:"SecurityGroup,omitempty"`
 }
 
-//Container network parameters
+// Container network parameters
 type ContainerNetworkSpec struct {
-	//Container network type: overlay_l2 , underlay_ipvlan or vpc-router
+	// Container network type: overlay_l2 , underlay_ipvlan or vpc-router
 	Mode string `json:"mode" required:"true"`
-	//Container network segment: 172.16.0.0/16 ~ 172.31.0.0/16. If there is a network segment conflict, it will be automatically reselected.
+	// Container network segment: 172.16.0.0/16 ~ 172.31.0.0/16. If there is a network segment conflict, it will be automatically reselected.
 	Cidr string `json:"cidr,omitempty"`
 }
 
-//Authentication parameters
+// Authentication parameters
 type AuthenticationSpec struct {
-	//Authentication mode: rbac , x509 or authenticating_proxy
+	// Authentication mode: rbac , x509 or authenticating_proxy
 	Mode                string            `json:"mode" required:"true"`
 	AuthenticatingProxy map[string]string `json:"authenticatingProxy" required:"true"`
 }
 
 type Status struct {
-	//The state of the cluster
+	// The state of the cluster
 	Phase string `json:"phase"`
-	//The ID of the Job that is operating asynchronously in the cluster
+	// The ID of the Job that is operating asynchronously in the cluster
 	JobID string `json:"jobID"`
-	//Reasons for the cluster to become current
+	// Reasons for the cluster to become current
 	Reason string `json:"reason"`
-	//The status of each component in the cluster
+	// The status of each component in the cluster
 	Conditions Conditions `json:"conditions"`
-	//Kube-apiserver access address in the cluster
+	// Kube-apiserver access address in the cluster
 	Endpoints []Endpoints `json:"-"`
 }
 
 type Conditions struct {
-	//The type of component
+	// The type of component
 	Type string `json:"type"`
-	//The state of the component
+	// The state of the component
 	Status string `json:"status"`
-	//The reason that the component becomes current
+	// The reason that the component becomes current
 	Reason string `json:"reason"`
 }
 
 type Endpoints struct {
-	//The address accessed within the user's subnet - OpenTelekomCloud
+	// The address accessed within the user's subnet - OpenTelekomCloud
 	Url string `json:"url"`
-	//Public network access address - OpenTelekomCloud
+	// Public network access address - OpenTelekomCloud
 	Type string `json:"type"`
-	//Internal network address - OTC
+	// Internal network address - OTC
 	Internal string `json:"internal"`
-	//External network address - OTC
+	// External network address - OTC
 	External string `json:"external"`
-	//Endpoint of the cluster to be accessed through API Gateway - OTC
+	// Endpoint of the cluster to be accessed through API Gateway - OTC
 	ExternalOTC string `json:"external_otc"`
 }
 
 type Certificate struct {
-	//API type, fixed value Config
+	// API type, fixed value Config
 	Kind string `json:"kind"`
-	//API version, fixed value v1
+	// API version, fixed value v1
 	ApiVersion string `json:"apiVersion"`
-	//Cluster list
+	// Cluster list
 	Clusters []CertClusters `json:"clusters"`
-	//User list
+	// User list
 	Users []CertUsers `json:"users"`
-	//Context list
+	// Context list
 	Contexts []CertContexts `json:"contexts"`
-	//The current context
+	// The current context
 	CurrentContext string `json:"current-context"`
 }
 
 type CertClusters struct {
-	//Cluster name
+	// Cluster name
 	Name string `json:"name"`
-	//Cluster information
+	// Cluster information
 	Cluster CertCluster `json:"cluster"`
 }
 
 type CertCluster struct {
-	//Server IP address
+	// Server IP address
 	Server string `json:"server"`
-	//Certificate data
+	// Certificate data
 	CertAuthorityData string `json:"certificate-authority-data"`
 }
 
 type CertUsers struct {
-	//User name
+	// User name
 	Name string `json:"name"`
-	//Cluster information
+	// Cluster information
 	User CertUser `json:"user"`
 }
 
 type CertUser struct {
-	//Client certificate
+	// Client certificate
 	ClientCertData string `json:"client-certificate-data"`
-	//Client key data
+	// Client key data
 	ClientKeyData string `json:"client-key-data"`
 }
 
 type CertContexts struct {
-	//Context name
+	// Context name
 	Name string `json:"name"`
-	//Context information
+	// Context information
 	Context CertContext `json:"context"`
 }
 
 type CertContext struct {
-	//Cluster name
+	// Cluster name
 	Cluster string `json:"cluster"`
-	//User name
+	// User name
 	User string `json:"user"`
 }
 
 // UnmarshalJSON helps to unmarshal Status fields into needed values.
-//OTC and Huawei have different data types and child fields for `endpoints` field in Cluster Status.
-//This function handles the unmarshal for both
+// OTC and Huawei have different data types and child fields for `endpoints` field in Cluster Status.
+// This function handles the unmarshal for both
 func (r *Status) UnmarshalJSON(b []byte) error {
 	type tmp Status
 	var s struct {
@@ -198,7 +203,7 @@ func (r *Status) UnmarshalJSON(b []byte) error {
 
 	if err != nil {
 		switch err.(type) {
-		case *json.UnmarshalTypeError: //check if type error occurred (handles the different endpoint structure for huawei and otc)
+		case *json.UnmarshalTypeError: // check if type error occurred (handles the different endpoint structure for huawei and otc)
 			var s struct {
 				tmp
 				Endpoints Endpoints `json:"endpoints"`


### PR DESCRIPTION
Add `KubernetesSvcIpRange` and `KubeProxyMode` to cce cluster spec

Required for opentelekomcloud/terraform-provider-opentelekomcloud#680

https://docs.otc.t-systems.com/en-us/api2/cce/cce_02_0236.html