### PR TITLE
Add possibility to list bandwidths

### DIFF
--- a/acceptance/openstack/networking/v1/bandwidths_test.go
+++ b/acceptance/openstack/networking/v1/bandwidths_test.go
@@ -47,6 +47,39 @@ func TestBandwidthsUpdate(t *testing.T) {
 	tools.PrintResource(t, newBandWidth)
 }
 
+func TestBandwidthsList(t *testing.T) {
+	client, err := clients.NewNetworkV1Client()
+	if err != nil {
+		t.Fatalf("Unable to create NetworkV1 client: %v", err)
+	}
+	bandwidthSize := 1
+
+	// Create eip/bandwidth
+	eip, err := createEipResource(t, client, bandwidthSize)
+	if err != nil {
+		t.Fatalf("Unable to create eip/banwidth pair: %s", err)
+	}
+
+	// Delete an eip
+	defer deleteEipResource(t, client, eip.ID)
+
+	// Query a bandwidth
+	existingBandwidths, err := bandwidths.List(client, bandwidths.ListOpts{
+		ShareType: "PER",
+	}).Extract()
+	if err != nil {
+		t.Fatalf("Unable to list bandwidths: %s", err)
+	}
+
+	for _, b := range existingBandwidths {
+		if b.ID == eip.BandwidthID {
+			t.Logf("Bandwith with ID %s is in bandwidth list", b.ID)
+			return
+		}
+	}
+	t.Errorf("Failed to find created bandwidth")
+}
+
 func createEipResource(t *testing.T, nwClient *golangsdk.ServiceClient, bandwidthSize int) (*eips.PublicIp, error) {
 	bandName := tools.RandomString("testacc-", 8)
 

--- a/openstack/networking/v1/bandwidths/requests.go
+++ b/openstack/networking/v1/bandwidths/requests.go
@@ -38,3 +38,38 @@ func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) 
 	})
 	return
 }
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToBandwidthListQuery() (string, error)
+}
+
+// ListOpts allows extensions to add additional parameters to the API.
+type ListOpts struct {
+	ShareType           string `q:"share_type"`
+	EnterpriseProjectID string `q:"enterprise_project_id"`
+}
+
+// ToBWListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToBandwidthListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List is a method by which can get the detailed information of all bandwidths
+func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) (r ListResult) {
+	url := listURL(client)
+	query, err := opts.ToBandwidthListQuery()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	url += query
+
+	_, r.Err = client.Get(url, &r.Body, nil)
+	return
+}

--- a/openstack/networking/v1/bandwidths/results.go
+++ b/openstack/networking/v1/bandwidths/results.go
@@ -75,7 +75,7 @@ type ListResult struct {
 }
 
 func (r ListResult) Extract() ([]BandWidth, error) {
-	var s []BandWidth
-	err := r.ExtractIntoSlicePtr(&s, "bandwidths")
-	return s, err
+	var bws []BandWidth
+	err := r.ExtractIntoSlicePtr(&bws, "bandwidths")
+	return bws, err
 }

--- a/openstack/networking/v1/bandwidths/results.go
+++ b/openstack/networking/v1/bandwidths/results.go
@@ -68,3 +68,14 @@ func (r UpdateResult) Extract() (BandWidth, error) {
 	err := r.Result.ExtractIntoStructPtr(&bw, "bandwidth")
 	return bw, err
 }
+
+// ListResult is a struct which contains the result of list method
+type ListResult struct {
+	golangsdk.Result
+}
+
+func (r ListResult) Extract() ([]BandWidth, error) {
+	var s []BandWidth
+	err := r.ExtractIntoSlicePtr(&s, "bandwidths")
+	return s, err
+}

--- a/openstack/networking/v1/bandwidths/urls.go
+++ b/openstack/networking/v1/bandwidths/urls.go
@@ -7,3 +7,7 @@ const resourcePath = "bandwidths"
 func resourceURL(client *golangsdk.ServiceClient, id string) string {
 	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
+
+func listURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL(client.ProjectID, resourcePath)
+}


### PR DESCRIPTION
Implement EIP bandwidth list

Doc: https://docs.otc.t-systems.com/api/eip/eip_apiBandwidth_0002.html

### Acceptance tests:

```
=== RUN   TestBandwidthsList
    bandwidths_test.go:86: Attempting to create eip/bandwidth: testacc-fW1tL9LI
    bandwidths_test.go:104: Waiting for eip 818eeb6a-b9b4-49b5-ba78-dd8bb9ab56b5 to be active
    bandwidths_test.go:113: Created eip/bandwidth: testacc-fW1tL9LI
    bandwidths_test.go:76: Bandwith with ID 5bad82b9-09bf-4167-8a5f-c433794f69a0 is in bandwidth list
    bandwidths_test.go:119: Attempting to delete eip/bandwidth: 818eeb6a-b9b4-49b5-ba78-dd8bb9ab56b5
    bandwidths_test.go:127: Waitting for eip 818eeb6a-b9b4-49b5-ba78-dd8bb9ab56b5 to be deleted
    bandwidths_test.go:132: Deleted eip/bandwidth: 818eeb6a-b9b4-49b5-ba78-dd8bb9ab56b5
--- PASS: TestBandwidthsList (9.57s)
PASS
```
