### PR TITLE
[CBR] Fix vault `UpdateOpts.VaultBindRules` type

### DIFF
--- a/openstack/cbr/v3/vaults/requests.go
+++ b/openstack/cbr/v3/vaults/requests.go
@@ -157,11 +157,11 @@ type BillingUpdate struct {
 }
 
 type UpdateOpts struct {
-	Billing    *BillingUpdate   `json:"billing,omitempty"`
-	Name       string           `json:"name,omitempty"`
-	AutoBind   *bool            `json:"auto_bind,omitempty"`
-	BindRules  []VaultBindRules `json:"bind_rules,omitempty"`
-	AutoExpand *bool            `json:"auto_expand,omitempty"`
+	Billing    *BillingUpdate  `json:"billing,omitempty"`
+	Name       string          `json:"name,omitempty"`
+	AutoBind   *bool           `json:"auto_bind,omitempty"`
+	BindRules  *VaultBindRules `json:"bind_rules,omitempty"`
+	AutoExpand *bool           `json:"auto_expand,omitempty"`
 }
 
 func (opts UpdateOpts) ToVaultUpdateMap() (map[string]interface{}, error) {


### PR DESCRIPTION
### What this PR does / why we need it
`UpdateOpts.VaultBindRules` are defined as `[]VaultBindRules` instead of `*VaultBindRules`

Doc reference: https://docs.otc.t-systems.com/en-us/api/cbr/UpdateVault.html