### PR TITLE
Add CSS v1 cluster operations

### DIFF
--- a/acceptance/openstack/common.go
+++ b/acceptance/openstack/common.go
@@ -57,6 +57,7 @@ func CreateSecurityGroup(t *testing.T) string {
 	secGroup, err := secgroups.Create(client, createSGOpts).Extract()
 	th.AssertNoErr(t, err)
 
+	t.Logf("Security group %s was created", secGroup.ID)
 	return secGroup.ID
 }
 
@@ -66,6 +67,8 @@ func DeleteSecurityGroup(t *testing.T, secGroupID string) {
 
 	err = secgroups.DeleteWithRetry(client, secGroupID, 600)
 	th.AssertNoErr(t, err)
+
+	t.Logf("Security group %s was deleted", secGroupID)
 }
 
 func CreateVolume(t *testing.T) *volumes.Volume {

--- a/acceptance/openstack/css/v1/clusters_test.go
+++ b/acceptance/openstack/css/v1/clusters_test.go
@@ -1,0 +1,90 @@
+package v1
+
+import (
+	"log"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/css/v1/clusters"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+const timeout = 1200
+
+func TestClusterWorkflow(t *testing.T) {
+	client, err := clients.NewCssV1Client()
+	th.AssertNoErr(t, err)
+
+	vpcID := clients.EnvOS.GetEnv("VPC_ID")
+	subnetID := clients.EnvOS.GetEnv("NETWORK_ID")
+
+	if vpcID == "" || subnetID == "" {
+		t.Skip("Both `VPC_ID` and `NETWORK_ID` need to be defined")
+	}
+
+	sgID := openstack.DefaultSecurityGroup(t)
+
+	opts := clusters.CreateOpts{
+		Name: tools.RandomString("css-cluster-", 4),
+		Instance: &clusters.InstanceSpec{
+			Flavor: "css.medium.8",
+
+			Volume: &clusters.Volume{
+				Type: "COMMON",
+				Size: 40,
+			},
+			Nics: &clusters.Nics{
+				VpcID:           vpcID,
+				SubnetID:        subnetID,
+				SecurityGroupID: sgID,
+			},
+			AvailabilityZone: "eu-de-02",
+		},
+		InstanceNum: 1,
+		DiskEncryption: &clusters.DiskEncryption{
+			Encrypted: "0",
+		},
+	}
+	created, err := clusters.Create(client, opts).Extract()
+	th.AssertNoErr(t, err)
+
+	defer func() {
+		err = clusters.Delete(client, created.ID).ExtractErr()
+		th.AssertNoErr(t, err)
+	}()
+
+	got, err := clusters.Get(client, created.ID).Extract()
+	th.AssertNoErr(t, err)
+
+	log.Printf("Creating cluster, ID: %s", got.ID)
+	th.AssertEquals(t, created.ID, got.ID)
+	th.AssertEquals(t, created.Name, got.Name)
+
+	th.CheckNoErr(t, clusters.WaitForClusterOperationSucces(client, created.ID, timeout))
+
+	pages, err := clusters.List(client).AllPages()
+	th.AssertNoErr(t, err)
+
+	list, err := clusters.ExtractClusters(pages)
+	th.AssertNoErr(t, err)
+
+	found := false
+	for _, one := range list {
+		if one.ID == created.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("cluster %s is not found in list", created.ID)
+	}
+
+	_, err = clusters.ExtendCluster(client, created.ID, clusters.ClusterExtendCommonOpts{
+		ModifySize: 1,
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertNoErr(t, clusters.WaitForClusterToExtend(client, created.ID, timeout))
+}

--- a/openstack/css/v1/clusters/requests.go
+++ b/openstack/css/v1/clusters/requests.go
@@ -1,0 +1,286 @@
+package clusters
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+)
+
+type CreateOptsBuilder interface {
+	ToClusterCreateMap() (map[string]interface{}, error)
+}
+
+type Volume struct {
+	// Type of the volume.
+	// One of:
+	//   - `COMMON`: Common I/O
+	//   - `HIGH`: High I/O
+	//   - `ULTRAHIGH`: Ultra-high I/O
+	Type string `json:"volume_type" required:"true"`
+
+	// Size of the volume, which must be a multiple of 4 and 10.
+	// Unit: GB.
+	Size int `json:"size" required:"true"`
+}
+
+type Nics struct {
+	// VpcID - VPC ID which is used for configuring cluster network.
+	VpcID string `json:"vpcId" required:"true"`
+
+	// SubnetID - Subnet ID.
+	// All instances in a cluster must have the same subnet.
+	SubnetID string `json:"netId" required:"true"`
+
+	// SecurityGroupID - Security group ID.
+	// All instances in a cluster must have the same security grou.
+	SecurityGroupID string `json:"securityGroupId" required:"true"`
+}
+
+type InstanceSpec struct {
+	// Flavor - instance flavor name.
+	Flavor string `json:"flavorRef" required:"true"`
+
+	// Volume - information about the volume.
+	Volume *Volume `json:"volume" required:"true"`
+
+	// Nics - subnet information.
+	Nics *Nics `json:"nics" required:"true"`
+
+	AvailabilityZone string `json:"availability_zone,omitempty"`
+}
+
+type Datastore struct {
+	// Version - engine version.
+	// The default value is 6.2.3.
+	Version string `json:"version" required:"true"`
+
+	// Type - Engine type.
+	// The default value is `elasticsearch`.
+	Type string `json:"type,omitempty"`
+}
+
+type BackupStrategy struct {
+	// Period - time when a snapshot is created every day.
+	// Snapshots can only be created on the hour.
+	// The time format is the time followed by the time zone, specifically, `HH:mm z`.
+	// In the format, `HH:mm` refers to the hour time and `z` refers to the time zone, for example,
+	// `00:00 GMT+08:00` and `01:00 GMT+08:00`.
+	Period string `json:"period" required:"true"`
+
+	// Prefix - prefix of the name of the snapshot that is automatically created.
+	Prefix string `json:"prefix" required:"true"`
+
+	// KeepDay - number of days for which automatically created snapshots are reserved.
+	//
+	// Value range: `1` to `90`
+	KeepDay int `json:"keepday" required:"true"`
+}
+
+type DiskEncryption struct {
+	// SystemEncrypted - value `1` indicates encryption is performed, and value `0` indicates encryption is not performed.
+	// Boolean sucks.
+	Encrypted string `json:"systemEncrypted" required:"true"`
+
+	// Key ID.
+	//  - The Default Master Keys cannot be used to create grants.
+	//    Specifically, you cannot use Default Master Keys whose aliases end with `/default` in KMS to create clusters.
+	//  - After a cluster is created, do not delete the key used by the cluster. Otherwise, the cluster will become unavailable.
+	CmkID string `json:"systemCmkid"`
+}
+
+type CreateOpts struct {
+	// Instance - instance specification
+	Instance *InstanceSpec `json:"instance" required:"true"`
+
+	// Datastore - type of the data search engine
+	Datastore *Datastore `json:"datastore,omitempty"`
+
+	// Name - cluster name.
+	// It contains 4 to 32 characters. Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	// The value must start with a letter.
+	Name string `json:"name" required:"true"`
+
+	// InstanceNum - number of clusters. The value range is 1 to 32.
+	InstanceNum int `json:"instanceNum" required:"true"`
+
+	// BackupStrategy - configuration of automatic snapshot creation.
+	// This function is enabled by default.
+	BackupStrategy *BackupStrategy `json:"backupStrategy,omitempty"`
+
+	// DiskEncryption - disk encryption configuration
+	DiskEncryption *DiskEncryption `json:"diskEncryption" required:"true"`
+
+	// HttpsEnabled - whether communication is not encrypted on the cluster.
+	HttpsEnabled string `json:"httpsEnable,omitempty"`
+
+	// AuthorityEnabled - whether to enable authentication.
+	// Available values include `true` and `false`. Authentication is disabled by default.
+	// When authentication is enabled, `HttpsEnabled` must be set to `true`.
+	AuthorityEnabled bool `json:"authorityEnable,omitempty"`
+
+	// AdminPassword - password of the cluster user `admin` in security mode.
+	// This parameter is mandatory only when `AuthorityEnabled` is set to `true`.
+	AdminPassword string `json:"adminPwd,omitempty"`
+
+	// Tags - tags of a cluster.
+	Tags []tags.ResourceTag `json:"tags,omitempty"`
+}
+
+func (opts CreateOpts) ToClusterCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "cluster")
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToClusterCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(listURL(client), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+func List(client *golangsdk.ServiceClient) (p pagination.Pager) {
+	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
+		return ClusterPage{pagination.SinglePageBase(r)}
+	})
+}
+
+func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(singleURL(client, id), &r.Body, nil)
+	return
+}
+
+func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(singleURL(client, id), &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	})
+	return
+}
+
+func WaitForClusterOperationSucces(client *golangsdk.ServiceClient, id string, timeout int) error {
+	return golangsdk.WaitFor(timeout, func() (bool, error) {
+		cluster, err := Get(client, id).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.BaseError); ok {
+				return true, err
+			}
+			log.Printf("Error waiting for CSS cluster: %s", err) // ignore connection-related errors
+			return false, nil
+		}
+
+		switch s := cluster.Status; s {
+		case "100":
+			time.Sleep(30 * time.Second) // make a bigger wait if it's not ready
+			return false, nil
+		case "200":
+			return true, nil
+		case "303":
+			return true, fmt.Errorf("cluster operartion failed: %+v", cluster.FailedReasons)
+		default:
+			return true, fmt.Errorf("invalid status: %s", s)
+		}
+	})
+}
+
+func DownloadCertificate(client *golangsdk.ServiceClient, clusterID string) (r CertificateResult) {
+	_, r.Err = client.Get(certificateURL(client, clusterID), &r.Body, nil)
+	return
+}
+
+type ClusterExtendOptsBuilder interface {
+	ToExtendClusterMap() (map[string]interface{}, error)
+}
+
+// ClusterExtendCommonOpts is used to extend cluster with only `common` nodes.
+// Clusters with master, client, or cold data nodes cannot use this.
+type ClusterExtendCommonOpts struct {
+	// ModifySize - number of instances to be added.
+	ModifySize int `json:"modifySize"`
+}
+
+func (opts ClusterExtendCommonOpts) ToExtendClusterMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "grow")
+}
+
+// ClusterExtendSpecialOpts is used to extend cluster with special nodes.
+// If a cluster has master, client, or cold data nodes, this should be used
+type ClusterExtendSpecialOpts struct {
+	// Type of the instance to be scaled out.
+	// Select at least one from `ess`, `ess-cold`, `ess-master`, and `ess-client`.
+	// You can only add instances, rather than increase storage capacity, on nodes of the `ess-master` and `ess-client` types.
+	Type string `json:"type"`
+
+	// NodeSize - number of instances to be scaled out.
+	// The total number of existing instances and newly added instances in a cluster cannot exceed 32.
+	NodeSize int `json:"nodesize"`
+
+	// DiskSize - Storage capacity of the instance to be expanded.
+	// The total storage capacity of existing instances and newly added instances in a cluster cannot exceed the maximum instance storage capacity allowed when a cluster is being created. In addition, you can expand the instance storage capacity for a cluster for up to six times.
+	//
+	// Unit: GB
+	DiskSize int `json:"disksize"`
+}
+
+func (opts ClusterExtendSpecialOpts) ToExtendClusterMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "grow")
+}
+
+// ExtendCluster - extends cluster capacity.
+//
+// ClusterExtendCommonOpts should be used as options to extend cluster with only `common` nodes.
+//
+// ClusterExtendSpecialOpts should be used if extended cluster has master, client, or cold data nodes.
+func ExtendCluster(client *golangsdk.ServiceClient, clusterID string, opts ClusterExtendOptsBuilder) (r ExtendResult) {
+	url := ""
+	switch opts.(type) {
+	case ClusterExtendCommonOpts:
+		url = extendCommonURL(client, clusterID)
+	case ClusterExtendSpecialOpts:
+		url = extendSpecialURL(client, clusterID)
+	default:
+		r.Err = fmt.Errorf("invalid options type provided: %T", opts)
+		return
+	}
+
+	b, err := opts.ToExtendClusterMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(url, b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+func WaitForClusterToExtend(client *golangsdk.ServiceClient, id string, timeout int) error {
+	return golangsdk.WaitFor(timeout, func() (bool, error) {
+		cluster, err := Get(client, id).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.BaseError); ok {
+				return true, err
+			}
+			log.Printf("Error waiting for CSS cluster to extend: %s", err) // ignore connection-related errors
+			return false, nil
+		}
+		// No active action
+		if len(cluster.Actions) == 0 {
+			return true, nil
+		}
+		if cluster.Actions[0] == "GROWING" {
+			time.Sleep(30 * time.Second) // make a bigger wait if it's not ready
+			return false, nil
+		}
+		return false, fmt.Errorf("unexpected cluster actions: %v; progress: %v", cluster.Actions, cluster.ActionProgress)
+	})
+}

--- a/openstack/css/v1/clusters/results.go
+++ b/openstack/css/v1/clusters/results.go
@@ -1,0 +1,128 @@
+package clusters
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+)
+
+type CreatedCluster struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Instance struct {
+	Type             string `json:"type"`
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	Status           string `json:"status"`
+	SpecCode         string `json:"specCode"`
+	AvailabilityZone string `json:"azCode"`
+}
+
+type FailedReasons struct {
+	ErrorCode    string `json:"errorCode"`
+	ErrorMessage string `json:"errorMsg"`
+}
+
+type Cluster struct {
+	Datastore        Datastore          `json:"datastore"`
+	Instances        []Instance         `json:"instances"`
+	Updated          string             `json:"updated"`
+	Name             string             `json:"name"`
+	Created          string             `json:"created"`
+	ID               string             `json:"id"`
+	Status           string             `json:"status"`
+	Endpoint         string             `json:"endpoint"`
+	ActionProgress   map[string]string  `json:"actionProgress"`
+	Actions          []string           `json:"actions"`
+	FailedReasons    *FailedReasons     `json:"failed_reasons"`
+	HttpsEnabled     bool               `json:"httpsEnable"`
+	AuthorityEnabled bool               `json:"authorityEnable"`
+	DiskEncrypted    bool               `json:"diskEncrypted"`
+	CmkID            string             `json:"cmkId"`
+	VpcID            string             `json:"vpcId"`
+	SubnetID         string             `json:"subnetId"`
+	SecurityGroupID  string             `json:"securityGroupId" required:"true"`
+	Tags             []tags.ResourceTag `json:"tags"`
+}
+
+type CreateResult struct {
+	golangsdk.Result
+}
+
+func (r CreateResult) Extract() (*CreatedCluster, error) {
+	var s struct {
+		Cluster *CreatedCluster `json:"cluster"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Cluster, err
+}
+
+type ClusterPage struct {
+	pagination.SinglePageBase
+}
+
+func ExtractClusters(r pagination.Page) ([]Cluster, error) {
+	var clusters []Cluster
+	err := (r.(ClusterPage)).ExtractIntoSlicePtr(&clusters, "clusters")
+	return clusters, err
+}
+
+func (p ClusterPage) GetBody() interface{} {
+	return p.Body
+}
+
+func (p ClusterPage) IsEmpty() (bool, error) {
+	clusterSlice, err := ExtractClusters(p)
+	return len(clusterSlice) == 0, err
+}
+
+type GetResult struct {
+	golangsdk.Result
+}
+
+func (r GetResult) Extract() (*Cluster, error) {
+	cluster := new(Cluster)
+	err := r.ExtractInto(cluster)
+	return cluster, err
+}
+
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+type CertificateResult struct {
+	golangsdk.Result
+}
+
+func (r CertificateResult) Extract() (string, error) {
+	var cert struct {
+		CertBase64 string `json:"certBase64"`
+	}
+
+	err := r.ExtractInto(&cert)
+	return cert.CertBase64, err
+}
+
+type ExtendResult struct {
+	golangsdk.Result
+}
+
+type ExtendedInstance struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	ShardID string `json:"shard_id"`
+}
+
+type ExtendedCluster struct {
+	ID        string             `json:"id"`
+	Instances []ExtendedInstance `json:"instances"`
+}
+
+func (r ExtendResult) Extract() (*ExtendedCluster, error) {
+	c := new(ExtendedCluster)
+	err := r.ExtractInto(c)
+	return c, err
+}

--- a/openstack/css/v1/clusters/testing/fixtures.go
+++ b/openstack/css/v1/clusters/testing/fixtures.go
@@ -1,0 +1,188 @@
+package testing
+
+import "fmt"
+
+const (
+	vpcID    = "fccd753c-91c3-40e2-852f-5ddf76d1a1b2"
+	subnetID = "af1c65ae-c494-4e24-acd8-81d6b355c9f1"
+	sgID     = "7e3fed21-1a44-4101-ab29-34e57124f614"
+	cmkID    = "42546bb1-8025-4ad1-868f-600729c341ae"
+
+	clusterID   = "ef683016-871e-48bc-bf93-74a29d60d214"
+	clusterName = "ES-Test"
+)
+
+const (
+	listResponseBody = `
+{
+    "clusters": [
+        {
+            "datastore": {
+                "type": "elasticsearch",
+                "version": "7.6.2"
+            },
+            "instances": [
+                {
+                    "status": "200",
+                    "type": "ess",
+                    "id": "c8c90973-924d-4201-b9ff-f32279c87d0e",
+                    "name": "css-5492-ess-esn-1-1",
+                    "specCode": "css.xlarge.2",
+                    "azCode": "eu-de-01"
+                }
+            ],
+            "updated": "2020-12-01T07:47:34",
+            "name": "css-5492",
+            "created": "2020-12-01T07:47:34",
+            "id": "66ea1e42-4ee2-44ad-bd80-c86e6d8c6b9e",
+            "status": "200",
+            "endpoint": "10.16.0.151:9200",
+            "vpcId": "e7daa617-3ee6-4ff1-b042-8cda4a006a46",
+            "subnetId": "6253dc44-24cd-4c0a-90b3-f965e7f4dcd4",
+            "securityGroupId": "d478041e-bcbe-4d69-a492-b6122d774b7f",
+            "httpsEnable": false,
+            "authorityEnable": false,
+            "diskEncrypted": true,
+            "cmkId": "00f05033-f8ac-4ceb-a1ce-4072fadb6b28",
+            "actionProgress": {},
+            "actions": [],
+            "tags": []
+        },
+        {
+            "datastore": {
+                "type": "elasticsearch",
+                "version": "6.2.3"
+            },
+            "instances": [
+                {
+                    "status": "200",
+                    "type": "ess",
+                    "id": "a24adddb-1553-4873-9978-9d064418f903",
+                    "name": "css-1d01-ess-esn-1-1",
+                    "specCode": "css.xlarge.2",
+                    "azCode": "eu-de-01"
+                }
+            ],
+            "updated": "2020-11-26T10:08:44",
+            "name": "css-1d01",
+            "created": "2020-11-26T10:08:44",
+            "id": "af5fbac7-b386-4305-b201-820a0f51f4f1",
+            "status": "200",
+            "endpoint": "10.16.0.124:9200",
+            "vpcId": "e7daa617-3ee6-4ff1-b042-8cda4a006a46",
+            "subnetId": "6253dc44-24cd-4c0a-90b3-f965e7f4dcd4",
+            "securityGroupId": "d478041e-bcbe-4d69-a492-b6122d774b7f",
+            "httpsEnable": true,
+            "authorityEnable": false,
+            "diskEncrypted": false,
+            "cmkId": "",
+            "actionProgress": {},
+            "actions": [],
+            "tags": []
+        },
+        {
+            "datastore": {
+                "type": "elasticsearch",
+                "version": "7.6.2"
+            },
+            "instances": [
+                {
+                    "status": "303",
+                    "type": "ess",
+                    "id": "071c7ecf-a11d-45bd-9564-201ceb7cfae3",
+                    "name": "css-9b36-ess-esn-1-1",
+                    "specCode": "css.xlarge.2",
+                    "azCode": "eu-de-02"
+                }
+            ],
+            "updated": "2020-11-13T14:33:24",
+            "name": "css-9b36",
+            "created": "2020-11-13T14:33:26",
+            "id": "cdb26954-c743-47dd-b23a-b693205eb2da",
+            "status": "303",
+            "endpoint": null,
+            "vpcId": "e7daa617-3ee6-4ff1-b042-8cda4a006a46",
+            "subnetId": "6253dc44-24cd-4c0a-90b3-f965e7f4dcd4",
+            "securityGroupId": "d478041e-bcbe-4d69-a492-b6122d774b7f",
+            "httpsEnable": true,
+            "authorityEnable": true,
+            "diskEncrypted": false,
+            "cmkId": "",
+            "actionProgress": {},
+            "actions": [],
+            "tags": []
+        }
+    ]
+}
+`
+)
+
+var (
+	createRequestBody = fmt.Sprintf(`
+{
+    "cluster": {
+        "name": "ES-Test",
+        "instanceNum": 4,
+        "instance": {
+            "flavorRef": "css.large.8",
+            "volume": {
+                "volume_type": "COMMON",
+                "size": 100
+            },
+            "nics": {
+                "vpcId": "%s",
+                "netId": "%s",
+                "securityGroupId": "%s"
+            }
+        },
+        "httpsEnable": "false",
+        "diskEncryption": {
+            "systemEncrypted": "1",
+            "systemCmkid": "%s"
+        }
+    }
+}
+`, vpcID, subnetID, sgID, cmkID)
+
+	createResponseBody = fmt.Sprintf(`
+{
+  "cluster": {
+    "id": "%s",
+    "name": "%s"
+  }
+}
+`, clusterID, clusterName)
+	getResponseBody = fmt.Sprintf(`
+{
+    "datastore": {
+        "type": "elasticsearch",
+        "version": "7.6.2"
+    },
+    "instances": [
+        {
+            "status": "200",
+            "type": "ess",
+            "id": "c2f29369-1985-4028-8e72-89cbb96a299d",
+            "name": "%s-ess-esn-1-1",
+            "specCode": "css.xlarge.2",
+            "azCode": "eu-de-01"
+        }
+    ],
+    "updated": "2020-12-03T07:02:08",
+    "name": "%[1]s",
+    "created": "2020-12-03T07:02:08",
+    "id": "%s",
+    "status": "200",
+    "endpoint": "10.16.0.88:9200",
+    "vpcId": "%s",
+    "subnetId": "%s",
+    "securityGroupId": "%s",
+    "httpsEnable": true,
+    "authorityEnable": true,
+    "diskEncrypted": false,
+    "actionProgress": {},
+    "actions": [],
+    "tags": []
+}
+`, clusterName, clusterID, vpcID, subnetID, sgID)
+)

--- a/openstack/css/v1/clusters/testing/requests_test.go
+++ b/openstack/css/v1/clusters/testing/requests_test.go
@@ -1,0 +1,134 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/css/v1/clusters"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	fake "github.com/opentelekomcloud/gophertelekomcloud/testhelper/client"
+)
+
+type Clusters struct {
+	suite.Suite
+}
+
+func (s *Clusters) SetupTest() {
+	th.SetupHTTP()
+}
+
+func (s *Clusters) TearDownTest() {
+	th.TeardownHTTP()
+}
+
+func (s *Clusters) TestCreateRequest() {
+	t := s.T()
+
+	th.Mux.HandleFunc("/clusters", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestJSONRequest(t, r, createRequestBody)
+
+		w.Header().Add("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, createResponseBody)
+	})
+
+	opts := clusters.CreateOpts{
+		Instance: &clusters.InstanceSpec{
+			Flavor: "css.large.8",
+			Volume: &clusters.Volume{
+				Type: "COMMON",
+				Size: 100,
+			},
+			Nics: &clusters.Nics{
+				VpcID:           vpcID,
+				SubnetID:        subnetID,
+				SecurityGroupID: sgID,
+			},
+		},
+		Name:        clusterName,
+		InstanceNum: 4,
+		DiskEncryption: &clusters.DiskEncryption{
+			Encrypted: "1",
+			CmkID:     cmkID,
+		},
+		HttpsEnabled:     "false",
+		AuthorityEnabled: false,
+	}
+
+	created, err := clusters.Create(fake.ServiceClient(), opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, clusterName, created.Name)
+	th.AssertEquals(t, clusterID, created.ID)
+}
+
+func (s *Clusters) TestGetRequest() {
+	t := s.T()
+
+	clusterURL := fmt.Sprintf("/clusters/%s", clusterID)
+	th.Mux.HandleFunc(clusterURL, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, getResponseBody)
+	})
+
+	cluster, err := clusters.Get(fake.ServiceClient(), clusterID).Extract()
+	th.AssertNoErr(t, err)
+	if cluster == nil {
+		t.Fatal("cluster is nil")
+	}
+
+	th.AssertEquals(t, clusterID, cluster.ID)
+	th.AssertEquals(t, clusterName, cluster.Name)
+	th.AssertEquals(t, "200", cluster.Status)
+	th.AssertEquals(t, "7.6.2", cluster.Datastore.Version)
+	th.AssertEquals(t, "elasticsearch", cluster.Datastore.Type)
+}
+
+func (s *Clusters) TestListRequest() {
+	t := s.T()
+
+	th.Mux.HandleFunc("/clusters", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, listResponseBody)
+	})
+
+	pages, err := clusters.List(fake.ServiceClient()).AllPages()
+	th.AssertNoErr(t, err)
+
+	clusterSlice, err := clusters.ExtractClusters(pages)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, len(clusterSlice), 3)
+	for _, cluster := range clusterSlice {
+		t.Logf("%+v", cluster)
+	}
+}
+
+func (s *Clusters) TestDeleteRequest() {
+	t := s.T()
+
+	clusterURL := fmt.Sprintf("/clusters/%s", clusterID)
+	th.Mux.HandleFunc(clusterURL, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.WriteHeader(200)
+	})
+
+	err := clusters.Delete(fake.ServiceClient(), clusterID).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestClustersMethods(t *testing.T) {
+	suite.Run(t, new(Clusters))
+}

--- a/openstack/css/v1/clusters/urls.go
+++ b/openstack/css/v1/clusters/urls.go
@@ -1,0 +1,27 @@
+package clusters
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+const (
+	clusters = "clusters"
+)
+
+func listURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(clusters)
+}
+
+func singleURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(clusters, id)
+}
+
+func certificateURL(c *golangsdk.ServiceClient, clusterID string) string {
+	return c.ServiceURL(clusters, clusterID, "sslCert")
+}
+
+func extendCommonURL(c *golangsdk.ServiceClient, clusterID string) string {
+	return c.ServiceURL(clusters, clusterID, "extend")
+}
+
+func extendSpecialURL(c *golangsdk.ServiceClient, clusterID string) string {
+	return c.ServiceURL(clusters, clusterID, "role_extend")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
CSS cluster client is missing

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->
Fix #105 

### Special notes for your reviewer
CSS works unstable

### Acceptance test:
_This test will be skipped in CI_
```
=== RUN   TestClusterWorkflow
2021/03/11 13:03:29 Creating cluster, ID: 6febcbd8-fac9-4b6a-8371-782dd09fb214
2021/03/11 13:30:09 Error waiting for CSS cluster to extend: Get "https://css.eu-de.otc.t-systems.com/v1.0/5dd3c0b24cdc4d31952c49589182a89d/clusters/6febcbd8-fac9-4b6a-8371-782dd09fb214": read tcp 192.168.1.44:40748->80.158.48.6:443: read: connection timed out
--- PASS: TestClusterWorkflow (1768.74s)
PASS

Process finished with exit code 0
```
