### PR TITLE
[sfs_turbo] Minor refactoring

### DIFF
--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -256,6 +256,19 @@ func NewSharedFileSystemV2Client() (*golangsdk.ServiceClient, error) {
 	})
 }
 
+// NewSharedFileSystemTurboV1Client returns a *ServiceClient for making calls
+// to the OpenStack Shared File System Turbo v1 API. An error will be returned
+// if authentication or client creation was not possible.
+func NewSharedFileSystemTurboV1Client() (*golangsdk.ServiceClient, error) {
+	cc, err := CloudAndClient()
+	if err != nil {
+		return nil, err
+	}
+	return openstack.NewSharedFileSystemTurboV1(cc.ProviderClient, golangsdk.EndpointOpts{
+		Region: cc.RegionName,
+	})
+}
+
 // NewRdsV3 returns authenticated RDS v3 client
 func NewRdsV3() (*golangsdk.ServiceClient, error) {
 	cc, err := CloudAndClient()

--- a/acceptance/openstack/common.go
+++ b/acceptance/openstack/common.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/extensions"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/secgroups"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
@@ -22,10 +23,10 @@ func PrintExtension(t *testing.T, extension *extensions.Extension) {
 }
 
 func DefaultSecurityGroup(t *testing.T) string {
-	computeClient, err := clients.NewComputeV2Client()
+	client, err := clients.NewComputeV2Client()
 	th.AssertNoErr(t, err)
 
-	securityGroupPages, err := secgroups.List(computeClient).AllPages()
+	securityGroupPages, err := secgroups.List(client).AllPages()
 	th.AssertNoErr(t, err)
 	securityGroups, err := secgroups.ExtractSecurityGroups(securityGroupPages)
 	th.AssertNoErr(t, err)
@@ -40,4 +41,26 @@ func DefaultSecurityGroup(t *testing.T) string {
 		t.Fatalf("Unable to find default secgroup")
 	}
 	return sgId
+}
+
+func CreateSecurityGroup(t *testing.T) string {
+	client, err := clients.NewComputeV2Client()
+	th.AssertNoErr(t, err)
+
+	createSGOpts := secgroups.CreateOpts{
+		Name:        tools.RandomString("acc-sg-", 3),
+		Description: "security group for acceptance testing",
+	}
+	secGroup, err := secgroups.Create(client, createSGOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	return secGroup.ID
+}
+
+func DeleteSecurityGroup(t *testing.T, secGroupID string) {
+	client, err := clients.NewComputeV2Client()
+	th.AssertNoErr(t, err)
+
+	err = secgroups.Delete(client, secGroupID).ExtractErr()
+	th.AssertNoErr(t, err)
 }

--- a/acceptance/openstack/common.go
+++ b/acceptance/openstack/common.go
@@ -61,6 +61,6 @@ func DeleteSecurityGroup(t *testing.T, secGroupID string) {
 	client, err := clients.NewComputeV2Client()
 	th.AssertNoErr(t, err)
 
-	err = secgroups.Delete(client, secGroupID).ExtractErr()
+	err = secgroups.DeleteWithRetry(client, secGroupID, 600)
 	th.AssertNoErr(t, err)
 }

--- a/acceptance/openstack/sfs_turbo/v1/helpers.go
+++ b/acceptance/openstack/sfs_turbo/v1/helpers.go
@@ -145,6 +145,5 @@ func waitForShareSubStatusSuccess(client *golangsdk.ServiceClient, shareID strin
 		}
 
 		return false, nil
-
 	})
 }

--- a/acceptance/openstack/sfs_turbo/v1/helpers.go
+++ b/acceptance/openstack/sfs_turbo/v1/helpers.go
@@ -46,7 +46,6 @@ env vars is missing but SFS Turbo test requires`)
 	t.Logf("Created SFS turbo: %s", newShare.ID)
 
 	return newShare
-
 }
 
 func deleteShare(t *testing.T, client *golangsdk.ServiceClient, shareID string) {

--- a/acceptance/openstack/sfs_turbo/v1/helpers.go
+++ b/acceptance/openstack/sfs_turbo/v1/helpers.go
@@ -84,12 +84,12 @@ func expandShare(t *testing.T, client *golangsdk.ServiceClient, shareID string) 
 	return newShare
 }
 
-func changeShareSG(t *testing.T, client *golangsdk.ServiceClient, shareID string) *shares.Turbo {
+func changeShareSG(t *testing.T, client *golangsdk.ServiceClient, shareID string, secGroupID string) *shares.Turbo {
 	t.Logf("Attempting to change SG SFS Turbo: %s", shareID)
 
 	changeSGOpts := shares.ChangeSGOpts{
 		ChangeSecurityGroup: shares.SecurityGroupOpts{
-			SecurityGroupID: "asd",
+			SecurityGroupID: secGroupID,
 		},
 	}
 

--- a/acceptance/openstack/sfs_turbo/v1/helpers.go
+++ b/acceptance/openstack/sfs_turbo/v1/helpers.go
@@ -1,0 +1,151 @@
+package v1
+
+import (
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/sfs_turbo/v1/shares"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func createShare(t *testing.T, client *golangsdk.ServiceClient) *shares.Turbo {
+	t.Logf("Attempting to create SFSTurboV1")
+
+	vpcID := clients.EnvOS.GetEnv("VPC_ID")
+	subnetID := clients.EnvOS.GetEnv("NETWORK_ID")
+	az := clients.EnvOS.GetEnv("AVAILABILITY_ZONE")
+	if vpcID == "" || subnetID == "" || az == "" {
+		t.Skip(`One of OS_VPC_ID or OS_NETWORK_ID of OS_AVAILABILITY_ZONE
+env vars is missing but SFS Turbo test requires`)
+	}
+
+	createOpts := shares.CreateOpts{
+		Name:             tools.RandomString("acc-share-", 3),
+		ShareType:        "STANDARD",
+		Size:             500,
+		AvailabilityZone: az,
+		VpcID:            vpcID,
+		SubnetID:         subnetID,
+		SecurityGroupID:  openstack.DefaultSecurityGroup(t),
+		Description:      "some interesting description",
+	}
+
+	share, err := shares.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Waiting for SFS Turbo %s to be active", share.ID)
+	err = waitForShareToActive(client, share.ID, 600)
+	th.AssertNoErr(t, err)
+
+	newShare, err := shares.Get(client, share.ID).Extract()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Created SFS turbo: %s", newShare.ID)
+
+	return newShare
+
+}
+
+func deleteShare(t *testing.T, client *golangsdk.ServiceClient, shareID string) {
+	t.Logf("Attempting to delete SFS Turbo: %s", shareID)
+
+	err := shares.Delete(client, shareID).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = waitForShareToDelete(client, shareID, 600)
+	th.AssertNoErr(t, err)
+
+	t.Logf("Deleted SFS Turbo: %s", shareID)
+}
+
+func expandShare(t *testing.T, client *golangsdk.ServiceClient, shareID string) *shares.Turbo {
+	t.Logf("Attempting to expand SFS Turbo: %s", shareID)
+
+	expandOpts := shares.ExpandOpts{
+		Extend: shares.ExtendOpts{
+			NewSize: 1000,
+		},
+	}
+
+	err := shares.Expand(client, shareID, expandOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = waitForShareSubStatusSuccess(client, shareID, 600)
+	th.AssertNoErr(t, err)
+
+	newShare, err := shares.Get(client, shareID).Extract()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Expanded SFS turbo: %s", shareID)
+
+	return newShare
+}
+
+func changeShareSG(t *testing.T, client *golangsdk.ServiceClient, shareID string) *shares.Turbo {
+	t.Logf("Attempting to change SG SFS Turbo: %s", shareID)
+
+	changeSGOpts := shares.ChangeSGOpts{
+		ChangeSecurityGroup: shares.SecurityGroupOpts{
+			SecurityGroupID: "asd",
+		},
+	}
+
+	err := shares.ChangeSG(client, shareID, changeSGOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	err = waitForShareSubStatusSuccess(client, shareID, 600)
+	th.AssertNoErr(t, err)
+
+	newShare, err := shares.Get(client, shareID).Extract()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Change SG SFS turbo: %s", shareID)
+
+	return newShare
+}
+
+func waitForShareToActive(client *golangsdk.ServiceClient, shareID string, secs int) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		share, err := shares.Get(client, shareID).Extract()
+		if err != nil {
+			return false, err
+		}
+		if share.Status == "200" {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}
+
+func waitForShareToDelete(client *golangsdk.ServiceClient, shareID string, secs int) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		_, err := shares.Get(client, shareID).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	})
+}
+
+func waitForShareSubStatusSuccess(client *golangsdk.ServiceClient, shareID string, secs int) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		share, err := shares.Get(client, shareID).Extract()
+		if err != nil {
+			return false, err
+		}
+
+		if share.SubStatus == "221" || share.SubStatus == "232" {
+			return true, nil
+		}
+
+		return false, nil
+
+	})
+}

--- a/acceptance/openstack/sfs_turbo/v1/sfs_turbo_test.go
+++ b/acceptance/openstack/sfs_turbo/v1/sfs_turbo_test.go
@@ -39,7 +39,7 @@ func TestSFSTurboLifecycle(t *testing.T) {
 	tools.PrintResource(t, share)
 
 	share = expandShare(t, client, share.ID)
-	th.AssertEquals(t, "1000", share.Size)
+	th.AssertEquals(t, "1000.00", share.Size)
 	share = changeShareSG(t, client, share.ID, secGroupID)
 
 	newShare, err := shares.Get(client, share.ID).Extract()

--- a/acceptance/openstack/sfs_turbo/v1/sfs_turbo_test.go
+++ b/acceptance/openstack/sfs_turbo/v1/sfs_turbo_test.go
@@ -1,0 +1,46 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/sfs_turbo/v1/shares"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestSFSTurboList(t *testing.T) {
+	client, err := clients.NewSharedFileSystemTurboV1Client()
+	th.AssertNoErr(t, err)
+
+	listOpts := shares.ListOpts{}
+	allSharesPages, err := shares.List(client, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	sfsTurboShares, err := shares.ExtractTurbos(allSharesPages)
+	th.AssertNoErr(t, err)
+
+	for _, share := range sfsTurboShares {
+		tools.PrintResource(t, share)
+	}
+}
+
+func TestSFSTurboLifecycle(t *testing.T) {
+	client, err := clients.NewSharedFileSystemTurboV1Client()
+	th.AssertNoErr(t, err)
+
+	share := createShare(t, client)
+	defer deleteShare(t, client, share.ID)
+
+	tools.PrintResource(t, share)
+
+	share = expandShare(t, client, share.ID)
+	tools.PrintResource(t, share)
+
+	share = changeShareSG(t, client, share.ID)
+	tools.PrintResource(t, share)
+
+	newShare, err := shares.Get(client, share.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, share.ID, newShare.ID)
+}

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -547,7 +547,8 @@ func NewSharedFileSystemTurboV1(client *golangsdk.ProviderClient, eo golangsdk.E
 	if err != nil {
 		return nil, err
 	}
-	sc.ResourceBase = sc.Endpoint + "v1/"
+	sc.Endpoint = sc.Endpoint + "v1/"
+	sc.ResourceBase = sc.Endpoint + client.ProjectID + "/"
 	return sc, err
 }
 

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -541,6 +541,11 @@ func NewSharedFileSystemV2(client *golangsdk.ProviderClient, eo golangsdk.Endpoi
 	return initClientOpts(client, eo, "sharev2")
 }
 
+// NewSharedFileSystemTurboV1 creates a ServiceClient that may be used to access the v2 shared file system turbo service.
+func NewSharedFileSystemTurboV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	return initClientOpts(client, eo, "sfsturbo")
+}
+
 // NewOrchestrationV1 creates a ServiceClient that may be used to access the v1
 // orchestration service.
 func NewOrchestrationV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -543,7 +543,12 @@ func NewSharedFileSystemV2(client *golangsdk.ProviderClient, eo golangsdk.Endpoi
 
 // NewSharedFileSystemTurboV1 creates a ServiceClient that may be used to access the v2 shared file system turbo service.
 func NewSharedFileSystemTurboV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
-	return initClientOpts(client, eo, "sfsturbo")
+	sc, err := initClientOpts(client, eo, "sfsturbo")
+	if err != nil {
+		return nil, err
+	}
+	sc.ResourceBase = sc.Endpoint + "v1/"
+	return sc, err
 }
 
 // NewOrchestrationV1 creates a ServiceClient that may be used to access the v1

--- a/openstack/sfs_turbo/v1/shares/requests.go
+++ b/openstack/sfs_turbo/v1/shares/requests.go
@@ -95,7 +95,7 @@ func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Page
 		url += query
 	}
 
-	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return TurboPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }
@@ -163,12 +163,12 @@ type ChangeSGOpts struct {
 
 type SecurityGroupOpts struct {
 	// Specifies the ID of the security group to be modified.
-	SecurityGroupID int `json:"security_group_id" required:"true"`
+	SecurityGroupID string `json:"security_group_id" required:"true"`
 }
 
 // ToShareExpandMap assembles a request body based on the contents of a
-// ExpandOpts.
-func (opts ExpandOpts) ToShareSGMap() (map[string]interface{}, error) {
+// ChangeSGOpts.
+func (opts ChangeSGOpts) ToShareSGMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "")
 }
 

--- a/openstack/sfs_turbo/v1/shares/requests.go
+++ b/openstack/sfs_turbo/v1/shares/requests.go
@@ -16,9 +16,9 @@ type CreateOptsBuilder interface {
 type CreateOpts struct {
 	// Defines the SFS Turbo file system name
 	Name string `json:"name" required:"true"`
-	// Defines the SFS Turbo file system protocol to use, the vaild value is NFS.
+	// Defines the SFS Turbo file system protocol to use, the valid value is NFS.
 	ShareProto string `json:"share_proto,omitempty"`
-	// ShareType defines the file system type. the vaild values are STANDARD and PERFORMANCE.
+	// ShareType defines the file system type. the valid values are STANDARD and PERFORMANCE.
 	ShareType string `json:"share_type" required:"true"`
 	// Size in GB, range from 500 to 32768.
 	Size int `json:"size" required:"true"`
@@ -42,12 +42,7 @@ type CreateOpts struct {
 
 // Metadata specifies the metadata information
 type Metadata struct {
-	ExpandType            string `json:"expand_type,omitempty"`
-	CryptKeyID            string `json:"crypt_key_id,omitempty"`
-	DedicatedFlavor       string `json:"dedicated_flavor,omitempty"`
-	MasterDedicatedHostID string `json:"master_dedicated_host_id,omitempty"`
-	SlaveDedicatedHostID  string `json:"slave_dedicated_host_id,omitempty"`
-	DedicatedStorageID    string `json:"dedicated_storage_id,omitempty"`
+	CryptKeyID string `json:"crypt_key_id,omitempty"`
 }
 
 // ToShareCreateMap assembles a request body based on the contents of a
@@ -71,27 +66,47 @@ func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateRe
 	return
 }
 
-// List returns a Pager which allows you to iterate over a collection of
-// SFS Turbo resources.
-func List(c *golangsdk.ServiceClient) ([]Turbo, error) {
-	pages, err := pagination.NewPager(c, listURL(c), func(r pagination.PageResult) pagination.Page {
-		return TurboPage{pagination.LinkedPageBase{PageResult: r}}
-	}).AllPages()
-	if err != nil {
-		return nil, err
-	}
-
-	return ExtractTurbos(pages)
+type ListOptsBuilder interface {
+	ToShareListQuery() (string, error)
 }
 
-// Get will get a single SFS Trubo file system with given UUID
+type ListOpts struct {
+	Limit  string `q:"limit"`
+	Offset string `q:"offset"`
+}
+
+func (opts ListOpts) ToShareListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// SFS Turbo resources.
+func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToShareListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
+		return TurboPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get will get a single SFS Turbo file system with given UUID
 func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(resourceURL(client, id), &r.Body, nil)
-
 	return
 }
 
-// Delete will delete an existing SFS Trubo file system with the given UUID.
+// Delete will delete an existing SFS Turbo file system with the given UUID.
 func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(resourceURL(client, id), nil)
 	return
@@ -122,13 +137,49 @@ func (opts ExpandOpts) ToShareExpandMap() (map[string]interface{}, error) {
 }
 
 // Expand will expand a SFS Turbo based on the values in ExpandOpts.
-func Expand(client *golangsdk.ServiceClient, share_id string, opts ExpandOptsBuilder) (r ExpandResult) {
+func Expand(client *golangsdk.ServiceClient, shareID string, opts ExpandOptsBuilder) (r ExpandResult) {
 	b, err := opts.ToShareExpandMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(actionURL(client, share_id), b, nil, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(actionURL(client, shareID), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// ChangeSGOptsBuilder allows extensions to change the security group
+// bound to a SFS Turbo file system
+type ChangeSGOptsBuilder interface {
+	ToShareSGMap() (map[string]interface{}, error)
+}
+
+// ChangeSGOpts contains the options for changing security group to a SFS Turbo
+type ChangeSGOpts struct {
+	// Specifies the change_security_group object.
+	ChangeSecurityGroup SecurityGroupOpts `json:"change_security_group" required:"true"`
+}
+
+type SecurityGroupOpts struct {
+	// Specifies the ID of the security group to be modified.
+	SecurityGroupID int `json:"security_group_id" required:"true"`
+}
+
+// ToShareExpandMap assembles a request body based on the contents of a
+// ExpandOpts.
+func (opts ExpandOpts) ToShareSGMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// ChangeSG will change security group to a SFS Turbo based on the values in ChangeSGOpts.
+func ChangeSG(client *golangsdk.ServiceClient, shareID string, opts ChangeSGOptsBuilder) (r ExpandResult) {
+	b, err := opts.ToShareSGMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(actionURL(client, shareID), b, nil, &golangsdk.RequestOpts{
 		OkCodes: []int{202},
 	})
 	return

--- a/openstack/sfs_turbo/v1/shares/results.go
+++ b/openstack/sfs_turbo/v1/shares/results.go
@@ -89,18 +89,16 @@ type ChangeSGResult struct {
 
 // Extract will get the Turbo response object from the CreateResult
 func (r CreateResult) Extract() (*TurboResponse, error) {
-	var responseCreate struct {
-		Share TurboResponse `json:"share"`
-	}
-	err := r.ExtractInto(&responseCreate)
-	return &responseCreate.Share, err
+	var s *TurboResponse
+	err := r.ExtractInto(&s)
+	return s, err
 }
 
 // Extract will get the Turbo object from the GetResult
 func (r GetResult) Extract() (*Turbo, error) {
-	var responseGet Turbo
-	err := r.ExtractInto(&responseGet)
-	return &responseGet, err
+	var s Turbo
+	err := r.ExtractInto(&s)
+	return &s, err
 }
 
 // TurboPage is the page returned by a pager when traversing over a

--- a/openstack/sfs_turbo/v1/shares/results.go
+++ b/openstack/sfs_turbo/v1/shares/results.go
@@ -90,15 +90,15 @@ type ChangeSGResult struct {
 // Extract will get the Turbo response object from the CreateResult
 func (r CreateResult) Extract() (*TurboResponse, error) {
 	var s *TurboResponse
-	err := r.ExtractInto(&s)
+	err := r.ExtractInto(s)
 	return s, err
 }
 
 // Extract will get the Turbo object from the GetResult
 func (r GetResult) Extract() (*Turbo, error) {
-	var s Turbo
-	err := r.ExtractInto(&s)
-	return &s, err
+	var s *Turbo
+	err := r.ExtractInto(s)
+	return s, err
 }
 
 // TurboPage is the page returned by a pager when traversing over a

--- a/openstack/sfs_turbo/v1/shares/results.go
+++ b/openstack/sfs_turbo/v1/shares/results.go
@@ -1,9 +1,6 @@
 package shares
 
 import (
-	"encoding/json"
-	"time"
-
 	"github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
@@ -49,7 +46,7 @@ type Turbo struct {
 	SubnetID string `json:"subnet_id"`
 	// The security group ID
 	SecurityGroupID string `json:"security_group_id"`
-	// The avaliable capacity if the SFS Turbo file system
+	// The available capacity if the SFS Turbo file system
 	AvailCapacity string `json:"avail_capacity"`
 	// bandwidth is returned for an enhanced file system
 	ExpandType string `json:"expand_type"`
@@ -58,24 +55,7 @@ type Turbo struct {
 	// The billing mode, 0 indicates pay-per-use, 1 indicates yearly/monthly subscription
 	PayModel string `json:"pay_model"`
 	// Timestamp when the share was created
-	CreatedAt time.Time `json:"-"`
-}
-
-func (r *Turbo) UnmarshalJSON(b []byte) error {
-	type tmp Turbo
-	var s struct {
-		tmp
-		CreatedAt golangsdk.JSONRFC3339MilliNoZ `json:"created_at"`
-	}
-	err := json.Unmarshal(b, &s)
-	if err != nil {
-		return err
-	}
-	*r = Turbo(s.tmp)
-
-	r.CreatedAt = time.Time(s.CreatedAt)
-
-	return nil
+	CreatedAt string `json:"created_at"`
 }
 
 type commonResult struct {
@@ -92,28 +72,35 @@ type GetResult struct {
 	commonResult
 }
 
-// DeleteResult contains the response body and error from a Delete request.
+// DeleteResult contains the error from a Delete request.
 type DeleteResult struct {
 	golangsdk.ErrResult
 }
 
-// ExpandResult contains the response body and error from a Expand request.
+// ExpandResult contains the error from an Expand request.
 type ExpandResult struct {
+	golangsdk.ErrResult
+}
+
+// ChangeSGResult contains the error from a ChangeSG request.
+type ChangeSGResult struct {
 	golangsdk.ErrResult
 }
 
 // Extract will get the Turbo response object from the CreateResult
 func (r CreateResult) Extract() (*TurboResponse, error) {
-	var resp TurboResponse
-	err := r.ExtractInto(&resp)
-	return &resp, err
+	var responseCreate struct {
+		Share TurboResponse `json:"share"`
+	}
+	err := r.ExtractInto(&responseCreate)
+	return &responseCreate.Share, err
 }
 
 // Extract will get the Turbo object from the GetResult
 func (r GetResult) Extract() (*Turbo, error) {
-	var object Turbo
-	err := r.ExtractInto(&object)
-	return &object, err
+	var responseGet Turbo
+	err := r.ExtractInto(&responseGet)
+	return &responseGet, err
 }
 
 // TurboPage is the page returned by a pager when traversing over a

--- a/openstack/sfs_turbo/v1/shares/urls.go
+++ b/openstack/sfs_turbo/v1/shares/urls.go
@@ -9,20 +9,20 @@ const (
 
 // createURL used to assemble the URI of creating API
 func createURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(rootPath, resourcePath)
+	return c.ServiceURL(c.ProjectID, rootPath, resourcePath)
 }
 
 // resourceURL used to assemble the URI of deleting API or querying details API
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(rootPath, resourcePath, id)
+	return c.ServiceURL(c.ProjectID, rootPath, resourcePath, id)
 }
 
 // listURL used to assemble the URI of querying all file system details API
 func listURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(rootPath, resourcePath, "detail")
+	return c.ServiceURL(c.ProjectID, rootPath, resourcePath, "detail")
 }
 
 // For manage the specified file system, e.g.: extend
 func actionURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(rootPath, resourcePath, id, "action")
+	return c.ServiceURL(c.ProjectID, rootPath, resourcePath, id, "action")
 }

--- a/openstack/sfs_turbo/v1/shares/urls.go
+++ b/openstack/sfs_turbo/v1/shares/urls.go
@@ -9,20 +9,20 @@ const (
 
 // createURL used to assemble the URI of creating API
 func createURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, rootPath, resourcePath)
+	return c.ServiceURL(rootPath, resourcePath)
 }
 
 // resourceURL used to assemble the URI of deleting API or querying details API
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(c.ProjectID, rootPath, resourcePath, id)
+	return c.ServiceURL(rootPath, resourcePath, id)
 }
 
 // listURL used to assemble the URI of querying all file system details API
 func listURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, rootPath, resourcePath, "detail")
+	return c.ServiceURL(rootPath, resourcePath, "detail")
 }
 
 // For manage the specified file system, e.g.: extend
 func actionURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(c.ProjectID, rootPath, resourcePath, id, "action")
+	return c.ServiceURL(rootPath, resourcePath, id, "action")
 }

--- a/openstack/sfs_turbo/v1/shares/urls.go
+++ b/openstack/sfs_turbo/v1/shares/urls.go
@@ -2,22 +2,27 @@ package shares
 
 import "github.com/opentelekomcloud/gophertelekomcloud"
 
+const (
+	rootPath     = "sfs-turbo"
+	resourcePath = "shares"
+)
+
 // createURL used to assemble the URI of creating API
 func createURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL("sfs-turbo/shares")
+	return c.ServiceURL(rootPath, resourcePath)
 }
 
 // resourceURL used to assemble the URI of deleting API or querying details API
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL("sfs-turbo/shares", id)
+	return c.ServiceURL(rootPath, resourcePath, id)
 }
 
 // listURL used to assemble the URI of querying all file system details API
 func listURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL("sfs-turbo/shares", "detail")
+	return c.ServiceURL(rootPath, resourcePath, "detail")
 }
 
-// For mamage the specified file system, e.g.: extend
+// For manage the specified file system, e.g.: extend
 func actionURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL("sfs-turbo/shares", id, "action")
+	return c.ServiceURL(rootPath, resourcePath, id, "action")
 }


### PR DESCRIPTION
### What this PR does / why we need it
Minor refactoring of `sfs_turbo` package
Implement change SG action

### Which issue this PR fixes
Resolves: #96 

```
=== RUN   TestSFSTurboList
--- PASS: TestSFSTurboList (1.84s)
=== RUN   TestSFSTurboLifecycle
    helpers.go:15: Attempting to create SFSTurboV1
    helpers.go:39: Waiting for SFS Turbo f34fc53b-a554-49dc-926d-32ce4c8a3c36 to be active
    helpers.go:46: Created SFS turbo: f34fc53b-a554-49dc-926d-32ce4c8a3c36
    helpers.go:64: Attempting to expand SFS Turbo: f34fc53b-a554-49dc-926d-32ce4c8a3c36
    helpers.go:81: Expanded SFS turbo: f34fc53b-a554-49dc-926d-32ce4c8a3c36
    helpers.go:87: Attempting to change SG SFS Turbo: f34fc53b-a554-49dc-926d-32ce4c8a3c36
    helpers.go:104: Change SG SFS turbo: f34fc53b-a554-49dc-926d-32ce4c8a3c36
    helpers.go:52: Attempting to delete SFS Turbo: f34fc53b-a554-49dc-926d-32ce4c8a3c36
    helpers.go:60: Deleted SFS Turbo: f34fc53b-a554-49dc-926d-32ce4c8a3c36
--- PASS: TestSFSTurboLifecycle (284.98s)
PASS

Process finished with exit code 0
```