### PR TITLE
[sfs_turbo] Fix nil pointers in Extract

### DIFF
--- a/openstack/sfs_turbo/v1/shares/results.go
+++ b/openstack/sfs_turbo/v1/shares/results.go
@@ -89,16 +89,16 @@ type ChangeSGResult struct {
 
 // Extract will get the Turbo response object from the CreateResult
 func (r CreateResult) Extract() (*TurboResponse, error) {
-	var s *TurboResponse
-	err := r.ExtractInto(s)
-	return s, err
+	var s TurboResponse
+	err := r.ExtractInto(&s)
+	return &s, err
 }
 
 // Extract will get the Turbo object from the GetResult
 func (r GetResult) Extract() (*Turbo, error) {
-	var s *Turbo
-	err := r.ExtractInto(s)
-	return s, err
+	var s Turbo
+	err := r.ExtractInto(&s)
+	return &s, err
 }
 
 // TurboPage is the page returned by a pager when traversing over a


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Fix nil pointer exception with nil structs

```
=== RUN   TestSFSTurboList
--- PASS: TestSFSTurboList (2.23s)
=== RUN   TestSFSTurboLifecycle
    helpers.go:15: Attempting to create SFSTurboV1
    helpers.go:39: Waiting for SFS Turbo 4e6fe3d2-4047-4512-a8ca-266a5ad6bdf3 to be active
    helpers.go:46: Created SFS turbo: 4e6fe3d2-4047-4512-a8ca-266a5ad6bdf3
    helpers.go:64: Attempting to expand SFS Turbo: 4e6fe3d2-4047-4512-a8ca-266a5ad6bdf3
    helpers.go:81: Expanded SFS turbo: 4e6fe3d2-4047-4512-a8ca-266a5ad6bdf3
    helpers.go:87: Attempting to change SG SFS Turbo: 4e6fe3d2-4047-4512-a8ca-266a5ad6bdf3
    helpers.go:104: Change SG SFS turbo: 4e6fe3d2-4047-4512-a8ca-266a5ad6bdf3
    helpers.go:52: Attempting to delete SFS Turbo: 4e6fe3d2-4047-4512-a8ca-266a5ad6bdf3
    helpers.go:60: Deleted SFS Turbo: 4e6fe3d2-4047-4512-a8ca-266a5ad6bdf3
--- PASS: TestSFSTurboLifecycle (265.64s)
PASS

Process finished with exit code 0
```