### PR TITLE
Remove default region value

### DIFF
--- a/openstack/utils/utils.go
+++ b/openstack/utils/utils.go
@@ -1,13 +1,12 @@
 package utils
 
 import (
-	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"os"
 	"reflect"
 	"strings"
-)
 
-const defaultRegion = "eu-de"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+)
 
 func DeleteNotPassParams(params *map[string]interface{}, notPassParams []string) {
 	for _, i := range notPassParams {
@@ -75,21 +74,19 @@ func In(item interface{}, slice interface{}) bool {
 }
 
 // GetRegion returns the region that was specified in the auth options. If a
-// region was not set it returns value from env OS_REGION_NAME or defaultRegion
-// "eu-de"
+// region was not set it returns value from env OS_REGION_NAME
 func GetRegion(authOpts golangsdk.AuthOptions) string {
 	n := authOpts.TenantName
+	region := ""
 	if n == "" {
 		n = authOpts.DelegatedProject
+	} else {
+		region = strings.Split(n, "_")[0]
 	}
-	defRegion := defaultRegion
-	if len(n) != 0 {
-		defRegion = strings.Split(n, "_")[0]
-	}
-	return getenv("OS_REGION_NAME", defRegion)
+	return getenv("OS_REGION_NAME", region)
 }
 
-//getenv returns value from env is present or default value
+// getenv returns value from env is present or default value
 func getenv(key, fallback string) string {
 	value := os.Getenv(key)
 	if value == "" {


### PR DESCRIPTION
If a region is not set, no default value will be used

<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it:
Terraform provider for OTC uses identity service client with domain-scoped token.
Domain-scoped service catalog has only one endpoint record: 
```json
      {
        "endpoints": [
          {
            "id": "2df96872ffd84d4a84c29967739ae3fd",
            "interface": "public",
            "region": "*",
            "region_id": "*",
            "url": "https://iam.eu-de.otc.t-systems.com/v3"
          }
        ],
        "id": "45a401041b6547f79b976e2d0727c52b",
        "name": "keystone",
        "type": "identity"
      },
```
Which is not used because for catalog discovery following check is used:
```go
if (endpoint.Region == opts.Region || (opts.Region == "" && endpoint.Region == "*")) {
```
So in case `opts.Region` is not empty, wildcard region won't be used.
If we will remove `opts.Region == ""` check, for project-scoped service catalog there will be two entries, both wildcard one and 
```json
      {
        "endpoints": [
          {
            "id": "f4be859c14914a4ea9213f60114b221c",
            "interface": "public",
            "region": "eu-de",
            "region_id": "eu-de",
            "url": "https://iam.eu-de.otc.t-systems.com/v3"
          }
        ],
        "id": "45a401041b6547f79b976e2d0727c52b",
        "name": "keystone",
        "type": "identity"
      },
```

So removing the default region seems to be the most correct resolution in our case

### Which issue this PR fixes:
Fixes #49 

### Acceptance tests:
```
=== RUN   TestAuthenticatedClient
    client_test.go:48: Located a storage service at endpoint: [https://swift.eu-de.otc.t-systems.com/v1/AUTH_5dd3c0b24cdc4d31952c49589182a89d/]
--- PASS: TestAuthenticatedClient (0.49s)
=== RUN   TestAuthTokenNoRegion
--- PASS: TestAuthTokenNoRegion (0.66s)
=== RUN   TestReauth
    client_test.go:97: Creating a compute client
    client_test.go:105: Sleeping for 1 second
    client_test.go:107: Attempting to reauthenticate
    client_test.go:114: Creating a compute client
--- PASS: TestReauth (1.67s)
PASS
```