### PR TITLE
[ELB] Update `Monitor` createOpts/updateOpts

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/certificates_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/certificates_test.go
@@ -3,27 +3,23 @@ package lbaas_v2
 import (
 	"testing"
 
-	"github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/certificates"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
 
 func TestLbaasV2CertificatesList(t *testing.T) {
 	client, err := clients.NewNetworkV2Client()
-	if err != nil {
-		t.Fatalf("Unable to create a NetworkingV2 client: %s", err)
-	}
+	th.AssertNoErr(t, err)
 
 	listOpts := certificates.ListOpts{}
 	allPages, err := certificates.List(client, listOpts).AllPages()
-	if err != nil {
-		t.Fatalf("Unable to fetch LbaasV2 pages: %s", err)
-	}
+	th.AssertNoErr(t, err)
+
 	lbaasCertificates, err := certificates.ExtractCertificates(allPages)
-	if err != nil {
-		t.Fatalf("Unable to extract LbaasV2 pages: %s", err)
-	}
+	th.AssertNoErr(t, err)
+
 	for _, certificate := range lbaasCertificates {
 		tools.PrintResource(t, certificate)
 	}
@@ -31,150 +27,20 @@ func TestLbaasV2CertificatesList(t *testing.T) {
 
 func TestLbaasV2CertificateLifeCycle(t *testing.T) {
 	client, err := clients.NewNetworkV2Client()
-	if err != nil {
-		t.Fatalf("Unable to create a NetworkingV2 client: %s", err)
-	}
+	th.AssertNoErr(t, err)
 
 	// Create lbaasV2 certificate
 	lbaasCertificate, err := createLbaasCertificate(t, client)
-	if err != nil {
-		t.Fatalf("Unable to create LbaasV2 certificate: %s", err)
-	}
+	th.AssertNoErr(t, err)
 	defer deleteLbaasCertificate(t, client, lbaasCertificate.ID)
 
 	tools.PrintResource(t, lbaasCertificate)
 
 	err = updateLbaasCertificate(t, client, lbaasCertificate.ID)
-	if err != nil {
-		t.Fatalf("Unable to update LbaasV2 certificate: %s", err)
-	}
+	th.AssertNoErr(t, err)
 	tools.PrintResource(t, lbaasCertificate)
 
 	newLbaasCertificate, err := certificates.Get(client, lbaasCertificate.ID).Extract()
-	if err != nil {
-		t.Fatalf("Unable to get LbaasV2 certificate: %s", err)
-	}
+	th.AssertNoErr(t, err)
 	tools.PrintResource(t, newLbaasCertificate)
-}
-
-func createLbaasCertificate(t *testing.T, client *golangsdk.ServiceClient) (*certificates.Certificate, error) {
-	certificateName := tools.RandomString("create-cert-", 8)
-	privateKey := `
------BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
-qEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYldiE6Vp8HH5BSKaCWKVg8lGWg1
-UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb3iyNBmiZ8aZhGw2pI1YwR+15
-MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dzQ8z1JXWdg8/9Zx7Ktvgwu5PQ
-M3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5mf2DPkVgM08XAgaLJcLigwD5
-13koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwIDAQABAoIBACU9S5fjD9/jTMXA
-DRs08A+gGgZUxLn0xk+NAPX3LyB1tfdkCaFB8BccLzO6h3KZuwQOBPv6jkdvEDbx
-Nwyw3eA/9GJsIvKiHc0rejdvyPymaw9I8MA7NbXHaJrY7KpqDQyk6sx+aUTcy5jg
-iMXLWdwXYHhJ/1HVOo603oZyiS6HZeYU089NDUcX+1SJi3e5Ke0gPVXEqCq1O11/
-rh24bMxnwZo4PKBWdcMBN5Zf/4ij9vrZE+fFzW7vGBO48A5lvZxWU2U5t/OZQRtN
-1uLOHmMFa0FIF2aWbTVfwdUWAFsvAOkHj9VV8BXOUwKOUuEktdkfAlvrxmsFrO/H
-yDeYYPkCgYEA/S55CBbR0sMXpSZ56uRn8JHApZJhgkgvYr+FqDlJq/e92nAzf01P
-RoEBUajwrnf1ycevN/SDfbtWzq2XJGqhWdJmtpO16b7KBsC6BdRcH6dnOYh31jgA
-vABMIP3wzI4zSVTyxRE8LDuboytF1mSCeV5tHYPQTZNwrplDnLQhywcCgYEAw8Yc
-Uk/eiFr3hfH/ZohMfV5p82Qp7DNIGRzw8YtVG/3+vNXrAXW1VhugNhQY6L+zLtJC
-aKn84ooup0m3YCg0hvINqJuvzfsuzQgtjTXyaE0cEwsjUusOmiuj09vVx/3U7siK
-Hdjd2ICPCvQ6Q8tdi8jV320gMs05AtaBkZdsiWUCgYEAtLw4Kk4f+xTKDFsrLUNf
-75wcqhWVBiwBp7yQ7UX4EYsJPKZcHMRTk0EEcAbpyaJZE3I44vjp5ReXIHNLMfPs
-uvI34J4Rfot0LN3n7cFrAi2+wpNo+MOBwrNzpRmijGP2uKKrq4JiMjFbKV/6utGF
-Up7VxfwS904JYpqGaZctiIECgYA1A6nZtF0riY6ry/uAdXpZHL8ONNqRZtWoT0kD
-79otSVu5ISiRbaGcXsDExC52oKrSDAgFtbqQUiEOFg09UcXfoR6HwRkba2CiDwve
-yHQLQI5Qrdxz8Mk0gIrNrSM4FAmcW9vi9z4kCbQyoC5C+4gqeUlJRpDIkQBWP2Y4
-2ct/bQKBgHv8qCsQTZphOxc31BJPa2xVhuv18cEU3XLUrVfUZ/1f43JhLp7gynS2
-ep++LKUi9D0VGXY8bqvfJjbECoCeu85vl8NpCXwe/LoVoIn+7KaVIZMwqoGMfgNl
-nEqm7HWkNxHhf8A6En/IjleuddS1sf9e/x+TJN1Xhnt9W6pe7Fk1
------END RSA PRIVATE KEY-----`
-	certificate := `
------BEGIN CERTIFICATE-----
-MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
-BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
-CQYDVQQLDAJ4eDELMAkGA1UEAwwCeHgxGTAXBgkqhkiG9w0BCQEWCnh4QDE2My5j
-b20wHhcNMTcxMjA0MDM0MjQ5WhcNMjAxMjAzMDM0MjQ5WjBpMQswCQYDVQQGEwJ4
-eDELMAkGA1UECAwCeHgxCzAJBgNVBAcMAnh4MQswCQYDVQQKDAJ4eDELMAkGA1UE
-CwwCeHgxCzAJBgNVBAMMAnh4MRkwFwYJKoZIhvcNAQkBFgp4eEAxNjMuY29tMIIB
-IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN
-2s8tZ/6LC3X82fajpVsYqF1xqEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYld
-iE6Vp8HH5BSKaCWKVg8lGWg1UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb
-3iyNBmiZ8aZhGw2pI1YwR+15MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dz
-Q8z1JXWdg8/9Zx7Ktvgwu5PQM3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5
-mf2DPkVgM08XAgaLJcLigwD513koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwID
-AQABo1AwTjAdBgNVHQ4EFgQUo5A2tIu+bcUfvGTD7wmEkhXKFjcwHwYDVR0jBBgw
-FoAUo5A2tIu+bcUfvGTD7wmEkhXKFjcwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0B
-AQsFAAOCAQEAWJ2rS6Mvlqk3GfEpboezx2J3X7l1z8Sxoqg6ntwB+rezvK3mc9H0
-83qcVeUcoH+0A0lSHyFN4FvRQL6X1hEheHarYwJK4agb231vb5erasuGO463eYEG
-r4SfTuOm7SyiV2xxbaBKrXJtpBp4WLL/s+LF+nklKjaOxkmxUX0sM4CTA7uFJypY
-c8Tdr8lDDNqoUtMD8BrUCJi+7lmMXRcC3Qi3oZJW76ja+kZA5mKVFPd1ATih8TbA
-i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
-i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+8Kg==
------END CERTIFICATE-----`
-	adminStateUp := true
-
-	createLbaasCertificateOpts := certificates.CreateOpts{
-		AdminStateUp: &adminStateUp,
-		Name:         certificateName,
-		Description:  "some test description",
-		PrivateKey:   privateKey,
-		Certificate:  certificate,
-	}
-	lbaasCertificate, err := certificates.Create(client, createLbaasCertificateOpts).Extract()
-	if err != nil {
-		return nil, err
-	}
-	t.Logf("Created LbaasV2 certificate: %s", lbaasCertificate.ID)
-
-	return lbaasCertificate, nil
-}
-
-func deleteLbaasCertificate(t *testing.T, client *golangsdk.ServiceClient, lbaasCertificateId string) {
-	t.Logf("Attempting to delete LbaasV2 certificate: %s", lbaasCertificateId)
-
-	if err := certificates.Delete(client, lbaasCertificateId).Err; err != nil {
-		t.Fatalf("Unable to delete LbaasV2 certificate: %s", err)
-	}
-
-	t.Logf("LbaasV2 certificate is deleted: %s", lbaasCertificateId)
-}
-
-func updateLbaasCertificate(t *testing.T, client *golangsdk.ServiceClient, lbaasCertificateId string) error {
-	t.Logf("Attempting to update LbaasV2 certificate")
-
-	certificateNewName := tools.RandomString("update-cert-", 8)
-
-	updateCertificate := `
------BEGIN CERTIFICATE-----
-MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
-BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
-CQYDVQQLDAJ4eDELMAkGA1UEAwwCeHgxGTAXBgkqhkiG9w0BCQEWCnh4QDE2My5j
-b20wHhcNMTcxMjA0MDM0MjQ5WhcNMjAxMjAzMDM0MjQ5WjBpMQswCQYDVQQGEwJ4
-eDELMAkGA1UECAwCeHgxCzAJBgNVBAcMAnh4MQswCQYDVQQKDAJ4eDELMAkGA1UE
-CwwCeHgxCzAJBgNVBAMMAnh4MRkwFwYJKoZIhvcNAQkBFgp4eEAxNjMuY29tMIIB
-IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN
-2s8tZ/6LC3X82fajpVsYqF1xqEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYld
-iE6Vp8HH5BSKaCWKVg8lGWg1UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb
-3iyNBmiZ8aZhGw2pI1YwR+15MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dz
-Q8z1JXWdg8/9Zx7Ktvgwu5PQM3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5
-mf2DPkVgM08XAgaLJcLigwD513koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwID
-AQABo1AwTjAdBgNVHQ4EFgQUo5A2tIu+bcUfvGTD7wmEkhXKFjcwHwYDVR0jBBgw
-FoAUo5A2tIu+bcUfvGTD7wmEkhXKFjcwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0B
-AQsFAAOCAQEAWJ2rS6Mvlqk3GfEpboezx2J3X7l1z8Sxoqg6ntwB+rezvK3mc9H0
-83qcVeUcoH+0A0lSHyFN4FvRQL6X1hEheHarYwJK4agb231vb5erasuGO463eYEG
-r4SfTuOm7SyiV2xxbaBKrXJtpBp4WLL/s+LF+nklKjaOxkmxUX0sM4CTA7uFJypY
-c8Tdr8lDDNqoUtMD8BrUCJi+7lmMXRcC3Qi3oZJW76ja+kZA5mKVFPd1ATih8TbA
-i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
-i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+9Aa==
------END CERTIFICATE-----`
-
-	updateOpts := certificates.UpdateOpts{
-		Name:        certificateNewName,
-		Certificate: updateCertificate,
-	}
-
-	if err := certificates.Update(client, lbaasCertificateId, updateOpts).Err; err != nil {
-		return err
-	}
-	t.Logf("LbaasV2 certificate successfully updated: %s", lbaasCertificateId)
-	return nil
 }

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/helpers.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/helpers.go
@@ -175,6 +175,7 @@ func updateLbaasMonitor(t *testing.T, client *golangsdk.ServiceClient, lbaasMoni
 	updateOpts := monitors.UpdateOpts{
 		Name:         monitorNewName,
 		AdminStateUp: &adminStateUp,
+		DomainName:   "www.test.com",
 	}
 
 	_, err := monitors.Update(client, lbaasMonitorID, updateOpts).Extract()

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/helpers.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/helpers.go
@@ -1,0 +1,240 @@
+package lbaas_v2
+
+import (
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/certificates"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/monitors"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/pools"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func createLbaasCertificate(t *testing.T, client *golangsdk.ServiceClient) (*certificates.Certificate, error) {
+	certificateName := tools.RandomString("create-cert-", 8)
+	privateKey := `
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
+qEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYldiE6Vp8HH5BSKaCWKVg8lGWg1
+UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb3iyNBmiZ8aZhGw2pI1YwR+15
+MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dzQ8z1JXWdg8/9Zx7Ktvgwu5PQ
+M3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5mf2DPkVgM08XAgaLJcLigwD5
+13koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwIDAQABAoIBACU9S5fjD9/jTMXA
+DRs08A+gGgZUxLn0xk+NAPX3LyB1tfdkCaFB8BccLzO6h3KZuwQOBPv6jkdvEDbx
+Nwyw3eA/9GJsIvKiHc0rejdvyPymaw9I8MA7NbXHaJrY7KpqDQyk6sx+aUTcy5jg
+iMXLWdwXYHhJ/1HVOo603oZyiS6HZeYU089NDUcX+1SJi3e5Ke0gPVXEqCq1O11/
+rh24bMxnwZo4PKBWdcMBN5Zf/4ij9vrZE+fFzW7vGBO48A5lvZxWU2U5t/OZQRtN
+1uLOHmMFa0FIF2aWbTVfwdUWAFsvAOkHj9VV8BXOUwKOUuEktdkfAlvrxmsFrO/H
+yDeYYPkCgYEA/S55CBbR0sMXpSZ56uRn8JHApZJhgkgvYr+FqDlJq/e92nAzf01P
+RoEBUajwrnf1ycevN/SDfbtWzq2XJGqhWdJmtpO16b7KBsC6BdRcH6dnOYh31jgA
+vABMIP3wzI4zSVTyxRE8LDuboytF1mSCeV5tHYPQTZNwrplDnLQhywcCgYEAw8Yc
+Uk/eiFr3hfH/ZohMfV5p82Qp7DNIGRzw8YtVG/3+vNXrAXW1VhugNhQY6L+zLtJC
+aKn84ooup0m3YCg0hvINqJuvzfsuzQgtjTXyaE0cEwsjUusOmiuj09vVx/3U7siK
+Hdjd2ICPCvQ6Q8tdi8jV320gMs05AtaBkZdsiWUCgYEAtLw4Kk4f+xTKDFsrLUNf
+75wcqhWVBiwBp7yQ7UX4EYsJPKZcHMRTk0EEcAbpyaJZE3I44vjp5ReXIHNLMfPs
+uvI34J4Rfot0LN3n7cFrAi2+wpNo+MOBwrNzpRmijGP2uKKrq4JiMjFbKV/6utGF
+Up7VxfwS904JYpqGaZctiIECgYA1A6nZtF0riY6ry/uAdXpZHL8ONNqRZtWoT0kD
+79otSVu5ISiRbaGcXsDExC52oKrSDAgFtbqQUiEOFg09UcXfoR6HwRkba2CiDwve
+yHQLQI5Qrdxz8Mk0gIrNrSM4FAmcW9vi9z4kCbQyoC5C+4gqeUlJRpDIkQBWP2Y4
+2ct/bQKBgHv8qCsQTZphOxc31BJPa2xVhuv18cEU3XLUrVfUZ/1f43JhLp7gynS2
+ep++LKUi9D0VGXY8bqvfJjbECoCeu85vl8NpCXwe/LoVoIn+7KaVIZMwqoGMfgNl
+nEqm7HWkNxHhf8A6En/IjleuddS1sf9e/x+TJN1Xhnt9W6pe7Fk1
+-----END RSA PRIVATE KEY-----`
+	certificate := `
+-----BEGIN CERTIFICATE-----
+MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
+BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
+CQYDVQQLDAJ4eDELMAkGA1UEAwwCeHgxGTAXBgkqhkiG9w0BCQEWCnh4QDE2My5j
+b20wHhcNMTcxMjA0MDM0MjQ5WhcNMjAxMjAzMDM0MjQ5WjBpMQswCQYDVQQGEwJ4
+eDELMAkGA1UECAwCeHgxCzAJBgNVBAcMAnh4MQswCQYDVQQKDAJ4eDELMAkGA1UE
+CwwCeHgxCzAJBgNVBAMMAnh4MRkwFwYJKoZIhvcNAQkBFgp4eEAxNjMuY29tMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN
+2s8tZ/6LC3X82fajpVsYqF1xqEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYld
+iE6Vp8HH5BSKaCWKVg8lGWg1UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb
+3iyNBmiZ8aZhGw2pI1YwR+15MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dz
+Q8z1JXWdg8/9Zx7Ktvgwu5PQM3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5
+mf2DPkVgM08XAgaLJcLigwD513koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwID
+AQABo1AwTjAdBgNVHQ4EFgQUo5A2tIu+bcUfvGTD7wmEkhXKFjcwHwYDVR0jBBgw
+FoAUo5A2tIu+bcUfvGTD7wmEkhXKFjcwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0B
+AQsFAAOCAQEAWJ2rS6Mvlqk3GfEpboezx2J3X7l1z8Sxoqg6ntwB+rezvK3mc9H0
+83qcVeUcoH+0A0lSHyFN4FvRQL6X1hEheHarYwJK4agb231vb5erasuGO463eYEG
+r4SfTuOm7SyiV2xxbaBKrXJtpBp4WLL/s+LF+nklKjaOxkmxUX0sM4CTA7uFJypY
+c8Tdr8lDDNqoUtMD8BrUCJi+7lmMXRcC3Qi3oZJW76ja+kZA5mKVFPd1ATih8TbA
+i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
+i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+8Kg==
+-----END CERTIFICATE-----`
+	adminStateUp := true
+
+	createLbaasCertificateOpts := certificates.CreateOpts{
+		AdminStateUp: &adminStateUp,
+		Name:         certificateName,
+		Description:  "some test description",
+		PrivateKey:   privateKey,
+		Certificate:  certificate,
+	}
+	lbaasCertificate, err := certificates.Create(client, createLbaasCertificateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Created LbaasV2 certificate: %s", lbaasCertificate.ID)
+
+	return lbaasCertificate, nil
+}
+
+func deleteLbaasCertificate(t *testing.T, client *golangsdk.ServiceClient, lbaasCertificateId string) {
+	t.Logf("Attempting to delete LbaasV2 certificate: %s", lbaasCertificateId)
+
+	err := certificates.Delete(client, lbaasCertificateId).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	t.Logf("LbaasV2 certificate is deleted: %s", lbaasCertificateId)
+}
+
+func updateLbaasCertificate(t *testing.T, client *golangsdk.ServiceClient, lbaasCertificateId string) error {
+	t.Logf("Attempting to update LbaasV2 certificate")
+
+	certificateNewName := tools.RandomString("update-cert-", 8)
+
+	updateCertificate := `
+-----BEGIN CERTIFICATE-----
+MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
+BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
+CQYDVQQLDAJ4eDELMAkGA1UEAwwCeHgxGTAXBgkqhkiG9w0BCQEWCnh4QDE2My5j
+b20wHhcNMTcxMjA0MDM0MjQ5WhcNMjAxMjAzMDM0MjQ5WjBpMQswCQYDVQQGEwJ4
+eDELMAkGA1UECAwCeHgxCzAJBgNVBAcMAnh4MQswCQYDVQQKDAJ4eDELMAkGA1UE
+CwwCeHgxCzAJBgNVBAMMAnh4MRkwFwYJKoZIhvcNAQkBFgp4eEAxNjMuY29tMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN
+2s8tZ/6LC3X82fajpVsYqF1xqEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYld
+iE6Vp8HH5BSKaCWKVg8lGWg1UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb
+3iyNBmiZ8aZhGw2pI1YwR+15MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dz
+Q8z1JXWdg8/9Zx7Ktvgwu5PQM3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5
+mf2DPkVgM08XAgaLJcLigwD513koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwID
+AQABo1AwTjAdBgNVHQ4EFgQUo5A2tIu+bcUfvGTD7wmEkhXKFjcwHwYDVR0jBBgw
+FoAUo5A2tIu+bcUfvGTD7wmEkhXKFjcwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0B
+AQsFAAOCAQEAWJ2rS6Mvlqk3GfEpboezx2J3X7l1z8Sxoqg6ntwB+rezvK3mc9H0
+83qcVeUcoH+0A0lSHyFN4FvRQL6X1hEheHarYwJK4agb231vb5erasuGO463eYEG
+r4SfTuOm7SyiV2xxbaBKrXJtpBp4WLL/s+LF+nklKjaOxkmxUX0sM4CTA7uFJypY
+c8Tdr8lDDNqoUtMD8BrUCJi+7lmMXRcC3Qi3oZJW76ja+kZA5mKVFPd1ATih8TbA
+i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
+i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+9Aa==
+-----END CERTIFICATE-----`
+
+	updateOpts := certificates.UpdateOpts{
+		Name:        certificateNewName,
+		Certificate: updateCertificate,
+	}
+
+	_, err := certificates.Update(client, lbaasCertificateId, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	t.Logf("LbaasV2 certificate successfully updated: %s", lbaasCertificateId)
+	return nil
+}
+
+func createLbaasMonitor(t *testing.T, client *golangsdk.ServiceClient, lbaasPoolID string) (*monitors.Monitor, error) {
+	monitorName := tools.RandomString("create-monitor-", 3)
+	t.Logf("Attempting to create LbaasV2 monitor")
+
+	createOpts := monitors.CreateOpts{
+		PoolID:        lbaasPoolID,
+		Type:          "HTTP",
+		Delay:         15,
+		Timeout:       10,
+		MaxRetries:    10,
+		Name:          monitorName,
+		URLPath:       "/status.php",
+		ExpectedCodes: "200",
+	}
+	lbaasMonitor, err := monitors.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Created LbaasV2 monitor: %s", lbaasMonitor.ID)
+
+	return lbaasMonitor, nil
+}
+
+func deleteLbaasMonitor(t *testing.T, client *golangsdk.ServiceClient, lbaasMonitorID string) {
+	t.Logf("Attempting to delete LbaasV2 monitor: %s", lbaasMonitorID)
+
+	err := monitors.Delete(client, lbaasMonitorID).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	t.Logf("LbaasV2 monitor is deleted: %s", lbaasMonitorID)
+}
+
+func updateLbaasMonitor(t *testing.T, client *golangsdk.ServiceClient, lbaasMonitorID string) error {
+	t.Logf("Attempting to update LbaasV2 monitor")
+
+	monitorNewName := tools.RandomString("update-monitor-", 3)
+	adminStateUp := true
+
+	updateOpts := monitors.UpdateOpts{
+		Name:         monitorNewName,
+		AdminStateUp: &adminStateUp,
+	}
+
+	_, err := monitors.Update(client, lbaasMonitorID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	t.Logf("LbaasV2 monitor successfully updated: %s", lbaasMonitorID)
+	return nil
+}
+
+func createLbaasPool(t *testing.T, client *golangsdk.ServiceClient, loadBalancerID string) (*pools.Pool, error) {
+	poolName := tools.RandomString("create-pool-", 3)
+	t.Logf("Attempting to create LbaasV2 pool")
+
+	createOpts := pools.CreateOpts{
+		LBMethod:       "ROUND_ROBIN",
+		Protocol:       "TCP",
+		LoadbalancerID: loadBalancerID,
+		Name:           poolName,
+	}
+	lbaasMonitor, err := pools.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Created LbaasV2 pool: %s", lbaasMonitor.ID)
+
+	return lbaasMonitor, nil
+}
+
+func deleteLbaasPool(t *testing.T, client *golangsdk.ServiceClient, lbaasPoolID string) {
+	t.Logf("Attempting to delete LbaasV2 pool: %s", lbaasPoolID)
+
+	err := pools.Delete(client, lbaasPoolID).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	t.Logf("LbaasV2 pool is deleted: %s", lbaasPoolID)
+}
+
+func createLbaasLoadBalancer(t *testing.T, client *golangsdk.ServiceClient) (*loadbalancers.LoadBalancer, error) {
+	loadBalancerName := tools.RandomString("create-lb-", 3)
+	t.Logf("Attempting to create LbaasV2 LoadBalancer")
+
+	subnetID := clients.EnvOS.GetEnv("SUBNET_ID")
+	if subnetID == "" {
+		t.Skip("OS_SUBNET_ID env var is missing but LB test requires using existing network")
+	}
+
+	createOpts := loadbalancers.CreateOpts{
+		Name:        loadBalancerName,
+		VipSubnetID: subnetID,
+	}
+	lbaasLoadBalancer, err := loadbalancers.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Created LbaasV2 LoadBalancer: %s", lbaasLoadBalancer.ID)
+
+	return lbaasLoadBalancer, nil
+}
+
+func deleteLbaasLoadBalancer(t *testing.T, client *golangsdk.ServiceClient, lbaasLBID string) {
+	t.Logf("Attempting to delete LbaasV2 LoadBalancer: %s", lbaasLBID)
+
+	err := loadbalancers.Delete(client, lbaasLBID).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	t.Logf("LbaasV2 LoadBalancer is deleted: %s", lbaasLBID)
+}

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/helpers.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/helpers.go
@@ -137,6 +137,7 @@ func createLbaasMonitor(t *testing.T, client *golangsdk.ServiceClient, lbaasPool
 	monitorName := tools.RandomString("create-monitor-", 3)
 	t.Logf("Attempting to create LbaasV2 monitor")
 
+	adminState := false
 	createOpts := monitors.CreateOpts{
 		PoolID:        lbaasPoolID,
 		Type:          "HTTP",
@@ -146,6 +147,7 @@ func createLbaasMonitor(t *testing.T, client *golangsdk.ServiceClient, lbaasPool
 		Name:          monitorName,
 		URLPath:       "/status.php",
 		ExpectedCodes: "200",
+		AdminStateUp:  &adminState,
 	}
 	lbaasMonitor, err := monitors.Create(client, createOpts).Extract()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/helpers.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/helpers.go
@@ -133,58 +133,6 @@ i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+9Aa==
 	return nil
 }
 
-func createLbaasMonitor(t *testing.T, client *golangsdk.ServiceClient, lbaasPoolID string) (*monitors.Monitor, error) {
-	monitorName := tools.RandomString("create-monitor-", 3)
-	t.Logf("Attempting to create LbaasV2 monitor")
-
-	adminState := false
-	createOpts := monitors.CreateOpts{
-		PoolID:        lbaasPoolID,
-		Type:          "HTTP",
-		Delay:         15,
-		Timeout:       10,
-		MaxRetries:    10,
-		Name:          monitorName,
-		URLPath:       "/status.php",
-		ExpectedCodes: "200",
-		AdminStateUp:  &adminState,
-	}
-	lbaasMonitor, err := monitors.Create(client, createOpts).Extract()
-	th.AssertNoErr(t, err)
-
-	t.Logf("Created LbaasV2 monitor: %s", lbaasMonitor.ID)
-
-	return lbaasMonitor, nil
-}
-
-func deleteLbaasMonitor(t *testing.T, client *golangsdk.ServiceClient, lbaasMonitorID string) {
-	t.Logf("Attempting to delete LbaasV2 monitor: %s", lbaasMonitorID)
-
-	err := monitors.Delete(client, lbaasMonitorID).ExtractErr()
-	th.AssertNoErr(t, err)
-
-	t.Logf("LbaasV2 monitor is deleted: %s", lbaasMonitorID)
-}
-
-func updateLbaasMonitor(t *testing.T, client *golangsdk.ServiceClient, lbaasMonitorID string) error {
-	t.Logf("Attempting to update LbaasV2 monitor")
-
-	monitorNewName := tools.RandomString("update-monitor-", 3)
-	adminStateUp := true
-
-	updateOpts := monitors.UpdateOpts{
-		Name:         monitorNewName,
-		AdminStateUp: &adminStateUp,
-		DomainName:   "www.test.com",
-	}
-
-	_, err := monitors.Update(client, lbaasMonitorID, updateOpts).Extract()
-	th.AssertNoErr(t, err)
-
-	t.Logf("LbaasV2 monitor successfully updated: %s", lbaasMonitorID)
-	return nil
-}
-
 func createLbaasPool(t *testing.T, client *golangsdk.ServiceClient, loadBalancerID string) (*pools.Pool, error) {
 	poolName := tools.RandomString("create-pool-", 3)
 	t.Logf("Attempting to create LbaasV2 pool")

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/helpers.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/helpers.go
@@ -8,7 +8,6 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/certificates"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/monitors"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/pools"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/monitors_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/monitors_test.go
@@ -1,0 +1,55 @@
+package lbaas_v2
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/monitors"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestLbaasV2MonitorsList(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	listOpts := monitors.ListOpts{}
+	allPages, err := monitors.List(client, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	lbaasMonitors, err := monitors.ExtractMonitors(allPages)
+	th.AssertNoErr(t, err)
+
+	for _, monitor := range lbaasMonitors {
+		tools.PrintResource(t, monitor)
+	}
+}
+
+func TestLbaasV2MonitorLifeCycle(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	// Create lbaasV2 Load Balancer
+	loadBalancer, err := createLbaasLoadBalancer(t, client)
+	th.AssertNoErr(t, err)
+	defer deleteLbaasLoadBalancer(t, client, loadBalancer.ID)
+
+	// Create lbaasV2 pool
+	loadBalancerPool, err := createLbaasPool(t, client, loadBalancer.ID)
+	th.AssertNoErr(t, err)
+	defer deleteLbaasPool(t, client, loadBalancerPool.ID)
+
+	// Create lbaasV2 monitor
+	lbaasMonitor, err := createLbaasMonitor(t, client, loadBalancerPool.ID)
+	th.AssertNoErr(t, err)
+	defer deleteLbaasMonitor(t, client, lbaasMonitor.ID)
+
+	tools.PrintResource(t, lbaasMonitor)
+
+	err = updateLbaasMonitor(t, client, lbaasMonitor.ID)
+	th.AssertNoErr(t, err)
+
+	newLbaasMonitor, err := monitors.Get(client, lbaasMonitor.ID).Extract()
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, newLbaasMonitor)
+}

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/monitors_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/monitors_test.go
@@ -43,6 +43,7 @@ func TestLbaasV2MonitorLifeCycle(t *testing.T) {
 	lbaasMonitor, err := createLbaasMonitor(t, client, loadBalancerPool.ID)
 	th.AssertNoErr(t, err)
 	defer deleteLbaasMonitor(t, client, lbaasMonitor.ID)
+	th.AssertEquals(t, false, lbaasMonitor.AdminStateUp)
 
 	tools.PrintResource(t, lbaasMonitor)
 
@@ -51,5 +52,6 @@ func TestLbaasV2MonitorLifeCycle(t *testing.T) {
 
 	newLbaasMonitor, err := monitors.Get(client, lbaasMonitor.ID).Extract()
 	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, newLbaasMonitor.AdminStateUp)
 	tools.PrintResource(t, newLbaasMonitor)
 }

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/monitors_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/monitors_test.go
@@ -44,7 +44,7 @@ func TestLbaasV2MonitorLifeCycle(t *testing.T) {
 	monitorName := tools.RandomString("create-monitor-", 3)
 	t.Logf("Attempting to create LbaasV2 monitor")
 
-	adminState := false
+	adminStateUp := false
 	createOpts := monitors.CreateOpts{
 		PoolID:        loadBalancerPool.ID,
 		Type:          "HTTP",
@@ -54,7 +54,7 @@ func TestLbaasV2MonitorLifeCycle(t *testing.T) {
 		Name:          monitorName,
 		URLPath:       "/status.php",
 		ExpectedCodes: "200",
-		AdminStateUp:  &adminState,
+		AdminStateUp:  &adminStateUp,
 	}
 	lbaasMonitor, err := monitors.Create(client, createOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -70,7 +70,7 @@ func TestLbaasV2MonitorLifeCycle(t *testing.T) {
 	t.Logf("Attempting to update LbaasV2 monitor")
 
 	monitorNewName := tools.RandomString("update-monitor-", 3)
-	adminStateUp := true
+	adminStateUp = true
 
 	updateOpts := monitors.UpdateOpts{
 		Name:         monitorNewName,

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/monitors_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/monitors_test.go
@@ -3,6 +3,7 @@ package lbaas_v2
 import (
 	"testing"
 
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/lbaas_v2/monitors"
@@ -40,7 +41,7 @@ func TestLbaasV2MonitorLifeCycle(t *testing.T) {
 	defer deleteLbaasPool(t, client, loadBalancerPool.ID)
 
 	// Create lbaasV2 monitor
-	lbaasMonitor, err := createLbaasMonitor(t, client, loadBalancerPool.ID)
+	lbaasMonitor := createLbaasMonitor(t, client, loadBalancerPool.ID)
 	th.AssertNoErr(t, err)
 	defer deleteLbaasMonitor(t, client, lbaasMonitor.ID)
 	th.AssertEquals(t, false, lbaasMonitor.AdminStateUp)
@@ -48,12 +49,62 @@ func TestLbaasV2MonitorLifeCycle(t *testing.T) {
 
 	tools.PrintResource(t, lbaasMonitor)
 
-	err = updateLbaasMonitor(t, client, lbaasMonitor.ID)
-	th.AssertNoErr(t, err)
+	updateLbaasMonitor(t, client, lbaasMonitor.ID)
 
 	newLbaasMonitor, err := monitors.Get(client, lbaasMonitor.ID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, true, newLbaasMonitor.AdminStateUp)
 	th.AssertEquals(t, "www.test.com", newLbaasMonitor.DomainName)
 	tools.PrintResource(t, newLbaasMonitor)
+}
+
+func createLbaasMonitor(t *testing.T, client *golangsdk.ServiceClient, lbaasPoolID string) *monitors.Monitor {
+	monitorName := tools.RandomString("create-monitor-", 3)
+	t.Logf("Attempting to create LbaasV2 monitor")
+
+	adminState := false
+	createOpts := monitors.CreateOpts{
+		PoolID:        lbaasPoolID,
+		Type:          "HTTP",
+		Delay:         15,
+		Timeout:       10,
+		MaxRetries:    10,
+		Name:          monitorName,
+		URLPath:       "/status.php",
+		ExpectedCodes: "200",
+		AdminStateUp:  &adminState,
+	}
+	lbaasMonitor, err := monitors.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Created LbaasV2 monitor: %s", lbaasMonitor.ID)
+
+	return lbaasMonitor
+}
+
+func deleteLbaasMonitor(t *testing.T, client *golangsdk.ServiceClient, lbaasMonitorID string) {
+	t.Logf("Attempting to delete LbaasV2 monitor: %s", lbaasMonitorID)
+
+	err := monitors.Delete(client, lbaasMonitorID).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	t.Logf("LbaasV2 monitor is deleted: %s", lbaasMonitorID)
+}
+
+func updateLbaasMonitor(t *testing.T, client *golangsdk.ServiceClient, lbaasMonitorID string) {
+	t.Logf("Attempting to update LbaasV2 monitor")
+
+	monitorNewName := tools.RandomString("update-monitor-", 3)
+	adminStateUp := true
+
+	updateOpts := monitors.UpdateOpts{
+		Name:         monitorNewName,
+		AdminStateUp: &adminStateUp,
+		DomainName:   "www.test.com",
+	}
+
+	_, err := monitors.Update(client, lbaasMonitorID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	t.Logf("LbaasV2 monitor successfully updated: %s", lbaasMonitorID)
 }

--- a/acceptance/openstack/networking/v2/extensions/lbaas_v2/monitors_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas_v2/monitors_test.go
@@ -44,6 +44,7 @@ func TestLbaasV2MonitorLifeCycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 	defer deleteLbaasMonitor(t, client, lbaasMonitor.ID)
 	th.AssertEquals(t, false, lbaasMonitor.AdminStateUp)
+	th.AssertEquals(t, "", lbaasMonitor.DomainName)
 
 	tools.PrintResource(t, lbaasMonitor)
 
@@ -53,5 +54,6 @@ func TestLbaasV2MonitorLifeCycle(t *testing.T) {
 	newLbaasMonitor, err := monitors.Get(client, lbaasMonitor.ID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, true, newLbaasMonitor.AdminStateUp)
+	th.AssertEquals(t, "www.test.com", newLbaasMonitor.DomainName)
 	tools.PrintResource(t, newLbaasMonitor)
 }

--- a/openstack/networking/v2/extensions/lbaas_v2/monitors/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/monitors/requests.go
@@ -26,6 +26,7 @@ type ListOpts struct {
 	PoolID        string `q:"pool_id"`
 	Type          string `q:"type"`
 	Delay         int    `q:"delay"`
+	DomainName    string `q:"domain_name"`
 	Timeout       int    `q:"timeout"`
 	MaxRetries    int    `q:"max_retries"`
 	HTTPMethod    string `q:"http_method"`
@@ -204,6 +205,11 @@ type UpdateOptsBuilder interface {
 type UpdateOpts struct {
 	// The time, in seconds, between sending probes to members.
 	Delay int `json:"delay,omitempty"`
+
+	// Specifies the domain name of the HTTP request during the health check.
+	//
+	// This parameter is valid when the value of type is set to HTTP.
+	DomainName string `json:"domain_name,omitempty"`
 
 	// Maximum number of seconds for a Monitor to wait for a ping reply
 	// before it times out. The value must be less than the delay value.

--- a/openstack/networking/v2/extensions/lbaas_v2/monitors/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/monitors/requests.go
@@ -95,6 +95,11 @@ type CreateOpts struct {
 	// The time, in seconds, between sending probes to members.
 	Delay int `json:"delay" required:"true"`
 
+	// Specifies the domain name of the HTTP request during the health check.
+	//
+	// This parameter is valid when the value of type is set to HTTP.
+	DomainName string `json:"domain_name,omitempty"`
+
 	// Maximum number of seconds for a Monitor to wait for a ping reply
 	// before it times out. The value must be less than the delay value.
 	Timeout int `json:"timeout" required:"true"`

--- a/openstack/networking/v2/extensions/lbaas_v2/monitors/results.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/monitors/results.go
@@ -41,6 +41,9 @@ type Monitor struct {
 	// The time, in seconds, between sending probes to members.
 	Delay int `json:"delay"`
 
+	// Specifies the domain name of the HTTP request during the health check.
+	DomainName string `json:"domain_name"`
+
 	// The maximum number of seconds for a monitor to wait for a connection to be
 	// established before it times out. This value must be less than the delay
 	// value.


### PR DESCRIPTION
### What this PR does / why we need it
Add possibility to set `domain_name`

### Which issue this PR fixes
Refers: https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/920

### Acceptance tests passrd
```
=== RUN   TestLbaasV2MonitorsList
--- PASS: TestLbaasV2MonitorsList (2.39s)
=== RUN   TestLbaasV2MonitorLifeCycle
    helpers.go:214: Attempting to create LbaasV2 LoadBalancer
    helpers.go:228: Created LbaasV2 LoadBalancer: 827ef6e8-af82-49a5-934f-5fcbdc165e71
    helpers.go:187: Attempting to create LbaasV2 pool
    helpers.go:198: Created LbaasV2 pool: a68b2b0f-073d-4c55-a1f4-b1025c0a18f5
    helpers.go:138: Attempting to create LbaasV2 monitor
    helpers.go:153: Created LbaasV2 monitor: 9320254b-16c4-496c-941e-52bc73fd6708
    helpers.go:168: Attempting to update LbaasV2 monitor
    helpers.go:181: LbaasV2 monitor successfully updated: 9320254b-16c4-496c-941e-52bc73fd6708
    helpers.go:159: Attempting to delete LbaasV2 monitor: 9320254b-16c4-496c-941e-52bc73fd6708
    helpers.go:164: LbaasV2 monitor is deleted: 9320254b-16c4-496c-941e-52bc73fd6708
    helpers.go:204: Attempting to delete LbaasV2 pool: a68b2b0f-073d-4c55-a1f4-b1025c0a18f5
    helpers.go:209: LbaasV2 pool is deleted: a68b2b0f-073d-4c55-a1f4-b1025c0a18f5
    helpers.go:234: Attempting to delete LbaasV2 LoadBalancer: 827ef6e8-af82-49a5-934f-5fcbdc165e71
    helpers.go:239: LbaasV2 LoadBalancer is deleted: 827ef6e8-af82-49a5-934f-5fcbdc165e71
--- PASS: TestLbaasV2MonitorLifeCycle (11.12s)
PASS

Process finished with exit code 0

```
