### PR TITLE
[AS] Update `groups` json schema

### DIFF
--- a/acceptance/openstack/autoscaling/v1/goups_test.go
+++ b/acceptance/openstack/autoscaling/v1/goups_test.go
@@ -85,9 +85,6 @@ func TestGroupLifecycle(t *testing.T) {
 		Name: asGroupUpdateName,
 		SecurityGroup: []groups.SecurityGroupOpts{
 			{
-				ID: defaultSGID,
-			},
-			{
 				ID: secGroupID,
 			},
 		},
@@ -102,6 +99,6 @@ func TestGroupLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, group)
 	th.AssertEquals(t, asGroupUpdateName, group.Name)
-	th.AssertEquals(t, 2, len(group.SecurityGroups))
+	th.AssertEquals(t, secGroupID, group.SecurityGroups[0].ID)
 	th.AssertEquals(t, false, group.DeletePublicIP)
 }

--- a/acceptance/openstack/autoscaling/v1/goups_test.go
+++ b/acceptance/openstack/autoscaling/v1/goups_test.go
@@ -1,0 +1,107 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v1/groups"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestGroupsList(t *testing.T) {
+	client, err := clients.NewAutoscalingV1Client()
+	th.AssertNoErr(t, err)
+
+	listOpts := groups.ListOpts{}
+
+	allPages, err := groups.List(client, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	asGroups, err := groups.ExtractGroups(allPages)
+	th.AssertNoErr(t, err)
+
+	for _, group := range asGroups {
+		tools.PrintResource(t, group)
+	}
+}
+
+func TestGroupLifecycle(t *testing.T) {
+	client, err := clients.NewAutoscalingV1Client()
+	th.AssertNoErr(t, err)
+
+	asGroupCreateName := tools.RandomString("as-group-create-", 3)
+	networkID := clients.EnvOS.GetEnv("NETWORK_ID")
+	vpcID := clients.EnvOS.GetEnv("VPC_ID")
+	if networkID == "" {
+		t.Skip("OS_NETWORK_ID or OS_VPC_ID env vars are missing but AS Group test requires")
+	}
+
+	secGroupID := openstack.CreateSecurityGroup(t)
+	defer openstack.DeleteSecurityGroup(t, secGroupID)
+
+	defaultSGID := openstack.DefaultSecurityGroup(t)
+	deletePublicIP := true
+
+	createOpts := groups.CreateOpts{
+		Name: asGroupCreateName,
+		Networks: []groups.NetworkOpts{
+			{
+				ID: networkID,
+			},
+		},
+		SecurityGroup: []groups.SecurityGroupOpts{
+			{
+				ID: defaultSGID,
+			},
+		},
+		VpcID:          vpcID,
+		DeletePublicIP: &deletePublicIP,
+	}
+	t.Logf("Attempting to create AutoScaling Group")
+	groupID, err := groups.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Created AutoScaling Group: %s", groupID)
+	defer func() {
+		t.Logf("Attempting to delete AutoScaling Group")
+		err := groups.Delete(client, groupID).ExtractErr()
+		th.AssertNoErr(t, err)
+		t.Logf("Deleted AutoScaling Group: %s", groupID)
+	}()
+
+	group, err := groups.Get(client, groupID).Extract()
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, group)
+	th.AssertEquals(t, asGroupCreateName, group.Name)
+	th.AssertEquals(t, 1, len(group.SecurityGroups))
+	th.AssertEquals(t, true, group.DeletePublicIP)
+
+	t.Logf("Attempting to update AutoScaling Group")
+	asGroupUpdateName := tools.RandomString("as-group-update-", 3)
+	deletePublicIP = false
+
+	updateOpts := groups.UpdateOpts{
+		Name: asGroupUpdateName,
+		SecurityGroup: []groups.SecurityGroupOpts{
+			{
+				ID: defaultSGID,
+			},
+			{
+				ID: secGroupID,
+			},
+		},
+		DeletePublicIP: &deletePublicIP,
+	}
+
+	groupID, err = groups.Update(client, group.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Updated AutoScaling Group")
+
+	group, err = groups.Get(client, groupID).Extract()
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, group)
+	th.AssertEquals(t, asGroupUpdateName, group.Name)
+	th.AssertEquals(t, 2, len(group.SecurityGroups))
+	th.AssertEquals(t, false, group.DeletePublicIP)
+}

--- a/acceptance/openstack/autoscaling/v1/goups_test.go
+++ b/acceptance/openstack/autoscaling/v1/goups_test.go
@@ -56,8 +56,8 @@ func TestGroupLifecycle(t *testing.T) {
 				ID: defaultSGID,
 			},
 		},
-		VpcID:          vpcID,
-		DeletePublicIP: &deletePublicIP,
+		VpcID:            vpcID,
+		IsDeletePublicip: &deletePublicIP,
 	}
 	t.Logf("Attempting to create AutoScaling Group")
 	groupID, err := groups.Create(client, createOpts).Extract()
@@ -88,7 +88,7 @@ func TestGroupLifecycle(t *testing.T) {
 				ID: secGroupID,
 			},
 		},
-		DeletePublicIP: &deletePublicIP,
+		IsDeletePublicip: &deletePublicIP,
 	}
 
 	groupID, err = groups.Update(client, group.ID, updateOpts).Extract()

--- a/openstack/autoscaling/v1/groups/requests.go
+++ b/openstack/autoscaling/v1/groups/requests.go
@@ -29,8 +29,8 @@ type CreateOpts struct {
 	HealthPeriodicAuditGrace  int                 `json:"health_periodic_audit_grace_period,omitempty"`
 	InstanceTerminatePolicy   string              `json:"instance_terminate_policy,omitempty"`
 	Notifications             []string            `json:"notifications,omitempty"`
-	DeletePublicIP            *bool               `json:"delete_publicip,omitempty"`
-	DeleteVolume              *bool               `json:"delete_volume,omitempty"`
+	IsDeletePublicip          *bool               `json:"delete_publicip,omitempty"`
+	IsDeleteVolume            *bool               `json:"delete_volume,omitempty"`
 	EnterpriseProjectID       string              `json:"enterprise_project_id,omitempty"`
 	MultiAZPriorityPolicy     string              `json:"multi_az_priority_policy,omitempty"`
 }
@@ -137,8 +137,8 @@ type UpdateOpts struct {
 	HealthPeriodicAuditGrace  int                 `json:"health_periodic_audit_grace_period,omitempty"`
 	InstanceTerminatePolicy   string              `json:"instance_terminate_policy,omitempty"`
 	Notifications             []string            `json:"notifications,omitempty"`
-	DeletePublicIP            *bool               `json:"delete_publicip,omitempty"`
-	DeleteVolume              *bool               `json:"delete_volume,omitempty"`
+	IsDeletePublicip          *bool               `json:"delete_publicip,omitempty"`
+	IsDeleteVolume            *bool               `json:"delete_volume,omitempty"`
 	ConfigurationID           string              `json:"scaling_configuration_id,omitempty"`
 	EnterpriseProjectID       string              `json:"enterprise_project_id,omitempty"`
 	MultiAZPriorityPolicy     string              `json:"multi_az_priority_policy,omitempty"`

--- a/openstack/autoscaling/v1/groups/requests.go
+++ b/openstack/autoscaling/v1/groups/requests.go
@@ -5,12 +5,12 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
 
-// CreateGroupBuilder is an interface from which can build the request of creating group
+// CreateOptsBuilder is an interface from which can build the request of creating group
 type CreateOptsBuilder interface {
 	ToGroupCreateMap() (map[string]interface{}, error)
 }
 
-// CreateGroupOps is a struct contains the parameters of creating group
+// CreateOpts is a struct contains the parameters of creating group
 type CreateOpts struct {
 	Name                      string              `json:"scaling_group_name" required:"true"`
 	ConfigurationID           string              `json:"scaling_configuration_id,omitempty"`
@@ -21,36 +21,39 @@ type CreateOpts struct {
 	LBListenerID              string              `json:"lb_listener_id,omitempty"`
 	LBaaSListeners            []LBaaSListenerOpts `json:"lbaas_listeners,omitempty"`
 	AvailableZones            []string            `json:"available_zones,omitempty"`
-	Networks                  []NetworkOpts       `json:"networks" required:"ture"`
-	SecurityGroup             []SecurityGroupOpts `json:"security_groups" required:"ture"`
-	VpcID                     string              `json:"vpc_id" required:"ture"`
+	Networks                  []NetworkOpts       `json:"networks" required:"true"`
+	SecurityGroup             []SecurityGroupOpts `json:"security_groups,omitempty"`
+	VpcID                     string              `json:"vpc_id" required:"true"`
 	HealthPeriodicAuditMethod string              `json:"health_periodic_audit_method,omitempty"`
 	HealthPeriodicAuditTime   int                 `json:"health_periodic_audit_time,omitempty"`
 	HealthPeriodicAuditGrace  int                 `json:"health_periodic_audit_grace_period,omitempty"`
 	InstanceTerminatePolicy   string              `json:"instance_terminate_policy,omitempty"`
 	Notifications             []string            `json:"notifications,omitempty"`
-	IsDeletePublicip          bool                `json:"delete_publicip,omitempty"`
+	DeletePublicIP            *bool               `json:"delete_publicip,omitempty"`
+	DeleteVolume              *bool               `json:"delete_volume,omitempty"`
+	EnterpriseProjectID       string              `json:"enterprise_project_id,omitempty"`
+	MultiAZPriorityPolicy     string              `json:"multi_az_priority_policy,omitempty"`
 }
 
 type NetworkOpts struct {
-	ID string `json:"id,omitempty"`
+	ID string `json:"id" required:"true"`
 }
 
 type SecurityGroupOpts struct {
-	ID string `json:"id,omitempty"`
+	ID string `json:"id" required:"true"`
 }
 
 type LBaaSListenerOpts struct {
 	PoolID       string `json:"pool_id" required:"true"`
 	ProtocolPort int    `json:"protocol_port" required:"true"`
-	Weight       int    `json:"weight,omitempty"`
+	Weight       int    `json:"weight" required:"true"`
 }
 
 func (opts CreateOpts) ToGroupCreateMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "")
 }
 
-// CreateGroup is a method of creating group
+// Create is a method of creating group
 func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToGroupCreateMap()
 	if err != nil {
@@ -63,13 +66,13 @@ func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateRe
 	return
 }
 
-// DeleteGroup is a method of deleting a group by group id
+// Delete is a method of deleting a group by group id
 func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, id), nil)
 	return
 }
 
-// GetGroup is a method of getting the detailed information of the group by id
+// Get is a method of getting the detailed information of the group by id
 func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
 	return
@@ -80,9 +83,12 @@ type ListOptsBuilder interface {
 }
 
 type ListOpts struct {
-	Name            string `q:"scaling_group_name"`
-	ConfigurationID string `q:"scaling_configuration_id"`
-	Status          string `q:"scaling_group_status"`
+	Name                string `q:"scaling_group_name"`
+	ConfigurationID     string `q:"scaling_configuration_id"`
+	Status              string `q:"scaling_group_status"`
+	StartNumber         int    `q:"start_number"`
+	Limit               int    `q:"limit"`
+	EnterpriseProjectID string `q:"enterprise_project_id"`
 }
 
 // ToGroupListQuery formats a ListOpts into a query string.
@@ -109,7 +115,7 @@ func List(client *golangsdk.ServiceClient, ops ListOptsBuilder) pagination.Pager
 	})
 }
 
-// UpdateOptsBuilder is an interface which can build the map paramter of update function
+// UpdateOptsBuilder is an interface which can build the map parameter of update function
 type UpdateOptsBuilder interface {
 	ToGroupUpdateMap() (map[string]interface{}, error)
 }
@@ -117,9 +123,9 @@ type UpdateOptsBuilder interface {
 // UpdateOpts is a struct which represents the parameters of update function
 type UpdateOpts struct {
 	Name                      string              `json:"scaling_group_name,omitempty"`
-	DesireInstanceNumber      int                 `json:"desire_instance_number"`
-	MinInstanceNumber         int                 `json:"min_instance_number"`
-	MaxInstanceNumber         int                 `json:"max_instance_number"`
+	DesireInstanceNumber      int                 `json:"desire_instance_number,omitempty"`
+	MinInstanceNumber         int                 `json:"min_instance_number,omitempty"`
+	MaxInstanceNumber         int                 `json:"max_instance_number,omitempty"`
 	CoolDownTime              int                 `json:"cool_down_time,omitempty"`
 	LBListenerID              string              `json:"lb_listener_id,omitempty"`
 	LBaaSListeners            []LBaaSListenerOpts `json:"lbaas_listeners,omitempty"`
@@ -131,8 +137,11 @@ type UpdateOpts struct {
 	HealthPeriodicAuditGrace  int                 `json:"health_periodic_audit_grace_period,omitempty"`
 	InstanceTerminatePolicy   string              `json:"instance_terminate_policy,omitempty"`
 	Notifications             []string            `json:"notifications,omitempty"`
-	IsDeletePublicip          bool                `json:"delete_publicip,omitempty"`
+	DeletePublicIP            *bool               `json:"delete_publicip,omitempty"`
+	DeleteVolume              *bool               `json:"delete_volume,omitempty"`
 	ConfigurationID           string              `json:"scaling_configuration_id,omitempty"`
+	EnterpriseProjectID       string              `json:"enterprise_project_id,omitempty"`
+	MultiAZPriorityPolicy     string              `json:"multi_az_priority_policy,omitempty"`
 }
 
 func (opts UpdateOpts) ToGroupUpdateMap() (map[string]interface{}, error) {

--- a/openstack/autoscaling/v1/groups/results.go
+++ b/openstack/autoscaling/v1/groups/results.go
@@ -5,16 +5,27 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
 
-// CreateResult is a struct returned by CreateGroup request
-type CreateResult struct {
+type commonResult struct {
 	golangsdk.Result
 }
 
-// Extract the create group result as a string type.
-func (r CreateResult) Extract() (string, error) {
-	var s string
-	err := r.ExtractIntoStructPtr(s, "scaling_group_id")
-	return s, err
+// CreateResult is a struct returned by Create request
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult is a struct from which can get the result of Update request
+type UpdateResult struct {
+	commonResult
+}
+
+// Extract the ID of AS Group result as a string type.
+func (r commonResult) Extract() (string, error) {
+	var s struct {
+		ID string `json:"scaling_group_id"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ID, err
 }
 
 // DeleteResult contains the body of the deleting group request
@@ -104,18 +115,6 @@ func (r GroupPage) IsEmpty() (bool, error) {
 func ExtractGroups(r pagination.Page) ([]Group, error) {
 	var s []Group
 	err := (r.(GroupPage)).ExtractIntoSlicePtr(&s, "scaling_groups")
-	return s, err
-}
-
-// UpdateResult is a struct from which can get the result of update method
-type UpdateResult struct {
-	golangsdk.Result
-}
-
-// Extract will deserialize the result to group id with string
-func (r UpdateResult) Extract() (string, error) {
-	var s string
-	err := r.ExtractIntoStructPtr(s, "scaling_group_id")
 	return s, err
 }
 

--- a/openstack/autoscaling/v1/groups/results.go
+++ b/openstack/autoscaling/v1/groups/results.go
@@ -5,35 +5,33 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
 
-// CreateGroupResult is a struct retured by CreateGroup request
+// CreateResult is a struct returned by CreateGroup request
 type CreateResult struct {
 	golangsdk.Result
 }
 
 // Extract the create group result as a string type.
 func (r CreateResult) Extract() (string, error) {
-	var a struct {
-		GroupID string `json:"scaling_group_id"`
-	}
-	err := r.Result.ExtractInto(&a)
-	return a.GroupID, err
+	var s string
+	err := r.ExtractIntoStructPtr(s, "scaling_group_id")
+	return s, err
 }
 
-// DeleteGroupResult contains the body of the deleting group request
+// DeleteResult contains the body of the deleting group request
 type DeleteResult struct {
 	golangsdk.ErrResult
 }
 
-// GetGroupResult contains the body of getting detailed group request
+// GetResult contains the body of getting detailed group request
 type GetResult struct {
 	golangsdk.Result
 }
 
 // Extract method will parse the result body into Group struct
-func (r GetResult) Extract() (Group, error) {
-	var g Group
-	err := r.Result.ExtractIntoStructPtr(&g, "scaling_group")
-	return g, err
+func (r GetResult) Extract() (*Group, error) {
+	s := new(Group)
+	err := r.ExtractIntoStructPtr(s, "scaling_group")
+	return s, err
 }
 
 // Group represents the struct of one autoscaling group
@@ -62,11 +60,21 @@ type Group struct {
 	HealthPeriodicAuditGrace  int             `json:"health_periodic_audit_grace_period"`
 	InstanceTerminatePolicy   string          `json:"instance_terminate_policy"`
 	Notifications             []string        `json:"notifications"`
-	DeletePublicip            bool            `json:"delete_publicip"`
+	DeletePublicIP            bool            `json:"delete_publicip"`
+	DeleteVolume              bool            `json:"delete_volume"`
 	CloudLocationID           string          `json:"cloud_location_id"`
+	EnterpriseProjectID       string          `json:"enterprise_project_id"`
+	ActivityType              string          `json:"activity_type"`
+	MultiAZPriorityPolicy     string          `json:"multi_az_priority_policy"`
 }
 
 type Network struct {
+	ID            string        `json:"id"`
+	IPv6Enable    bool          `json:"ipv6_enable"`
+	IPv6Bandwidth IPv6Bandwidth `json:"ipv6_bandwidth"`
+}
+
+type IPv6Bandwidth struct {
 	ID string `json:"id"`
 }
 
@@ -87,31 +95,31 @@ type GroupPage struct {
 
 // IsEmpty returns true if a ListResult contains no Volumes.
 func (r GroupPage) IsEmpty() (bool, error) {
-	groups, err := r.Extract()
+	groups, err := ExtractGroups(r)
 	return len(groups) == 0, err
 }
 
-func (r GroupPage) Extract() ([]Group, error) {
-	var gs []Group
-	err := r.Result.ExtractIntoSlicePtr(&gs, "scaling_groups")
-	return gs, err
+// ExtractGroups returns a slice of AS Groups contained in a
+// single page of results.
+func ExtractGroups(r pagination.Page) ([]Group, error) {
+	var s []Group
+	err := (r.(GroupPage)).ExtractIntoSlicePtr(&s, "scaling_groups")
+	return s, err
 }
 
-// UpdateResult is a struct from which can get the result of udpate method
+// UpdateResult is a struct from which can get the result of update method
 type UpdateResult struct {
 	golangsdk.Result
 }
 
 // Extract will deserialize the result to group id with string
 func (r UpdateResult) Extract() (string, error) {
-	var a struct {
-		ID string `json:"scaling_group_id"`
-	}
-	err := r.Result.ExtractInto(&a)
-	return a.ID, err
+	var s string
+	err := r.ExtractIntoStructPtr(s, "scaling_group_id")
+	return s, err
 }
 
-// this is the action result which is the result of enable or disable operations
+// ActionResult this is the action result which is the result of enable or disable operations
 type ActionResult struct {
 	golangsdk.ErrResult
 }

--- a/openstack/autoscaling/v1/groups/urls.go
+++ b/openstack/autoscaling/v1/groups/urls.go
@@ -1,17 +1,13 @@
 package groups
 
 import (
-	"log"
-
 	"github.com/opentelekomcloud/gophertelekomcloud"
 )
 
 const resourcePath = "scaling_group"
 
 func createURL(c *golangsdk.ServiceClient) string {
-	ur := c.ServiceURL(resourcePath)
-	log.Printf("[DEBUG] Create URL is: %#v", ur)
-	return ur
+	return c.ServiceURL(resourcePath)
 }
 
 func deleteURL(c *golangsdk.ServiceClient, id string) string {


### PR DESCRIPTION
### What this PR does / why we need it
Update create and update schema
Fix typo issues in json notation

### Which issue this PR fixes
Fixes: #134

```
=== RUN   TestGroupsList
--- PASS: TestGroupsList (1.64s)
=== RUN   TestGroupLifecycle
    common.go:62: Security group 77d65ccb-6692-4fec-b1d0-a50d1517ecff was created
    goups_test.go:62: Attempting to create AutoScaling Group
    goups_test.go:65: Created AutoScaling Group: 5a613e1a-208e-4ad5-b5c0-470cb48a3aa3
    goups_test.go:80: Attempting to update AutoScaling Group
    goups_test.go:96: Updated AutoScaling Group
    goups_test.go:67: Attempting to delete AutoScaling Group
    goups_test.go:70: Deleted AutoScaling Group: 5a613e1a-208e-4ad5-b5c0-470cb48a3aa3
    common.go:73: Security group 77d65ccb-6692-4fec-b1d0-a50d1517ecff was deleted
--- PASS: TestGroupLifecycle (10.44s)
PASS

Process finished with the exit code 0
```