### PR TITLE
Add setting `client.DomainID` for domain-scoped token

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -196,6 +196,7 @@ func v3auth(client *golangsdk.ProviderClient, endpoint string, opts tokens3.Auth
 	}
 	if user != nil {
 		client.UserID = user.ID
+		client.DomainID = user.Domain.ID
 	}
 
 	if opts.CanReauth() {


### PR DESCRIPTION
### Description
Use `user.domain.id` instead of `project.domain.id`: `project` is optional in token response and `user` is mandatory and exist for both project- and domain-scoped tokens

### Documentation
https://docs.otc.t-systems.com/en-us/api/iam/en-us_topic_0057845583.html
https://docs.otc.t-systems.com/en-us/api/iam/en-us_topic_0057845585.html
