### PR TITLE
[AS] Update configurations 

### DIFF
--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -17,6 +17,18 @@ const envPrefix = "OS_"
 
 var EnvOS = openstack.NewEnv(envPrefix)
 
+// NewAutoscalingV1Client returns authenticated AutoScaling v1 client
+func NewAutoscalingV1Client() (*golangsdk.ServiceClient, error) {
+	cc, err := CloudAndClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return openstack.NewAutoScalingV1(cc.ProviderClient, golangsdk.EndpointOpts{
+		Region: cc.RegionName,
+	})
+}
+
 // NewBlockStorageV1Client returns a *ServiceClient for making calls
 // to the OpenStack Block Storage v1 API. An error will be returned
 // if authentication or client creation was not possible.

--- a/acceptance/openstack/autoscaling/v1/configurations_test.go
+++ b/acceptance/openstack/autoscaling/v1/configurations_test.go
@@ -1,0 +1,84 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v1/configurations"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestConfigurationsList(t *testing.T) {
+	client, err := clients.NewAutoscalingV1Client()
+	th.AssertNoErr(t, err)
+
+	listOpts := configurations.ListOpts{}
+
+	allPages, err := configurations.List(client, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	configs, err := configurations.ExtractConfigurations(allPages)
+	th.AssertNoErr(t, err)
+
+	for _, config := range configs {
+		tools.PrintResource(t, config)
+	}
+}
+
+func TestConfigurationsLifecycle(t *testing.T) {
+	client, err := clients.NewAutoscalingV1Client()
+	th.AssertNoErr(t, err)
+
+	asCreateName := tools.RandomString("as-create-", 3)
+	keyPairName := clients.EnvOS.GetEnv("KEYPAIR_NAME")
+	imageID := clients.EnvOS.GetEnv("IMAGE_ID")
+	if keyPairName == "" || imageID == "" {
+		t.Skip("OS_KEYPAIR_NAME or OS_IMAGE_ID env vars is missing but AS Configuration test requires")
+	}
+
+	secGroupID := openstack.CreateSecurityGroup(t)
+	defer openstack.DeleteSecurityGroup(t, secGroupID)
+
+	defaultSGID := openstack.DefaultSecurityGroup(t)
+
+	createOpts := configurations.CreateOpts{
+		Name: asCreateName,
+		InstanceConfig: configurations.InstanceConfigOpts{
+			FlavorRef: "s3.xlarge.4",
+			ImageRef:  imageID,
+			Disk: []configurations.DiskOpts{
+				{
+					Size:       40,
+					VolumeType: "SATA",
+					DiskType:   "SYS",
+				},
+			},
+			SSHKey: keyPairName,
+			SecurityGroups: []configurations.SecurityGroupOpts{
+				{
+					ID: defaultSGID,
+				},
+				{
+					ID: secGroupID,
+				},
+			},
+		},
+	}
+	t.Logf("Attempting to create AutoScaling Configuration")
+	configID, err := configurations.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Created AutoScaling Configuration: %s", configID)
+	defer func() {
+		t.Logf("Attempting to delete AutoScaling Configuration")
+		err := configurations.Delete(client, configID).ExtractErr()
+		th.AssertNoErr(t, err)
+		t.Logf("Deleted AutoScaling Configuration: %s", configID)
+	}()
+
+	config, err := configurations.Get(client, configID).Extract()
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, config)
+	th.AssertEquals(t, 2, len(config.InstanceConfig.SecurityGroups))
+}

--- a/openstack/autoscaling/v1/configurations/results.go
+++ b/openstack/autoscaling/v1/configurations/results.go
@@ -25,7 +25,7 @@ type GetResult struct {
 
 func (r GetResult) Extract() (Configuration, error) {
 	var s Configuration
-	err := r.Result.ExtractIntoStructPtr(&s, "scaling_configuration")
+	err := r.ExtractIntoStructPtr(&s, "scaling_configuration")
 	return s, err
 }
 

--- a/openstack/autoscaling/v1/configurations/results.go
+++ b/openstack/autoscaling/v1/configurations/results.go
@@ -24,9 +24,11 @@ type GetResult struct {
 }
 
 func (r GetResult) Extract() (Configuration, error) {
-	var a Configuration
-	err := r.Result.ExtractIntoStructPtr(&a, "scaling_configuration")
-	return a, err
+	var s struct {
+		ScalingConfiguration Configuration `json:"scaling_configuration"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ScalingConfiguration, err
 }
 
 type Configuration struct {
@@ -38,23 +40,34 @@ type Configuration struct {
 }
 
 type InstanceConfig struct {
-	FlavorRef    string                 `json:"flavorRef"`
-	ImageRef     string                 `json:"imageRef"`
-	Disk         []Disk                 `json:"disk"`
-	SSHKey       string                 `json:"key_name"`
-	InstanceName string                 `json:"instance_name"`
-	InstanceID   string                 `json:"instance_id"`
-	AdminPass    string                 `json:"adminPass"`
-	Personality  []Personality          `json:"personality"`
-	PublicIp     PublicIp               `json:"public_ip"`
-	UserData     string                 `json:"user_data"`
-	Metadata     map[string]interface{} `json:"metadata"`
+	FlavorRef                 string                 `json:"flavorRef"`
+	ImageRef                  string                 `json:"imageRef"`
+	Disk                      []Disk                 `json:"disk"`
+	SSHKey                    string                 `json:"key_name"`
+	KeyFingerprint            string                 `json:"key_fingerprint"`
+	InstanceName              string                 `json:"instance_name"`
+	InstanceID                string                 `json:"instance_id"`
+	AdminPass                 string                 `json:"adminPass"`
+	Personality               []Personality          `json:"personality"`
+	PublicIp                  PublicIp               `json:"public_ip"`
+	UserData                  string                 `json:"user_data"`
+	Metadata                  map[string]interface{} `json:"metadata"`
+	SecurityGroups            []SecurityGroup        `json:"security_groups"`
+	ServerGroupID             string                 `json:"server_group_id"`
+	Tenancy                   string                 `json:"tenancy"`
+	DedicatedHostID           string                 `json:"dedicated_host_id"`
+	MarketType                string                 `json:"market_type"`
+	MultiFlavorPriorityPolicy string                 `json:"multi_flavor_priority_policy"`
 }
 
 type Disk struct {
-	Size       int    `json:"size"`
-	VolumeType string `json:"volume_type"`
-	DiskType   string `json:"disk_type"`
+	Size               int                    `json:"size"`
+	VolumeType         string                 `json:"volume_type"`
+	DiskType           string                 `json:"disk_type"`
+	DedicatedStorageID string                 `json:"dedicated_storage_id"`
+	DataDiskImageID    string                 `json:"data_disk_image_id"`
+	SnapshotID         string                 `json:"snapshot_id"`
+	Metadata           map[string]interface{} `json:"metadata"`
 }
 
 type Personality struct {
@@ -77,6 +90,10 @@ type Bandwidth struct {
 	ChargingMode string `json:"charging_mode"`
 }
 
+type SecurityGroup struct {
+	ID string `json:"id"`
+}
+
 type DeleteResult struct {
 	golangsdk.ErrResult
 }
@@ -89,6 +106,16 @@ type ConfigurationPage struct {
 func (r ConfigurationPage) IsEmpty() (bool, error) {
 	configs, err := r.Extract()
 	return len(configs) == 0, err
+}
+
+// ExtractConfigurations returns a slice of AS Configurations contained in a
+// single page of results.
+func ExtractConfigurations(r pagination.Page) ([]Configuration, error) {
+	var s struct {
+		Configurations []Configuration `json:"scaling_configurations"`
+	}
+	err := (r.(ConfigurationPage)).ExtractInto(&s)
+	return s.Configurations, err
 }
 
 func (r ConfigurationPage) Extract() ([]Configuration, error) {

--- a/openstack/autoscaling/v1/configurations/results.go
+++ b/openstack/autoscaling/v1/configurations/results.go
@@ -24,11 +24,9 @@ type GetResult struct {
 }
 
 func (r GetResult) Extract() (Configuration, error) {
-	var s struct {
-		ScalingConfiguration Configuration `json:"scaling_configuration"`
-	}
-	err := r.ExtractInto(&s)
-	return s.ScalingConfiguration, err
+	var s Configuration
+	err := r.Result.ExtractIntoStructPtr(&s, "scaling_configuration")
+	return s, err
 }
 
 type Configuration struct {

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -632,7 +632,7 @@ func NewRdsTagV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*
 }
 
 // NewAutoScalingV1 creates a ServiceClient that may be used to access the
-// auto-scaling service of huawei public cloud
+// auto-scaling service of OpenTelekomCloud public cloud
 func NewAutoScalingV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
 	return initClientOpts(client, eo, "asv1")
 }

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -631,17 +631,10 @@ func NewRdsTagV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*
 	return sc, err
 }
 
-// NewAutoScalingService creates a ServiceClient that may be used to access the
+// NewAutoScalingV1 creates a ServiceClient that may be used to access the
 // auto-scaling service of huawei public cloud
-func NewAutoScalingService(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
-	sc, err := initClientOpts(client, eo, "volumev2")
-	if err != nil {
-		return nil, err
-	}
-	e := strings.Replace(sc.Endpoint, "v2", "autoscaling-api/v1", 1)
-	sc.Endpoint = strings.Replace(e, "evs", "as", 1)
-	sc.ResourceBase = sc.Endpoint
-	return sc, err
+func NewAutoScalingV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	return initClientOpts(client, eo, "asv1")
 }
 
 // NewNetworkV1 creates a ServiceClient that may be used with the v1 network


### PR DESCRIPTION
### What this PR does / why we need it
Add possibility to set `securityGroups` in `createOpts`

### Which issue this PR fixes
Refers to: https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/935

### Acceptance tests passed

```
=== RUN   TestConfigurationsList
--- PASS: TestConfigurationsList (1.75s)
=== RUN   TestConfigurationsLifecycle
    common.go:60: Security group f7f9a8f4-d661-4c80-949f-a1a3a6924f69 was created
    configurations_test.go:69: Attempting to create AutoScaling Configuration
    configurations_test.go:72: Created AutoScaling Configuration: 0884d9e5-d60f-4057-8f41-e77e814a6316
    configurations_test.go:74: Attempting to delete AutoScaling Configuration
    configurations_test.go:77: Deleted AutoScaling Configuration: 0884d9e5-d60f-4057-8f41-e77e814a6316
    common.go:71: Security group f7f9a8f4-d661-4c80-949f-a1a3a6924f69 was deleted
--- PASS: TestConfigurationsLifecycle (9.62s)
PASS

Process finished with exit code 0
```