### PR TITLE
Fix searching `clouds.yaml` in cwd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ vet:
 	@go vet ./...
 
 test-unit:
-	@go test ./openstack/... -parallel 4
+	@go test ./openstack/... -parallel 4 -v
 
 test-acc:
 	@echo "Starting acceptance tests..."

--- a/acceptance/openstack/client_test.go
+++ b/acceptance/openstack/client_test.go
@@ -1,11 +1,7 @@
 package openstack
 
 import (
-	"fmt"
-	"io/ioutil"
 	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -14,18 +10,6 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
-)
-
-var (
-	backupSuffix = ".backup"
-	tmpl         = []byte(`
-clouds:
-  useless_cloud:
-    auth:
-      auth_url: "http://localhost/"
-      password: "some-useless-passw0rd"
-      username: "some-name"
-`)
 )
 
 func TestAuthenticatedClient(t *testing.T) {
@@ -52,85 +36,6 @@ func TestAuthenticatedClient(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 	t.Logf("Located a storage service at endpoint: [%s]", storage.Endpoint)
-}
-
-// copyFile copies file if it exists
-func copyFile(t *testing.T, src, dest string) {
-	fileStat, err := os.Stat(src)
-	if err != nil && os.IsNotExist(err) {
-		t.Logf("File %s doesn't exist, skipping", src)
-		return
-	}
-
-	data, err := ioutil.ReadFile(src)
-	th.AssertNoErr(t, err)
-	th.AssertNoErr(t, ioutil.WriteFile(dest, data, fileStat.Mode()))
-}
-
-// backupFile creates copy of the file and return path to the copy
-func backupFiles(t *testing.T, originals ...string) {
-	for _, file := range originals {
-		backupFile := fmt.Sprintf("%s%s", file, backupSuffix)
-		copyFile(t, file, backupFile)
-	}
-}
-
-// restoreBackup replaces files with the backups
-func restoreBackup(t *testing.T, files ...string) {
-	for _, originalName := range files {
-		backupFile := fmt.Sprintf("%s%s", originalName, backupSuffix)
-		_, err := os.Stat(originalName)
-		if err != nil && os.IsNotExist(err) {
-			t.Logf("File %s doesn't exist, skipping", originalName)
-			continue
-		}
-		th.AssertNoErr(t, err)
-		th.AssertNoErr(t, os.Remove(originalName))
-		copyFile(t, backupFile, originalName)
-		if err != nil && os.IsNotExist(err) {
-			t.Logf("File %s doesn't exist, skipping", backupFile)
-			continue
-		}
-		th.AssertNoErr(t, err)
-		th.AssertNoErr(t, os.Remove(originalName))
-	}
-}
-
-func TestCloudYamlPaths(t *testing.T) {
-	_ = os.Setenv("OS_CLOUD", "useless_cloud")
-	home, _ := os.UserHomeDir()
-	cwd, _ := os.Getwd()
-
-	fileName := "clouds.yaml"
-	currentConfigDir := filepath.Join(cwd, fileName)
-	userConfigDir := filepath.Join(home, ".config/openstack", fileName)
-	unixConfigDir := filepath.Join("/etc/openstack", fileName)
-	files := []string{currentConfigDir, userConfigDir, unixConfigDir}
-	backupFiles(t, currentConfigDir, userConfigDir, unixConfigDir)
-	defer restoreBackup(t, files...)
-
-	for _, fileName := range files {
-		t.Run(fmt.Sprintf("Config at %s", fileName), func(subT *testing.T) {
-			if runtime.GOOS == "windows" && fileName == unixConfigDir {
-				subT.Skip("Skipping on windows")
-			}
-
-			dir := filepath.Dir(fileName)
-			if err := os.MkdirAll(dir, 0755); err != nil { // make sure that dir exists
-				if os.IsPermission(err) {
-					subT.Skip(err.Error())
-				}
-				th.AssertNoErr(t, err)
-			}
-
-			th.AssertNoErr(subT, ioutil.WriteFile(fileName, tmpl, 0644))
-			cloud, err := clients.EnvOS.Cloud()
-			th.AssertNoErr(subT, err)
-			th.AssertEquals(subT, "http://localhost/", cloud.AuthInfo.AuthURL)
-			th.AssertEquals(subT, "some-useless-passw0rd", cloud.AuthInfo.Password)
-			th.AssertEquals(subT, "some-name", cloud.AuthInfo.Username)
-		})
-	}
 }
 
 func TestAuthTokenNoRegion(t *testing.T) {

--- a/acceptance/openstack/client_test.go
+++ b/acceptance/openstack/client_test.go
@@ -55,26 +55,24 @@ func TestAuthenticatedClient(t *testing.T) {
 }
 
 // copyFile copies file if it exists
-func copyFile(t *testing.T, src, dest string) string {
+func copyFile(t *testing.T, src, dest string) {
 	fileStat, err := os.Stat(src)
 	if err != nil && os.IsNotExist(err) {
 		t.Logf("File %s doesn't exist, skipping", src)
-		return ""
+		return
 	}
 
 	data, err := ioutil.ReadFile(src)
 	th.AssertNoErr(t, err)
 	th.AssertNoErr(t, ioutil.WriteFile(dest, data, fileStat.Mode()))
-	return dest
 }
 
 // backupFile creates copy of the file and return path to the copy
 func backupFiles(t *testing.T, originals ...string) {
 	for _, file := range originals {
 		backupFile := fmt.Sprintf("%s%s", file, backupSuffix)
-		backupFile = copyFile(t, file, backupFile)
+		copyFile(t, file, backupFile)
 	}
-	return
 }
 
 // restoreBackup replaces files with the backups
@@ -112,7 +110,7 @@ func TestCloudYamlPaths(t *testing.T) {
 			}
 
 			dir := filepath.Dir(fileName)
-			if err := os.MkdirAll(dir, 755); err != nil { // make sure that dir exists
+			if err := os.MkdirAll(dir, 0755); err != nil { // make sure that dir exists
 				if os.IsPermission(err) {
 					subT.Skip(err.Error())
 				}

--- a/acceptance/openstack/client_test.go
+++ b/acceptance/openstack/client_test.go
@@ -84,9 +84,15 @@ func restoreBackup(t *testing.T, files ...string) {
 			t.Logf("File %s doesn't exist, skipping", originalName)
 			continue
 		}
+		th.AssertNoErr(t, err)
 		th.AssertNoErr(t, os.Remove(originalName))
 		copyFile(t, backupFile, originalName)
-		th.AssertNoErr(t, os.Remove(backupFile))
+		if err != nil && os.IsNotExist(err) {
+			t.Logf("File %s doesn't exist, skipping", backupFile)
+			continue
+		}
+		th.AssertNoErr(t, err)
+		th.AssertNoErr(t, os.Remove(originalName))
 	}
 }
 

--- a/acceptance/openstack/client_test.go
+++ b/acceptance/openstack/client_test.go
@@ -16,16 +16,16 @@ import (
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
 
-const (
+var (
 	backupSuffix = ".backup"
-	tmpl         = `
+	tmpl         = []byte(`
 clouds:
   useless_cloud:
     auth:
       auth_url: "http://localhost/"
       password: "some-useless-passw0rd"
       username: "some-name"
-`
+`)
 )
 
 func TestAuthenticatedClient(t *testing.T) {
@@ -117,7 +117,7 @@ func TestCloudYamlPaths(t *testing.T) {
 				th.AssertNoErr(t, err)
 			}
 
-			th.AssertNoErr(subT, writeYamlFile(tmpl, fileName))
+			th.AssertNoErr(subT, ioutil.WriteFile(fileName, tmpl, 0644))
 			cloud, err := clients.EnvOS.Cloud()
 			th.AssertNoErr(subT, err)
 			th.AssertEquals(subT, "http://localhost/", cloud.AuthInfo.AuthURL)

--- a/acceptance/openstack/common.go
+++ b/acceptance/openstack/common.go
@@ -3,7 +3,6 @@
 package openstack
 
 import (
-	"os"
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/extensions"
@@ -17,18 +16,4 @@ func PrintExtension(t *testing.T, extension *extensions.Extension) {
 	t.Logf("Description: %s", extension.Description)
 	t.Logf("Updated: %s", extension.Updated)
 	t.Logf("Links: %v", extension.Links)
-}
-
-func writeYamlFile(tmpl string, filename string) error {
-	file, err := os.Create(filename)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = file.Close() }()
-
-	_, err = file.Write([]byte(tmpl))
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/acceptance/openstack/common.go
+++ b/acceptance/openstack/common.go
@@ -3,6 +3,7 @@
 package openstack
 
 import (
+	"os"
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/extensions"
@@ -16,4 +17,18 @@ func PrintExtension(t *testing.T, extension *extensions.Extension) {
 	t.Logf("Description: %s", extension.Description)
 	t.Logf("Updated: %s", extension.Updated)
 	t.Logf("Links: %v", extension.Links)
+}
+
+func writeYamlFile(tmpl string, filename string) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+
+	_, err = file.Write([]byte(tmpl))
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/openstack/client_test.go
+++ b/openstack/client_test.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
 
@@ -94,7 +93,7 @@ func TestCloudYamlPaths(t *testing.T) {
 			}
 
 			th.AssertNoErr(subT, ioutil.WriteFile(fileName, tmpl, 0644))
-			cloud, err := clients.EnvOS.Cloud()
+			cloud, err := NewEnv("OS_").Cloud()
 			th.AssertNoErr(subT, err)
 			th.AssertEquals(subT, "http://localhost/", cloud.AuthInfo.AuthURL)
 			th.AssertEquals(subT, "some-useless-passw0rd", cloud.AuthInfo.Password)

--- a/openstack/client_test.go
+++ b/openstack/client_test.go
@@ -44,24 +44,23 @@ func backupFiles(t *testing.T, originals ...string) {
 	}
 }
 
+func removeIfExist(t *testing.T, path string) {
+	_, err := os.Stat(path)
+	if err != nil && os.IsNotExist(err) {
+		t.Logf("File %s doesn't exist, skipping", path)
+		return
+	}
+	th.AssertNoErr(t, err)
+	th.AssertNoErr(t, os.Remove(path))
+}
+
 // restoreBackup replaces files with the backups
 func restoreBackup(t *testing.T, files ...string) {
-	for _, originalName := range files {
-		backupFile := fmt.Sprintf("%s%s", originalName, backupSuffix)
-		_, err := os.Stat(originalName)
-		if err != nil && os.IsNotExist(err) {
-			t.Logf("File %s doesn't exist, skipping", originalName)
-			continue
-		}
-		th.AssertNoErr(t, err)
-		th.AssertNoErr(t, os.Remove(originalName))
-		copyFile(t, backupFile, originalName)
-		if err != nil && os.IsNotExist(err) {
-			t.Logf("File %s doesn't exist, skipping", backupFile)
-			continue
-		}
-		th.AssertNoErr(t, err)
-		th.AssertNoErr(t, os.Remove(originalName))
+	for _, original := range files {
+		backup := fmt.Sprintf("%s%s", original, backupSuffix)
+		removeIfExist(t, original)
+		copyFile(t, backup, original)
+		removeIfExist(t, backup)
 	}
 }
 

--- a/openstack/client_test.go
+++ b/openstack/client_test.go
@@ -1,0 +1,104 @@
+package openstack
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+var (
+	backupSuffix = ".backup"
+	tmpl         = []byte(`
+clouds:
+  useless_cloud:
+    auth:
+      auth_url: "http://localhost/"
+      password: "some-useless-passw0rd"
+      username: "some-name"
+`)
+)
+
+// copyFile copies file if it exists
+func copyFile(t *testing.T, src, dest string) {
+	fileStat, err := os.Stat(src)
+	if err != nil && os.IsNotExist(err) {
+		t.Logf("File %s doesn't exist, skipping", src)
+		return
+	}
+
+	data, err := ioutil.ReadFile(src)
+	th.AssertNoErr(t, err)
+	th.AssertNoErr(t, ioutil.WriteFile(dest, data, fileStat.Mode()))
+}
+
+// backupFile creates copy of the file and return path to the copy
+func backupFiles(t *testing.T, originals ...string) {
+	for _, file := range originals {
+		backupFile := fmt.Sprintf("%s%s", file, backupSuffix)
+		copyFile(t, file, backupFile)
+	}
+}
+
+// restoreBackup replaces files with the backups
+func restoreBackup(t *testing.T, files ...string) {
+	for _, originalName := range files {
+		backupFile := fmt.Sprintf("%s%s", originalName, backupSuffix)
+		_, err := os.Stat(originalName)
+		if err != nil && os.IsNotExist(err) {
+			t.Logf("File %s doesn't exist, skipping", originalName)
+			continue
+		}
+		th.AssertNoErr(t, err)
+		th.AssertNoErr(t, os.Remove(originalName))
+		copyFile(t, backupFile, originalName)
+		if err != nil && os.IsNotExist(err) {
+			t.Logf("File %s doesn't exist, skipping", backupFile)
+			continue
+		}
+		th.AssertNoErr(t, err)
+		th.AssertNoErr(t, os.Remove(originalName))
+	}
+}
+
+func TestCloudYamlPaths(t *testing.T) {
+	_ = os.Setenv("OS_CLOUD", "useless_cloud")
+	home, _ := os.UserHomeDir()
+	cwd, _ := os.Getwd()
+
+	fileName := "clouds.yaml"
+	currentConfigDir := filepath.Join(cwd, fileName)
+	userConfigDir := filepath.Join(home, ".config/openstack", fileName)
+	unixConfigDir := filepath.Join("/etc/openstack", fileName)
+	files := []string{currentConfigDir, userConfigDir, unixConfigDir}
+	backupFiles(t, currentConfigDir, userConfigDir, unixConfigDir)
+	defer restoreBackup(t, files...)
+
+	for _, fileName := range files {
+		t.Run(fmt.Sprintf("Config at %s", fileName), func(subT *testing.T) {
+			if runtime.GOOS == "windows" && fileName == unixConfigDir {
+				subT.Skip("Skipping on windows")
+			}
+
+			dir := filepath.Dir(fileName)
+			if err := os.MkdirAll(dir, 0755); err != nil { // make sure that dir exists
+				if os.IsPermission(err) {
+					subT.Skip(err.Error())
+				}
+				th.AssertNoErr(t, err)
+			}
+
+			th.AssertNoErr(subT, ioutil.WriteFile(fileName, tmpl, 0644))
+			cloud, err := clients.EnvOS.Cloud()
+			th.AssertNoErr(subT, err)
+			th.AssertEquals(subT, "http://localhost/", cloud.AuthInfo.AuthURL)
+			th.AssertEquals(subT, "some-useless-passw0rd", cloud.AuthInfo.Password)
+			th.AssertEquals(subT, "some-name", cloud.AuthInfo.Username)
+		})
+	}
+}

--- a/openstack/loader.go
+++ b/openstack/loader.go
@@ -31,7 +31,7 @@ var (
 
 func configSearchPath() []string {
 	home, _ := os.UserHomeDir()
-	cwd, _ := filepath.Abs(filepath.Dir(os.Args[0]))
+	cwd, _ := os.Getwd()
 	userConfigDir, _ := filepath.Abs(filepath.Join(home, ".config/openstack"))
 	unixConfigDir, _ := filepath.Abs("/etc/openstack")
 	return []string{


### PR DESCRIPTION
Instead of using the current working directory for `clouds.yaml` file search, a directory relative to `openstack/loader.go` was used.

Required for opentelekomcloud/terraform-provider-opentelekomcloud#798
Resolves: #75