### PR TITLE
Add resource operations to CBR Vaults

### DIFF
--- a/acceptance/openstack/cbr/v3/vaults_test.go
+++ b/acceptance/openstack/cbr/v3/vaults_test.go
@@ -1,10 +1,13 @@
 package v3
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	volumesV3 "github.com/opentelekomcloud/gophertelekomcloud/openstack/blockstorage/v3/volumes"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cbr/v3/vaults"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
@@ -53,4 +56,83 @@ func TestVaultLifecycle(t *testing.T) {
 	getUpdated, err := vaults.Get(client, vault.ID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, updated, getUpdated)
+}
+
+func createVolume(t *testing.T) *volumesV3.Volume {
+	client, err := clients.NewBlockStorageV3Client()
+	th.AssertNoErr(t, err)
+	vol, err := volumesV3.Create(client, volumesV3.CreateOpts{
+		Size:       10,
+		VolumeType: "SSD",
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	err = golangsdk.WaitFor(300, func() (bool, error) {
+		volume, err := volumesV3.Get(client, vol.ID).Extract()
+		if err != nil {
+			return false, err
+		}
+		if volume.Status == "available" {
+			return true, nil
+		}
+		if volume.Status == "error" {
+			return false, fmt.Errorf("error creating a volume")
+		}
+		return false, nil
+	})
+	th.AssertNoErr(t, err)
+
+	return vol
+}
+
+func removeVolume(t *testing.T, id string) {
+	client, err := clients.NewBlockStorageV3Client()
+	th.AssertNoErr(t, err)
+	th.AssertNoErr(t, volumesV3.Delete(client, id).ExtractErr())
+}
+
+func TestVaultResources(t *testing.T) {
+	client, err := clients.NewCbrV3Client()
+	th.AssertNoErr(t, err)
+
+	opts := vaults.CreateOpts{
+		Billing: &vaults.BillingCreate{
+			ConsistentLevel: "crash_consistent",
+			ObjectType:      "disk",
+			ProtectType:     "backup",
+			Size:            100,
+		},
+		Description: "gophertelemocloud testing vault",
+		Name:        tools.RandomString("cbr-test-", 5),
+		Resources:   []vaults.ResourceCreate{},
+	}
+	vault, err := vaults.Create(client, opts).Extract()
+	th.AssertNoErr(t, err)
+
+	defer func() {
+		th.AssertNoErr(t, vaults.Delete(client, vault.ID).ExtractErr())
+	}()
+
+	resourceType := "OS::Cinder::Volume"
+	volume := createVolume(t)
+	defer removeVolume(t, volume.ID)
+
+	aOpts := vaults.AssociateResourcesOpts{
+		Resources: []vaults.ResourceCreate{
+			{
+				ID:   volume.ID,
+				Type: resourceType,
+				Name: "cbr-vault-test-volume",
+			},
+		},
+	}
+	associated, err := vaults.AssociateResources(client, vault.ID, aOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(associated))
+	th.AssertEquals(t, volume.ID, associated[0])
+
+	dOpts := vaults.DissociateResourcesOpts{ResourceIDs: associated}
+	dissociated, err := vaults.DissociateResources(client, vault.ID, dOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, associated, dissociated)
 }

--- a/openstack/cbr/v3/vaults/requests.go
+++ b/openstack/cbr/v3/vaults/requests.go
@@ -3,7 +3,7 @@ package vaults
 import (
 	"fmt"
 
-	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud"
 )
 
 type CreateOptsBuilder interface {
@@ -175,6 +175,52 @@ func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) 
 		return
 	}
 	_, r.Err = client.Put(vaultURL(client, id), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+type AssociateResourcesOptsBuilder interface {
+	ToAssociateResourcesMap() (map[string]interface{}, error)
+}
+type AssociateResourcesOpts struct {
+	Resources []ResourceCreate `json:"resources"`
+}
+
+func (opts AssociateResourcesOpts) ToAssociateResourcesMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+func AssociateResources(client *golangsdk.ServiceClient, vaultID string, opts AssociateResourcesOptsBuilder) (r AssociateResourcesResult) {
+	reqBody, err := opts.ToAssociateResourcesMap()
+	if err != nil {
+		r.Err = fmt.Errorf("failed to create associate resource map: %s", err)
+		return
+	}
+	_, r.Err = client.Post(addResourcesURL(client, vaultID), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+type DissociateResourcesOptsBuilder interface {
+	ToDissociateResourcesMap() (map[string]interface{}, error)
+}
+type DissociateResourcesOpts struct {
+	ResourceIDs []string `json:"resource_ids"`
+}
+
+func (opts DissociateResourcesOpts) ToDissociateResourcesMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+func DissociateResources(client *golangsdk.ServiceClient, vaultID string, opts DissociateResourcesOptsBuilder) (r DissociateResourcesResult) {
+	reqBody, err := opts.ToDissociateResourcesMap()
+	if err != nil {
+		r.Err = fmt.Errorf("failed to create dissociate resource map: %s", err)
+		return
+	}
+	_, r.Err = client.Post(removeResourcesURL(client, vaultID), reqBody, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{200},
 	})
 	return

--- a/openstack/cbr/v3/vaults/results.go
+++ b/openstack/cbr/v3/vaults/results.go
@@ -1,6 +1,10 @@
 package vaults
 
-import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+import (
+	"fmt"
+
+	"github.com/opentelekomcloud/gophertelekomcloud"
+)
 
 type vaultResult struct {
 	golangsdk.Result
@@ -71,4 +75,40 @@ func (r vaultResult) Extract() (*Vault, error) {
 
 type DeleteResult struct {
 	golangsdk.ErrResult
+}
+
+type AssociateResourcesResult struct {
+	golangsdk.Result
+}
+
+func (r AssociateResourcesResult) Extract() ([]string, error) {
+	var s struct {
+		AddResourceIDs []string `json:"add_resource_ids"`
+	}
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract Associated Resource IDs")
+	}
+	return s.AddResourceIDs, nil
+}
+
+type DissociateResourcesResult struct {
+	golangsdk.Result
+}
+
+func (r DissociateResourcesResult) Extract() ([]string, error) {
+	var s struct {
+		AddResourceIDs []string `json:"remove_resource_ids"`
+	}
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract Dissociated Resource IDs")
+	}
+	return s.AddResourceIDs, nil
 }

--- a/openstack/cbr/v3/vaults/urls.go
+++ b/openstack/cbr/v3/vaults/urls.go
@@ -11,3 +11,11 @@ func rootURL(client *golangsdk.ServiceClient) string {
 func vaultURL(client *golangsdk.ServiceClient, id string) string {
 	return client.ServiceURL(baseURL, id)
 }
+
+func addResourcesURL(client *golangsdk.ServiceClient, id string) string {
+	return client.ServiceURL(baseURL, id, "addresources")
+}
+
+func removeResourcesURL(client *golangsdk.ServiceClient, id string) string {
+	return client.ServiceURL(baseURL, id, "removeresources")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it:
Part of https://github.com/opentelekomcloud/gophertelekomcloud/issues/64

### Acceptance tests:
```
=== RUN   TestVaultResources
--- PASS: TestVaultResources (11.48s)
PASS

Process finished with exit code 0
```