### PR TITLE
[AS] Fix issues with Update in `groups`

### DIFF
--- a/openstack/autoscaling/v1/groups/requests.go
+++ b/openstack/autoscaling/v1/groups/requests.go
@@ -123,15 +123,15 @@ type UpdateOptsBuilder interface {
 // UpdateOpts is a struct which represents the parameters of update function
 type UpdateOpts struct {
 	Name                      string              `json:"scaling_group_name,omitempty"`
-	DesireInstanceNumber      int                 `json:"desire_instance_number,omitempty"`
-	MinInstanceNumber         int                 `json:"min_instance_number,omitempty"`
-	MaxInstanceNumber         int                 `json:"max_instance_number,omitempty"`
+	DesireInstanceNumber      int                 `json:"desire_instance_number"`
+	MinInstanceNumber         int                 `json:"min_instance_number"`
+	MaxInstanceNumber         int                 `json:"max_instance_number"`
 	CoolDownTime              int                 `json:"cool_down_time,omitempty"`
 	LBListenerID              string              `json:"lb_listener_id,omitempty"`
 	LBaaSListeners            []LBaaSListenerOpts `json:"lbaas_listeners,omitempty"`
 	AvailableZones            []string            `json:"available_zones,omitempty"`
 	Networks                  []NetworkOpts       `json:"networks,omitempty"`
-	SecurityGroup             []SecurityGroupOpts `json:"security_groups,omitempty"`
+	SecurityGroup             []SecurityGroupOpts `json:"security_groups"`
 	HealthPeriodicAuditMethod string              `json:"health_periodic_audit_method,omitempty"`
 	HealthPeriodicAuditTime   int                 `json:"health_periodic_audit_time,omitempty"`
 	HealthPeriodicAuditGrace  int                 `json:"health_periodic_audit_grace_period,omitempty"`


### PR DESCRIPTION
### What this PR does / why we need it
Revert last change with `ommiting` in UpdateOpts

### Which issue this PR fixes
Refers to: https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/991


```
=== RUN   TestGroupsList
--- PASS: TestGroupsList (1.38s)
=== RUN   TestGroupLifecycle
    common.go:62: Security group 4a1ad441-e0f2-4695-ab1f-3036c7aafe84 was created
    goups_test.go:62: Attempting to create AutoScaling Group
    goups_test.go:65: Created AutoScaling Group: f348136a-f13b-4cc2-82f6-25730b0593e6
    goups_test.go:67: Attempting to delete AutoScaling Group
    goups_test.go:70: Deleted AutoScaling Group: f348136a-f13b-4cc2-82f6-25730b0593e6
    common.go:73: Security group 4a1ad441-e0f2-4695-ab1f-3036c7aafe84 was deleted
--- PASS: TestGroupLifecycle (10.31s)
PASS

Process finished with the exit code 0
```