### PR TITLE
Fix unused CLIENT_*_FILE in config loading

### DIFF
--- a/openstack/loader.go
+++ b/openstack/loader.go
@@ -47,7 +47,7 @@ func fileList(name string) []string {
 	suffixes = append(suffixes, yamlSuffixes...)
 	suffixes = append(suffixes, jsonSuffixes...)
 	size := len(suffixes) * len(paths)
-	files := make([]string, size, size)
+	files := make([]string, size)
 	i := 0
 	for _, path := range paths {
 		for _, suffix := range suffixes {
@@ -475,11 +475,13 @@ func (e *env) loadOpenstackConfig() (*Config, error) {
 	if c := e.GetEnv("CLIENT_CONFIG_FILE"); c != "" {
 		configs = utils.PrependString(c, configs)
 	}
-	configPath := selectExisting(configFiles)
+	configPath := selectExisting(configs)
+
 	if s := e.GetEnv("CLIENT_SECURE_FILE"); s != "" {
 		secure = utils.PrependString(s, secure)
 	}
-	securePath := selectExisting(secureFiles)
+	securePath := selectExisting(secure)
+
 	if v := e.GetEnv("CLIENT_VENDOR_FILE"); v != "" {
 		vendors = utils.PrependString(v, vendors)
 	}


### PR DESCRIPTION
`CLIENT_CONFIG_FILE`, `CLIENT_SECURE_FILE`, `CLIENT_VENDOR_FILE` env vars were prepended to `configs`, `secure`, `vendors` list. But `configFiles`, `secureFiles`, `vendorFiles` lists were used afterwards.