### PR TITLE
Add policy operations to CBR Vaults

### DIFF
--- a/openstack/cbr/v3/vaults/requests.go
+++ b/openstack/cbr/v3/vaults/requests.go
@@ -180,6 +180,42 @@ func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) 
 	return
 }
 
+type BindPolicyOptsBuilder interface {
+	ToBindPolicyMap() (map[string]interface{}, error)
+}
+
+type BindPolicyOpts struct {
+	PolicyID string `json:"policy_id"`
+}
+
+func (opts BindPolicyOpts) ToBindPolicyMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+func BindPolicy(client *golangsdk.ServiceClient, vaultID string, opts BindPolicyOptsBuilder) (r BindPolicyResult) {
+	reqBody, err := opts.ToBindPolicyMap()
+	if err != nil {
+		r.Err = fmt.Errorf("failed to create bind policy map: %s", err)
+		return
+	}
+	_, r.Err = client.Post(bindPolicyURL(client, vaultID), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+func UnbindPolicy(client *golangsdk.ServiceClient, vaultID string, opts BindPolicyOptsBuilder) (r UnbindPolicyResult) {
+	reqBody, err := opts.ToBindPolicyMap()
+	if err != nil {
+		r.Err = fmt.Errorf("failed to create bind policy map: %s", err)
+		return
+	}
+	_, r.Err = client.Post(unbindPolicyURL(client, vaultID), reqBody, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
 type AssociateResourcesOptsBuilder interface {
 	ToAssociateResourcesMap() (map[string]interface{}, error)
 }

--- a/openstack/cbr/v3/vaults/results.go
+++ b/openstack/cbr/v3/vaults/results.go
@@ -112,3 +112,32 @@ func (r DissociateResourcesResult) Extract() ([]string, error) {
 	}
 	return s.AddResourceIDs, nil
 }
+
+type BindPolicyResult struct {
+	golangsdk.Result
+}
+
+type PolicyBinding struct {
+	VaultID  string `json:"vault_id"`
+	PolicyID string `json:"policy_id"`
+}
+
+func (r BindPolicyResult) Extract() (*PolicyBinding, error) {
+	var s struct {
+		PolicyBinding *PolicyBinding `json:"associate_policy"`
+	}
+	err := r.ExtractInto(&s)
+	return s.PolicyBinding, err
+}
+
+type UnbindPolicyResult struct {
+	golangsdk.Result
+}
+
+func (r UnbindPolicyResult) Extract() (*PolicyBinding, error) {
+	var s struct {
+		PolicyBinding *PolicyBinding `json:"dissociate_policy"`
+	}
+	err := r.ExtractInto(&s)
+	return s.PolicyBinding, err
+}

--- a/openstack/cbr/v3/vaults/urls.go
+++ b/openstack/cbr/v3/vaults/urls.go
@@ -19,3 +19,11 @@ func addResourcesURL(client *golangsdk.ServiceClient, id string) string {
 func removeResourcesURL(client *golangsdk.ServiceClient, id string) string {
 	return client.ServiceURL(baseURL, id, "removeresources")
 }
+
+func bindPolicyURL(client *golangsdk.ServiceClient, id string) string {
+	return client.ServiceURL(baseURL, id, "associatepolicy")
+}
+
+func unbindPolicyURL(client *golangsdk.ServiceClient, id string) string {
+	return client.ServiceURL(baseURL, id, "dissociatepolicy")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it:
Part of #64

### Acceptance test:
```
=== RUN   TestVaultPolicy
--- PASS: TestVaultPolicy (11.25s)
PASS

Process finished with exit code 0
```
