### PR TITLE
Allow to create service instance without region

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -196,7 +196,20 @@ func v3auth(client *golangsdk.ProviderClient, endpoint string, opts tokens3.Auth
 			return v3auth(client, endpoint, opts, eo)
 		}
 	}
+
+	clientRegion := ""
+	if aOpts, ok := opts.(*golangsdk.AuthOptions); ok {
+		if aOpts.TenantName == "" && project != nil {
+			aOpts.TenantName = project.Name
+		}
+		clientRegion = utils.GetRegion(*aOpts)
+	}
+
 	client.EndpointLocator = func(opts golangsdk.EndpointOpts) (string, error) {
+		// use client region as default one
+		if opts.Region == "" && clientRegion != "" {
+			opts.Region = clientRegion
+		}
 		return V3EndpointURL(serviceCatalog, opts)
 	}
 


### PR DESCRIPTION
Make `client.EndpointLocator` to use  region from auth opts

Refers to #25 

### Acceptance test results:
```
=== RUN   TestAuthTokenNoRegion
--- PASS: TestAuthTokenNoRegion (0.69s)
PASS

Process finished with exit code 0
```