### PR TITLE
Add default region resolution to Env.Cloud()

### DIFF
--- a/openstack/loader.go
+++ b/openstack/loader.go
@@ -110,6 +110,11 @@ func (e *env) cloudFromEnv() *Cloud {
 	if secret == "" {
 		secret = e.GetEnv("SECRET_KEY", "ACCESS_KEY_SECRET", "SK")
 	}
+	region := e.GetEnv("REGION_NAME", "REGION_ID")
+	if region == "" {
+		region = utils.GetRegion(authOpts)
+	}
+
 	cloud := &Cloud{
 		Cloud:   e.GetEnv("CLOUD"),
 		Profile: e.GetEnv("PROFILE"),
@@ -135,7 +140,7 @@ func (e *env) cloudFromEnv() *Cloud {
 			DelegatedProject:  authOpts.DelegatedProject,
 		},
 		AuthType:           AuthType(e.GetEnv("AUTH_TYPE")),
-		RegionName:         e.GetEnv("REGION_NAME", "REGION_ID"),
+		RegionName:         region,
 		EndpointType:       e.GetEnv("ENDPOINT_TYPE"),
 		Interface:          e.GetEnv("INTERFACE"),
 		IdentityAPIVersion: e.GetEnv("IDENTITY_API_VERSION"),


### PR DESCRIPTION
Use `utils.GetRegion` inside of `Env.Cloud()` to assure that region is set in cloud config