### PR TITLE
Add optional `cloudName` argument to `Env.Cloud`

### DIFF
--- a/openstack/client_test.go
+++ b/openstack/client_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
 
@@ -131,4 +132,12 @@ func TestCloudYamlPaths(t *testing.T) {
 			th.AssertEquals(subT, "some-name", cloud.AuthInfo.Username)
 		})
 	}
+}
+
+func TestCloudName(t *testing.T) {
+	_ = os.Setenv("OS_CLOUD", tools.RandomString("CLD_", 5))
+	expectedName := tools.RandomString("CLD_SET_", 5)
+	cloud, err := NewEnv("OS").Cloud(expectedName)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expectedName, cloud.Cloud)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We need to control cloud name when calling `Env.Cloud()`

Fix #85
