### PR TITLE
Make CCE addons to be up to date with doc

### DIFF
--- a/openstack/cce/v3/addons/requests.go
+++ b/openstack/cce/v3/addons/requests.go
@@ -4,7 +4,7 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud"
 )
 
-var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
+var RequestOpts = golangsdk.RequestOpts{
 	MoreHeaders: map[string]string{"Content-Type": "application/json"},
 }
 
@@ -27,14 +27,14 @@ type CreateOpts struct {
 }
 
 type CreateMetadata struct {
-	Anno Annotations `json:"annotations" required:"true"`
+	Annotations Annotations `json:"annotations" required:"true"`
 }
 
 type Annotations struct {
 	AddonInstallType string `json:"addon.install/type" required:"true"`
 }
 
-//Specifications to create an addon
+// Specifications to create an addon
 type RequestSpec struct {
 	// For the addon version.
 	Version string `json:"version" required:"true"`
@@ -47,7 +47,8 @@ type RequestSpec struct {
 }
 
 type Values struct {
-	Basic map[string]string `json:"basic" required:"true"`
+	Basic    map[string]interface{} `json:"basic" required:"true"`
+	Advanced map[string]interface{} `json:"custom,omitempty"`
 }
 
 // ToAddonCreateMap builds a create request body from CreateOpts.
@@ -57,20 +58,20 @@ func (opts CreateOpts) ToAddonCreateMap() (map[string]interface{}, error) {
 
 // Create accepts a CreateOpts struct and uses the values to create a new
 // addon.
-func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder, cluster_id string) (r CreateResult) {
+func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder, clusterId string) (r CreateResult) {
 	b, err := opts.ToAddonCreateMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
 	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{201}}
-	_, r.Err = c.Post(rootURL(c, cluster_id), b, &r.Body, reqOpt)
+	_, r.Err = c.Post(rootURL(c, clusterId), b, &r.Body, reqOpt)
 	return
 }
 
 // Get retrieves a particular addon based on its unique ID.
-func Get(c *golangsdk.ServiceClient, id, cluster_id string) (r GetResult) {
-	_, r.Err = c.Get(resourceURL(c, id, cluster_id), &r.Body, &golangsdk.RequestOpts{
+func Get(c *golangsdk.ServiceClient, id, clusterId string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id, clusterId), &r.Body, &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
 		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: nil,
 	})
@@ -78,8 +79,8 @@ func Get(c *golangsdk.ServiceClient, id, cluster_id string) (r GetResult) {
 }
 
 // Delete will permanently delete a particular addon based on its unique ID.
-func Delete(c *golangsdk.ServiceClient, id, cluster_id string) (r DeleteResult) {
-	_, r.Err = c.Delete(resourceURL(c, id, cluster_id), &golangsdk.RequestOpts{
+func Delete(c *golangsdk.ServiceClient, id, clusterId string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, id, clusterId), &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
 		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: nil,
 	})

--- a/openstack/cce/v3/addons/results.go
+++ b/openstack/cce/v3/addons/results.go
@@ -17,7 +17,7 @@ type Addon struct {
 	Status Status `json:"status"`
 }
 
-//Metadata required to create an addon
+// Metadata required to create an addon
 type MetaData struct {
 	// Addon unique name
 	Name string `json:"name"`
@@ -29,7 +29,7 @@ type MetaData struct {
 	Annotations map[string]string `json:"annotaions"`
 }
 
-//Specifications to create an addon
+// Specifications to create an addon
 type Spec struct {
 	// For the addon version.
 	Version string `json:"version" required:"true"`
@@ -48,13 +48,13 @@ type Spec struct {
 }
 
 type Status struct {
-	//The state of the addon
+	// The state of the addon
 	Status string `json:"status"`
-	//Reasons for the addon to become current
+	// Reasons for the addon to become current
 	Reason string `json:"reason"`
-	//Error Message
+	// Error Message
 	Message string `json:"message"`
-	//The target versions of the addon
+	// The target versions of the addon
 	TargetVersions []string `json:"targetVersions"`
 }
 


### PR DESCRIPTION
### Fix issues with CCE addon API usage
- Apply huaweicloud/golangsdk#347
- Add missing `Advanced`(`custom`) values