### PR TITLE
[VPC] Update subnets pkg

### DIFF
--- a/acceptance/openstack/networking/v1/helpers.go
+++ b/acceptance/openstack/networking/v1/helpers.go
@@ -145,7 +145,7 @@ func createSubnet(t *testing.T, client *golangsdk.ServiceClient, vpcID string) *
 	t.Logf("Waitting for subnet %s to be active", subnet.ID)
 	err = waitForSubnetToBeActive(client, subnet.ID, 600)
 	th.AssertNoErr(t, err)
-	t.Logf("Created subnet: %v", subnet)
+	t.Logf("Created subnet: %v", subnet.ID)
 
 	return subnet
 }

--- a/acceptance/openstack/networking/v1/helpers.go
+++ b/acceptance/openstack/networking/v1/helpers.go
@@ -27,7 +27,7 @@ func CreateNetwork(t *testing.T, prefix, az string) *subnets.Subnet {
 	subnet, err := subnets.Create(client, subnets.CreateOpts{
 		Name:             tools.RandomString(prefix, 4),
 		CIDR:             "192.168.0.0/24",
-		DnsList:          []string{"1.1.1.1", "8.8.8.8"},
+		DNSList:          []string{"1.1.1.1", "8.8.8.8"},
 		GatewayIP:        "192.168.0.1",
 		EnableDHCP:       &enableDHCP,
 		AvailabilityZone: az,

--- a/acceptance/openstack/networking/v1/helpers.go
+++ b/acceptance/openstack/networking/v1/helpers.go
@@ -23,14 +23,15 @@ func CreateNetwork(t *testing.T, prefix, az string) *subnets.Subnet {
 		CIDR: "192.168.0.0/16",
 	}).Extract()
 	th.AssertNoErr(t, err)
+	enableDHCP := true
 	subnet, err := subnets.Create(client, subnets.CreateOpts{
 		Name:             tools.RandomString(prefix, 4),
 		CIDR:             "192.168.0.0/24",
 		DnsList:          []string{"1.1.1.1", "8.8.8.8"},
 		GatewayIP:        "192.168.0.1",
-		EnableDHCP:       true,
+		EnableDHCP:       &enableDHCP,
 		AvailabilityZone: az,
-		VPC_ID:           vpc.ID,
+		VpcID:            vpc.ID,
 	}).Extract()
 	th.AssertNoErr(t, err)
 
@@ -45,12 +46,12 @@ func DeleteNetwork(t *testing.T, subnet *subnets.Subnet) {
 	client, err := clients.NewNetworkV1Client()
 	th.AssertNoErr(t, err)
 
-	err = subnets.Delete(client, subnet.VPC_ID, subnet.ID).ExtractErr()
+	err = subnets.Delete(client, subnet.VpcID, subnet.ID).ExtractErr()
 	th.AssertNoErr(t, err)
 	err = waitForSubnetToBeDeleted(client, subnet.ID, 300)
 	th.AssertNoErr(t, err)
 
-	err = vpcs.Delete(client, subnet.VPC_ID).ExtractErr()
+	err = vpcs.Delete(client, subnet.VpcID).ExtractErr()
 	th.AssertNoErr(t, err)
 }
 
@@ -127,12 +128,13 @@ func waitForEipToDelete(client *golangsdk.ServiceClient, eipID string, secs int)
 }
 
 func createSubnet(t *testing.T, client *golangsdk.ServiceClient, vpcID string) *subnets.Subnet {
+	enableDHCP := true
 	createSubnetOpts := subnets.CreateOpts{
 		Name:       tools.RandomString("acc-subnet-", 3),
 		CIDR:       "192.168.20.0/24",
 		GatewayIP:  "192.168.20.1",
-		EnableDHCP: true,
-		VPC_ID:     vpcID,
+		EnableDHCP: &enableDHCP,
+		VpcID:      vpcID,
 	}
 	t.Logf("Attempting to create subnet: %s", createSubnetOpts.Name)
 

--- a/acceptance/openstack/networking/v1/subnet_test.go
+++ b/acceptance/openstack/networking/v1/subnet_test.go
@@ -27,7 +27,7 @@ func TestSubnetsLifecycle(t *testing.T) {
 	defer deleteVpc(t, client, vpc.ID)
 
 	subnet := createSubnet(t, client, vpc.ID)
-	defer deleteSubnet(t, client, subnet.VPC_ID, subnet.ID)
+	defer deleteSubnet(t, client, subnet.VpcID, subnet.ID)
 
 	tools.PrintResource(t, subnet)
 
@@ -36,12 +36,11 @@ func TestSubnetsLifecycle(t *testing.T) {
 		Name: tools.RandomString("acc-subnet-", 3),
 	}
 	t.Logf("Attempting to update name of subnet to %s", updateOpts.Name)
-	_, err = subnets.Update(client, subnet.VPC_ID, subnet.ID, updateOpts).Extract()
+	_, err = subnets.Update(client, subnet.VpcID, subnet.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	// Query a subnet
 	newSubnet, err := subnets.Get(client, subnet.ID).Extract()
 	th.AssertNoErr(t, err)
-
-	tools.PrintResource(t, newSubnet)
+	th.AssertEquals(t, updateOpts.Name, newSubnet.Name)
 }

--- a/openstack/networking/v1/subnets/doc.go
+++ b/openstack/networking/v1/subnets/doc.go
@@ -1,7 +1,7 @@
 /*
 Package Subnets enables management and retrieval of Subnets
 
-Example to List Vpcs
+Example to List VPCs
 
 	listOpts := subnets.ListOpts{}
 	allSubnets, err := subnets.List(subnetClient, listOpts)
@@ -19,10 +19,10 @@ Example to Create a Vpc
 		Name:          "test_subnets",
 		CIDR:          "192.168.0.0/16"
 		GatewayIP:	   "192.168.0.1"
-		PRIMARY_DNS:   "8.8.8.8"
-		SECONDARY_DNS: "8.8.4.4"
-		AvailabilityZone:"eu-de-02"
-		VPC_ID:"3b9740a0-b44d-48f0-84ee-42eb166e54f7"
+		PrimaryDns:   "8.8.8.8"
+		SecondaryDns: "8.8.4.4"
+		AvailabilityZone: "eu-de-02"
+		VpcID: "3b9740a0-b44d-48f0-84ee-42eb166e54f7"
 
 	}
 	vpc, err := subnets.Create(subnetClient, createOpts).Extract()
@@ -36,7 +36,7 @@ Example to Update a Vpc
 	subnetID := "4e8e5957-649f-477b-9e5b-f1f75b21c03c"
 
 	updateOpts := subnets.UpdateOpts{
-		Name:          "testsubnet",
+		Name: "testsubnet",
 	}
 
 	subnet, err := subnets.Update(subnetClient, subnetID, updateOpts).Extract()
@@ -54,4 +54,5 @@ Example to Delete a Vpc
 		panic(err)
 	}
 */
+
 package subnets

--- a/openstack/networking/v1/subnets/doc.go
+++ b/openstack/networking/v1/subnets/doc.go
@@ -16,14 +16,13 @@ Example to List VPCs
 Example to Create a Vpc
 
 	createOpts := subnets.CreateOpts{
-		Name:          "test_subnets",
-		CIDR:          "192.168.0.0/16"
-		GatewayIP:	   "192.168.0.1"
-		PrimaryDns:   "8.8.8.8"
-		SecondaryDns: "8.8.4.4"
+		Name:             "test_subnets",
+		CIDR:             "192.168.0.0/16"
+		GatewayIP:	      "192.168.0.1"
+		PrimaryDNS:       "8.8.8.8"
+		SecondaryDNS:     "8.8.4.4"
 		AvailabilityZone: "eu-de-02"
-		VpcID: "3b9740a0-b44d-48f0-84ee-42eb166e54f7"
-
+		VpcID:            "3b9740a0-b44d-48f0-84ee-42eb166e54f7"
 	}
 	vpc, err := subnets.Create(subnetClient, createOpts).Extract()
 

--- a/openstack/networking/v1/subnets/requests.go
+++ b/openstack/networking/v1/subnets/requests.go
@@ -91,8 +91,8 @@ func FilterSubnets(subnets []Subnet, opts ListOpts) ([]Subnet, error) {
 }
 
 func subnetMatchesFilter(subnet *Subnet, filter map[string]interface{}) bool {
-	for key, value := range filter {
-		if getStructField(subnet, key) != value {
+	for key, expectedValue := range filter {
+		if getStructField(subnet, key) != expectedValue {
 			return false
 		}
 	}

--- a/openstack/networking/v1/subnets/requests.go
+++ b/openstack/networking/v1/subnets/requests.go
@@ -49,9 +49,9 @@ type ListOpts struct {
 //
 // Default policy settings return only those subnets that are owned by the
 // tenant who submits the request, unless an admin user submits the request.
-func List(c *golangsdk.ServiceClient, opts ListOpts) ([]Subnet, error) {
-	url := rootURL(c)
-	pages, err := pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]Subnet, error) {
+	url := rootURL(client)
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return SubnetPage{pagination.LinkedPageBase{PageResult: r}}
 	}).AllPages()
 	if err != nil {

--- a/openstack/networking/v1/subnets/requests.go
+++ b/openstack/networking/v1/subnets/requests.go
@@ -12,7 +12,6 @@ import (
 // the floating IP attributes you want to see returned. SortKey allows you to
 // sort by a particular network attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
-
 type ListOpts struct {
 	// ID is the unique identifier for the subnet.
 	ID string `json:"id"`
@@ -31,16 +30,16 @@ type ListOpts struct {
 	GatewayIP string `json:"gateway_ip"`
 
 	// Specifies the IP address of DNS server 1 on the subnet.
-	PRIMARY_DNS string `json:"primary_dns"`
+	PrimaryDns string `json:"primary_dns"`
 
 	// Specifies the IP address of DNS server 2 on the subnet.
-	SECONDARY_DNS string `json:"secondary_dns"`
+	SecondaryDns string `json:"secondary_dns"`
 
 	// Identifies the availability zone (AZ) to which the subnet belongs.
 	AvailabilityZone string `json:"availability_zone"`
 
 	// Specifies the ID of the VPC to which the subnet belongs.
-	VPC_ID string `json:"vpc_id"`
+	VpcID string `json:"vpc_id"`
 }
 
 // List returns collection of
@@ -49,10 +48,9 @@ type ListOpts struct {
 //
 // Default policy settings return only those subnets that are owned by the
 // tenant who submits the request, unless an admin user submits the request.
-
 func List(c *golangsdk.ServiceClient, opts ListOpts) ([]Subnet, error) {
-	u := rootURL(c)
-	pages, err := pagination.NewPager(c, u, func(r pagination.PageResult) pagination.Page {
+	url := rootURL(c)
+	pages, err := pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
 		return SubnetPage{pagination.LinkedPageBase{PageResult: r}}
 	}).AllPages()
 	if err != nil {
@@ -68,44 +66,43 @@ func List(c *golangsdk.ServiceClient, opts ListOpts) ([]Subnet, error) {
 }
 
 func FilterSubnets(subnets []Subnet, opts ListOpts) ([]Subnet, error) {
-
 	var refinedSubnets []Subnet
 	var matched bool
-	m := map[string]interface{}{}
+	matchOpts := map[string]interface{}{}
 
 	if opts.ID != "" {
-		m["ID"] = opts.ID
+		matchOpts["ID"] = opts.ID
 	}
 	if opts.Name != "" {
-		m["Name"] = opts.Name
+		matchOpts["Name"] = opts.Name
 	}
 	if opts.CIDR != "" {
-		m["CIDR"] = opts.CIDR
+		matchOpts["CIDR"] = opts.CIDR
 	}
 	if opts.Status != "" {
-		m["Status"] = opts.Status
+		matchOpts["Status"] = opts.Status
 	}
 	if opts.GatewayIP != "" {
-		m["GatewayIP"] = opts.GatewayIP
+		matchOpts["GatewayIP"] = opts.GatewayIP
 	}
-	if opts.PRIMARY_DNS != "" {
-		m["PRIMARY_DNS"] = opts.PRIMARY_DNS
+	if opts.PrimaryDns != "" {
+		matchOpts["PrimaryDns"] = opts.PrimaryDns
 	}
-	if opts.SECONDARY_DNS != "" {
-		m["SECONDARY_DNS"] = opts.SECONDARY_DNS
+	if opts.SecondaryDns != "" {
+		matchOpts["SecondaryDns"] = opts.SecondaryDns
 	}
 	if opts.AvailabilityZone != "" {
-		m["AvailabilityZone"] = opts.AvailabilityZone
+		matchOpts["AvailabilityZone"] = opts.AvailabilityZone
 	}
-	if opts.VPC_ID != "" {
-		m["VPC_ID"] = opts.VPC_ID
+	if opts.VpcID != "" {
+		matchOpts["VpcID"] = opts.VpcID
 	}
 
-	if len(m) > 0 && len(subnets) > 0 {
+	if len(matchOpts) > 0 && len(subnets) > 0 {
 		for _, subnet := range subnets {
 			matched = true
 
-			for key, value := range m {
+			for key, value := range matchOpts {
 				if sVal := getStructField(&subnet, key); !(sVal == value) {
 					matched = false
 				}
@@ -115,7 +112,6 @@ func FilterSubnets(subnets []Subnet, opts ListOpts) ([]Subnet, error) {
 				refinedSubnets = append(refinedSubnets, subnet)
 			}
 		}
-
 	} else {
 		refinedSubnets = subnets
 	}
@@ -139,14 +135,15 @@ type CreateOptsBuilder interface {
 // no required values.
 type CreateOpts struct {
 	Name             string         `json:"name" required:"true"`
+	Description      string         `json:"description,omitempty"`
 	CIDR             string         `json:"cidr" required:"true"`
 	DnsList          []string       `json:"dnsList,omitempty"`
 	GatewayIP        string         `json:"gateway_ip" required:"true"`
-	EnableDHCP       bool           `json:"dhcp_enable" no_default:"y"`
-	PRIMARY_DNS      string         `json:"primary_dns,omitempty"`
-	SECONDARY_DNS    string         `json:"secondary_dns,omitempty"`
+	EnableDHCP       *bool          `json:"dhcp_enable,omitempty"`
+	PrimaryDns       string         `json:"primary_dns,omitempty"`
+	SecondaryDns     string         `json:"secondary_dns,omitempty"`
 	AvailabilityZone string         `json:"availability_zone,omitempty"`
-	VPC_ID           string         `json:"vpc_id" required:"true"`
+	VpcID            string         `json:"vpc_id" required:"true"`
 	ExtraDhcpOpts    []ExtraDhcpOpt `json:"extra_dhcp_opts,omitempty"`
 }
 
@@ -163,37 +160,37 @@ func (opts CreateOpts) ToSubnetCreateMap() (map[string]interface{}, error) {
 // Create accepts a CreateOpts struct and uses the values to create a new
 // logical subnets. When it is created, the subnets does not have an internal
 // interface - it is not associated to any subnet.
-//
-func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToSubnetCreateMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
-	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
-	_, r.Err = c.Post(rootURL(c), b, &r.Body, reqOpt)
+	_, r.Err = client.Post(rootURL(client), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
 	return
 }
 
 // Get retrieves a particular subnets based on its unique ID.
-func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
-	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, id), &r.Body, nil)
 	return
 }
 
 // UpdateOptsBuilder allows extensions to add additional parameters to the
 // Update request.
 type UpdateOptsBuilder interface {
-	// ToSubnetUpdateMap() (map[string]interface{}, error)
 	ToSubnetUpdateMap() (map[string]interface{}, error)
 }
 
 // UpdateOpts contains the values used when updating a subnets.
 type UpdateOpts struct {
 	Name          string         `json:"name,omitempty"`
-	EnableDHCP    bool           `json:"dhcp_enable"`
-	PRIMARY_DNS   string         `json:"primary_dns,omitempty"`
-	SECONDARY_DNS string         `json:"secondary_dns,omitempty"`
+	Description   string         `json:"description,omitempty"`
+	EnableDHCP    *bool          `json:"dhcp_enable,omitempty"`
+	PrimaryDns    string         `json:"primary_dns,omitempty"`
+	SecondaryDns  string         `json:"secondary_dns,omitempty"`
 	DnsList       []string       `json:"dnsList,omitempty"`
 	ExtraDhcpOpts []ExtraDhcpOpt `json:"extra_dhcp_opts,omitempty"`
 }
@@ -205,20 +202,20 @@ func (opts UpdateOpts) ToSubnetUpdateMap() (map[string]interface{}, error) {
 
 // Update allows subnets to be updated. You can update the name, administrative
 // state, and the external gateway.
-func Update(c *golangsdk.ServiceClient, vpcid string, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(client *golangsdk.ServiceClient, vpcID string, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToSubnetUpdateMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
-	_, r.Err = c.Put(updateURL(c, vpcid, id), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Put(updateURL(client, vpcID, id), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{200},
 	})
 	return
 }
 
 // Delete will permanently delete a particular subnets based on its unique ID.
-func Delete(c *golangsdk.ServiceClient, vpcid string, id string) (r DeleteResult) {
-	_, r.Err = c.Delete(updateURL(c, vpcid, id), nil)
+func Delete(client *golangsdk.ServiceClient, vpcID string, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(updateURL(client, vpcID, id), nil)
 	return
 }

--- a/openstack/networking/v1/subnets/requests.go
+++ b/openstack/networking/v1/subnets/requests.go
@@ -30,10 +30,10 @@ type ListOpts struct {
 	GatewayIP string `json:"gateway_ip"`
 
 	// Specifies the IP address of DNS server 1 on the subnet.
-	PrimaryDns string `json:"primary_dns"`
+	PrimaryDNS string `json:"primary_dns"`
 
 	// Specifies the IP address of DNS server 2 on the subnet.
-	SecondaryDns string `json:"secondary_dns"`
+	SecondaryDNS string `json:"secondary_dns"`
 
 	// Identifies the availability zone (AZ) to which the subnet belongs.
 	AvailabilityZone string `json:"availability_zone"`
@@ -85,11 +85,11 @@ func FilterSubnets(subnets []Subnet, opts ListOpts) ([]Subnet, error) {
 	if opts.GatewayIP != "" {
 		matchOpts["GatewayIP"] = opts.GatewayIP
 	}
-	if opts.PrimaryDns != "" {
-		matchOpts["PrimaryDns"] = opts.PrimaryDns
+	if opts.PrimaryDNS != "" {
+		matchOpts["PrimaryDNS"] = opts.PrimaryDNS
 	}
-	if opts.SecondaryDns != "" {
-		matchOpts["SecondaryDns"] = opts.SecondaryDns
+	if opts.SecondaryDNS != "" {
+		matchOpts["SecondaryDNS"] = opts.SecondaryDNS
 	}
 	if opts.AvailabilityZone != "" {
 		matchOpts["AvailabilityZone"] = opts.AvailabilityZone
@@ -137,17 +137,17 @@ type CreateOpts struct {
 	Name             string         `json:"name" required:"true"`
 	Description      string         `json:"description,omitempty"`
 	CIDR             string         `json:"cidr" required:"true"`
-	DnsList          []string       `json:"dnsList,omitempty"`
+	DNSList          []string       `json:"dnsList,omitempty"`
 	GatewayIP        string         `json:"gateway_ip" required:"true"`
 	EnableDHCP       *bool          `json:"dhcp_enable,omitempty"`
-	PrimaryDns       string         `json:"primary_dns,omitempty"`
-	SecondaryDns     string         `json:"secondary_dns,omitempty"`
+	PrimaryDNS       string         `json:"primary_dns,omitempty"`
+	SecondaryDNS     string         `json:"secondary_dns,omitempty"`
 	AvailabilityZone string         `json:"availability_zone,omitempty"`
 	VpcID            string         `json:"vpc_id" required:"true"`
-	ExtraDhcpOpts    []ExtraDhcpOpt `json:"extra_dhcp_opts,omitempty"`
+	ExtraDHCPOpts    []ExtraDHCPOpt `json:"extra_dhcp_opts,omitempty"`
 }
 
-type ExtraDhcpOpt struct {
+type ExtraDHCPOpt struct {
 	OptName  string `json:"opt_name" required:"true"`
 	OptValue string `json:"opt_value,omitempty"`
 }
@@ -189,10 +189,10 @@ type UpdateOpts struct {
 	Name          string         `json:"name,omitempty"`
 	Description   string         `json:"description,omitempty"`
 	EnableDHCP    *bool          `json:"dhcp_enable,omitempty"`
-	PrimaryDns    string         `json:"primary_dns,omitempty"`
-	SecondaryDns  string         `json:"secondary_dns,omitempty"`
-	DnsList       []string       `json:"dnsList,omitempty"`
-	ExtraDhcpOpts []ExtraDhcpOpt `json:"extra_dhcp_opts,omitempty"`
+	PrimaryDNS    string         `json:"primary_dns,omitempty"`
+	SecondaryDNS  string         `json:"secondary_dns,omitempty"`
+	DNSList       []string       `json:"dnsList,omitempty"`
+	ExtraDhcpOpts []ExtraDHCPOpt `json:"extra_dhcp_opts,omitempty"`
 }
 
 // ToSubnetUpdateMap builds an update body based on UpdateOpts.

--- a/openstack/networking/v1/subnets/results.go
+++ b/openstack/networking/v1/subnets/results.go
@@ -13,6 +13,9 @@ type Subnet struct {
 	// unique.
 	Name string `json:"name"`
 
+	// Provides supplementary information about the subnet.
+	Description string `json:"description"`
+
 	// Specifies the network segment on which the subnet resides.
 	CIDR string `json:"cidr"`
 
@@ -29,19 +32,22 @@ type Subnet struct {
 	EnableDHCP bool `json:"dhcp_enable"`
 
 	// Specifies the IP address of DNS server 1 on the subnet.
-	PRIMARY_DNS string `json:"primary_dns"`
+	PrimaryDns string `json:"primary_dns"`
 
 	// Specifies the IP address of DNS server 2 on the subnet.
-	SECONDARY_DNS string `json:"secondary_dns"`
+	SecondaryDns string `json:"secondary_dns"`
 
 	// Identifies the availability zone (AZ) to which the subnet belongs.
 	AvailabilityZone string `json:"availability_zone"`
 
 	// Specifies the ID of the VPC to which the subnet belongs.
-	VPC_ID string `json:"vpc_id"`
+	VpcID string `json:"vpc_id"`
 
 	// Specifies the subnet ID.
-	SubnetId string `json:"neutron_subnet_id"`
+	SubnetID string `json:"neutron_subnet_id"`
+
+	// Specifies the network ID.
+	NetworkID string `json:"neutron_network_id"`
 
 	// Specifies the extra dhcp opts.
 	ExtraDhcpOpts []ExtraDhcp `json:"extra_dhcp_opts"`
@@ -82,11 +88,9 @@ func (r SubnetPage) IsEmpty() (bool, error) {
 // and extracts the elements into a slice of Subnet structs. In other words,
 // a generic collection is mapped into a relevant slice.
 func ExtractSubnets(r pagination.Page) ([]Subnet, error) {
-	var s struct {
-		Subnets []Subnet `json:"subnets"`
-	}
-	err := (r.(SubnetPage)).ExtractInto(&s)
-	return s.Subnets, err
+	var s []Subnet
+	err := (r.(SubnetPage)).ExtractIntoSlicePtr(&s, "subnets")
+	return s, err
 }
 
 type commonResult struct {
@@ -95,11 +99,9 @@ type commonResult struct {
 
 // Extract is a function that accepts a result and extracts a Subnet.
 func (r commonResult) Extract() (*Subnet, error) {
-	var s struct {
-		Subnet *Subnet `json:"subnet"`
-	}
-	err := r.ExtractInto(&s)
-	return s.Subnet, err
+	s := new(Subnet)
+	err := r.ExtractIntoStructPtr(s, "subnet")
+	return s, err
 }
 
 // CreateResult represents the result of a create operation. Call its Extract

--- a/openstack/networking/v1/subnets/results.go
+++ b/openstack/networking/v1/subnets/results.go
@@ -20,7 +20,7 @@ type Subnet struct {
 	CIDR string `json:"cidr"`
 
 	// Specifies the IP address list of DNS servers on the subnet.
-	DnsList []string `json:"dnsList"`
+	DNSList []string `json:"dnsList"`
 
 	// Status indicates whether or not a subnet is currently operational.
 	Status string `json:"status"`
@@ -32,10 +32,10 @@ type Subnet struct {
 	EnableDHCP bool `json:"dhcp_enable"`
 
 	// Specifies the IP address of DNS server 1 on the subnet.
-	PrimaryDns string `json:"primary_dns"`
+	PrimaryDNS string `json:"primary_dns"`
 
 	// Specifies the IP address of DNS server 2 on the subnet.
-	SecondaryDns string `json:"secondary_dns"`
+	SecondaryDNS string `json:"secondary_dns"`
 
 	// Identifies the availability zone (AZ) to which the subnet belongs.
 	AvailabilityZone string `json:"availability_zone"`
@@ -50,10 +50,10 @@ type Subnet struct {
 	NetworkID string `json:"neutron_network_id"`
 
 	// Specifies the extra dhcp opts.
-	ExtraDhcpOpts []ExtraDhcp `json:"extra_dhcp_opts"`
+	ExtraDHCPOpts []ExtraDHCP `json:"extra_dhcp_opts"`
 }
 
-type ExtraDhcp struct {
+type ExtraDHCP struct {
 	OptName  string `json:"opt_name"`
 	OptValue string `json:"opt_value"`
 }

--- a/openstack/networking/v1/subnets/testing/doc.go
+++ b/openstack/networking/v1/subnets/testing/doc.go
@@ -1,2 +1,3 @@
-// vpcs unit tests
+// VPCs unit tests
+
 package testing

--- a/openstack/networking/v1/subnets/testing/requests_test.go
+++ b/openstack/networking/v1/subnets/testing/requests_test.go
@@ -56,7 +56,7 @@ func TestListSubnet(t *testing.T) {
 			  "114.114.115.115"
 		    ],
             "neutron_subnet_id": "3d543273-31c3-41f8-b887-ed8c2c837578",
-			"neutron_network_id": "134ca339-24dc-44f5-ae6a-cf0404216ed2"
+            "neutron_network_id": "134ca339-24dc-44f5-ae6a-cf0404216ed2"
         }
     ]
 }
@@ -78,9 +78,9 @@ func TestListSubnet(t *testing.T) {
 			ID:           "0345a6ef-9404-487b-87c8-212557a1160d",
 			GatewayIP:    "192.168.200.1",
 			VpcID:        "58c24204-170e-4ff0-9b42-c53cdea9239a",
-			PrimaryDns:   "114.114.114.114",
-			SecondaryDns: "114.114.115.115",
-			DnsList:      []string{"114.114.114.114", "114.114.115.115"},
+			PrimaryDNS:   "114.114.114.114",
+			SecondaryDNS: "114.114.115.115",
+			DNSList:      []string{"114.114.114.114", "114.114.115.115"},
 			SubnetID:     "3d543273-31c3-41f8-b887-ed8c2c837578",
 			NetworkID:    "0345a6ef-9404-487b-87c8-212557a1160d",
 		},
@@ -92,9 +92,9 @@ func TestListSubnet(t *testing.T) {
 			ID:           "134ca339-24dc-44f5-ae6a-cf0404216ed2",
 			GatewayIP:    "192.168.200.1",
 			VpcID:        "58c24204-170e-4ff0-9b42-c53cdea9239a",
-			PrimaryDns:   "114.114.114.114",
-			SecondaryDns: "114.114.115.115",
-			DnsList:      []string{"114.114.114.114", "114.114.115.115"},
+			PrimaryDNS:   "114.114.114.114",
+			SecondaryDNS: "114.114.115.115",
+			DNSList:      []string{"114.114.114.114", "114.114.115.115"},
 			SubnetID:     "3d543273-31c3-41f8-b887-ed8c2c837578",
 			NetworkID:    "134ca339-24dc-44f5-ae6a-cf0404216ed2",
 		},
@@ -145,11 +145,11 @@ func TestGetSubnet(t *testing.T) {
 	th.AssertEquals(t, "d4f2c817-d5df-4a66-994a-6571312b470e", n.VpcID)
 	th.AssertEquals(t, "3d543273-31c3-41f8-b887-ed8c2c837578", n.SubnetID)
 	th.AssertEquals(t, "10.0.0.1", n.GatewayIP)
-	th.AssertEquals(t, "100.125.4.25", n.PrimaryDns)
-	th.AssertEquals(t, "8.8.8.8", n.SecondaryDns)
+	th.AssertEquals(t, "100.125.4.25", n.PrimaryDNS)
+	th.AssertEquals(t, "8.8.8.8", n.SecondaryDNS)
 	th.AssertEquals(t, true, n.EnableDHCP)
-	th.AssertEquals(t, "100.125.4.25", n.DnsList[0])
-	th.AssertEquals(t, "8.8.8.8", n.DnsList[1])
+	th.AssertEquals(t, "100.125.4.25", n.DNSList[0])
+	th.AssertEquals(t, "8.8.8.8", n.DNSList[1])
 
 }
 
@@ -212,11 +212,11 @@ func TestCreateSubnet(t *testing.T) {
 		Name:             "test_subnets",
 		CIDR:             "192.168.0.0/16",
 		GatewayIP:        "192.168.0.1",
-		PrimaryDns:       "8.8.8.8",
-		SecondaryDns:     "8.8.4.4",
+		PrimaryDNS:       "8.8.8.8",
+		SecondaryDNS:     "8.8.4.4",
 		AvailabilityZone: "eu-de-02",
 		VpcID:            "3b9740a0-b44d-48f0-84ee-42eb166e54f7",
-		DnsList:          []string{"8.8.8.8", "8.8.4.4"},
+		DNSList:          []string{"8.8.8.8", "8.8.4.4"},
 		EnableDHCP:       &enableDHCP,
 	}
 	n, err := subnets.Create(fake.ServiceClient(), options).Extract()
@@ -225,15 +225,15 @@ func TestCreateSubnet(t *testing.T) {
 	th.AssertEquals(t, "192.168.0.1", n.GatewayIP)
 	th.AssertEquals(t, "192.168.0.0/16", n.CIDR)
 	th.AssertEquals(t, true, n.EnableDHCP)
-	th.AssertEquals(t, "8.8.8.8", n.PrimaryDns)
-	th.AssertEquals(t, "8.8.4.4", n.SecondaryDns)
+	th.AssertEquals(t, "8.8.8.8", n.PrimaryDNS)
+	th.AssertEquals(t, "8.8.4.4", n.SecondaryDNS)
 	th.AssertEquals(t, "eu-de-02", n.AvailabilityZone)
 	th.AssertEquals(t, "6b0cf733-f496-4159-9df1-d74c3584a9f7", n.ID)
 	th.AssertEquals(t, "UNKNOWN", n.Status)
 	th.AssertEquals(t, "3b9740a0-b44d-48f0-84ee-42eb166e54f7", n.VpcID)
 	th.AssertEquals(t, "3d543273-31c3-41f8-b887-ed8c2c837578", n.SubnetID)
-	th.AssertEquals(t, "8.8.8.8", n.DnsList[0])
-	th.AssertEquals(t, "8.8.4.4", n.DnsList[1])
+	th.AssertEquals(t, "8.8.8.8", n.DNSList[0])
+	th.AssertEquals(t, "8.8.4.4", n.DNSList[1])
 
 }
 

--- a/openstack/networking/v1/subnets/testing/requests_test.go
+++ b/openstack/networking/v1/subnets/testing/requests_test.go
@@ -39,7 +39,7 @@ func TestListSubnet(t *testing.T) {
 			  "114.114.115.115"
 		    ],
             "neutron_subnet_id": "3d543273-31c3-41f8-b887-ed8c2c837578",
-			"neutron_network_id": "0345a6ef-9404-487b-87c8-212557a1160d"
+            "neutron_network_id": "0345a6ef-9404-487b-87c8-212557a1160d"
         },
         {
             "id": "134ca339-24dc-44f5-ae6a-cf0404216ed2",

--- a/openstack/networking/v1/subnets/testing/requests_test.go
+++ b/openstack/networking/v1/subnets/testing/requests_test.go
@@ -38,7 +38,8 @@ func TestListSubnet(t *testing.T) {
 			  "114.114.114.114",
 			  "114.114.115.115"
 		    ],
-            "neutron_subnet_id": "3d543273-31c3-41f8-b887-ed8c2c837578"
+            "neutron_subnet_id": "3d543273-31c3-41f8-b887-ed8c2c837578",
+			"neutron_network_id": "0345a6ef-9404-487b-87c8-212557a1160d"
         },
         {
             "id": "134ca339-24dc-44f5-ae6a-cf0404216ed2",
@@ -54,7 +55,8 @@ func TestListSubnet(t *testing.T) {
 			  "114.114.114.114",
 			  "114.114.115.115"
 		    ],
-            "neutron_subnet_id": "3d543273-31c3-41f8-b887-ed8c2c837578"
+            "neutron_subnet_id": "3d543273-31c3-41f8-b887-ed8c2c837578",
+			"neutron_network_id": "134ca339-24dc-44f5-ae6a-cf0404216ed2"
         }
     ]
 }
@@ -69,32 +71,32 @@ func TestListSubnet(t *testing.T) {
 
 	expected := []subnets.Subnet{
 		{
-			Status:     "ACTIVE",
-			CIDR:       "192.168.200.0/24",
-			EnableDHCP: true,
-			Name:       "openlab-subnet",
-			// DnsList:          []string{},
-			ID:            "0345a6ef-9404-487b-87c8-212557a1160d",
-			GatewayIP:     "192.168.200.1",
-			VPC_ID:        "58c24204-170e-4ff0-9b42-c53cdea9239a",
-			PRIMARY_DNS:   "114.114.114.114",
-			SECONDARY_DNS: "114.114.115.115",
-			DnsList:       []string{"114.114.114.114", "114.114.115.115"},
-			SubnetId:      "3d543273-31c3-41f8-b887-ed8c2c837578",
+			Status:       "ACTIVE",
+			CIDR:         "192.168.200.0/24",
+			EnableDHCP:   true,
+			Name:         "openlab-subnet",
+			ID:           "0345a6ef-9404-487b-87c8-212557a1160d",
+			GatewayIP:    "192.168.200.1",
+			VpcID:        "58c24204-170e-4ff0-9b42-c53cdea9239a",
+			PrimaryDns:   "114.114.114.114",
+			SecondaryDns: "114.114.115.115",
+			DnsList:      []string{"114.114.114.114", "114.114.115.115"},
+			SubnetID:     "3d543273-31c3-41f8-b887-ed8c2c837578",
+			NetworkID:    "0345a6ef-9404-487b-87c8-212557a1160d",
 		},
 		{
-			Status:     "ACTIVE",
-			CIDR:       "192.168.200.0/24",
-			EnableDHCP: true,
-			Name:       "openlab-subnet",
-			// DnsList:          []string{},
-			ID:            "134ca339-24dc-44f5-ae6a-cf0404216ed2",
-			GatewayIP:     "192.168.200.1",
-			VPC_ID:        "58c24204-170e-4ff0-9b42-c53cdea9239a",
-			PRIMARY_DNS:   "114.114.114.114",
-			SECONDARY_DNS: "114.114.115.115",
-			DnsList:       []string{"114.114.114.114", "114.114.115.115"},
-			SubnetId:      "3d543273-31c3-41f8-b887-ed8c2c837578",
+			Status:       "ACTIVE",
+			CIDR:         "192.168.200.0/24",
+			EnableDHCP:   true,
+			Name:         "openlab-subnet",
+			ID:           "134ca339-24dc-44f5-ae6a-cf0404216ed2",
+			GatewayIP:    "192.168.200.1",
+			VpcID:        "58c24204-170e-4ff0-9b42-c53cdea9239a",
+			PrimaryDns:   "114.114.114.114",
+			SecondaryDns: "114.114.115.115",
+			DnsList:      []string{"114.114.114.114", "114.114.115.115"},
+			SubnetID:     "3d543273-31c3-41f8-b887-ed8c2c837578",
+			NetworkID:    "134ca339-24dc-44f5-ae6a-cf0404216ed2",
 		},
 	}
 	th.AssertDeepEquals(t, expected, actual)
@@ -140,11 +142,11 @@ func TestGetSubnet(t *testing.T) {
 	th.AssertEquals(t, "subnet-mgmt", n.Name)
 	th.AssertEquals(t, "10.0.0.0/24", n.CIDR)
 	th.AssertEquals(t, "ACTIVE", n.Status)
-	th.AssertEquals(t, "d4f2c817-d5df-4a66-994a-6571312b470e", n.VPC_ID)
-	th.AssertEquals(t, "3d543273-31c3-41f8-b887-ed8c2c837578", n.SubnetId)
+	th.AssertEquals(t, "d4f2c817-d5df-4a66-994a-6571312b470e", n.VpcID)
+	th.AssertEquals(t, "3d543273-31c3-41f8-b887-ed8c2c837578", n.SubnetID)
 	th.AssertEquals(t, "10.0.0.1", n.GatewayIP)
-	th.AssertEquals(t, "100.125.4.25", n.PRIMARY_DNS)
-	th.AssertEquals(t, "8.8.8.8", n.SECONDARY_DNS)
+	th.AssertEquals(t, "100.125.4.25", n.PrimaryDns)
+	th.AssertEquals(t, "8.8.8.8", n.SecondaryDns)
 	th.AssertEquals(t, true, n.EnableDHCP)
 	th.AssertEquals(t, "100.125.4.25", n.DnsList[0])
 	th.AssertEquals(t, "8.8.8.8", n.DnsList[1])
@@ -173,7 +175,7 @@ func TestCreateSubnet(t *testing.T) {
           "availability_zone":"eu-de-02",
           "vpc_id":"3b9740a0-b44d-48f0-84ee-42eb166e54f7",
 		  "dnsList": [
-             "8.8.8.8",
+            "8.8.8.8",
             "8.8.4.4"
           ]
           }
@@ -190,8 +192,8 @@ func TestCreateSubnet(t *testing.T) {
         "name": "test_subnets",
         "cidr": "192.168.0.0/16",
         "dnsList": [
-            "8.8.8.8",
-            "8.8.4.4"
+          "8.8.8.8",
+          "8.8.4.4"
         ],
         "status": "UNKNOWN",
         "vpc_id": "3b9740a0-b44d-48f0-84ee-42eb166e54f7",
@@ -205,16 +207,17 @@ func TestCreateSubnet(t *testing.T) {
 }	`)
 	})
 
+	enableDHCP := true
 	options := subnets.CreateOpts{
 		Name:             "test_subnets",
 		CIDR:             "192.168.0.0/16",
 		GatewayIP:        "192.168.0.1",
-		PRIMARY_DNS:      "8.8.8.8",
-		SECONDARY_DNS:    "8.8.4.4",
+		PrimaryDns:       "8.8.8.8",
+		SecondaryDns:     "8.8.4.4",
 		AvailabilityZone: "eu-de-02",
-		VPC_ID:           "3b9740a0-b44d-48f0-84ee-42eb166e54f7",
+		VpcID:            "3b9740a0-b44d-48f0-84ee-42eb166e54f7",
 		DnsList:          []string{"8.8.8.8", "8.8.4.4"},
-		EnableDHCP:       true,
+		EnableDHCP:       &enableDHCP,
 	}
 	n, err := subnets.Create(fake.ServiceClient(), options).Extract()
 	th.AssertNoErr(t, err)
@@ -222,13 +225,13 @@ func TestCreateSubnet(t *testing.T) {
 	th.AssertEquals(t, "192.168.0.1", n.GatewayIP)
 	th.AssertEquals(t, "192.168.0.0/16", n.CIDR)
 	th.AssertEquals(t, true, n.EnableDHCP)
-	th.AssertEquals(t, "8.8.8.8", n.PRIMARY_DNS)
-	th.AssertEquals(t, "8.8.4.4", n.SECONDARY_DNS)
+	th.AssertEquals(t, "8.8.8.8", n.PrimaryDns)
+	th.AssertEquals(t, "8.8.4.4", n.SecondaryDns)
 	th.AssertEquals(t, "eu-de-02", n.AvailabilityZone)
 	th.AssertEquals(t, "6b0cf733-f496-4159-9df1-d74c3584a9f7", n.ID)
 	th.AssertEquals(t, "UNKNOWN", n.Status)
-	th.AssertEquals(t, "3b9740a0-b44d-48f0-84ee-42eb166e54f7", n.VPC_ID)
-	th.AssertEquals(t, "3d543273-31c3-41f8-b887-ed8c2c837578", n.SubnetId)
+	th.AssertEquals(t, "3b9740a0-b44d-48f0-84ee-42eb166e54f7", n.VpcID)
+	th.AssertEquals(t, "3d543273-31c3-41f8-b887-ed8c2c837578", n.SubnetID)
 	th.AssertEquals(t, "8.8.8.8", n.DnsList[0])
 	th.AssertEquals(t, "8.8.4.4", n.DnsList[1])
 
@@ -267,7 +270,11 @@ func TestUpdateSubnet(t *testing.T) {
 		`)
 	})
 
-	options := subnets.UpdateOpts{Name: "testsubnet"}
+	enableDHCP := false
+	options := subnets.UpdateOpts{
+		Name:       "testsubnet",
+		EnableDHCP: &enableDHCP,
+	}
 
 	n, err := subnets.Update(fake.ServiceClient(), "8f794f06-2275-4d82-9f5a-6d68fbe21a75", "83e3bddc-b9ed-4614-a0dc-8a997095a86c", options).Extract()
 	th.AssertNoErr(t, err)

--- a/openstack/networking/v1/subnets/urls.go
+++ b/openstack/networking/v1/subnets/urls.go
@@ -4,17 +4,17 @@ import "github.com/opentelekomcloud/gophertelekomcloud"
 
 const (
 	resourcePath = "subnets"
-	rootpath     = "vpcs"
+	rootPath     = "vpcs"
 )
 
-func rootURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath)
+func rootURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL(client.ProjectID, resourcePath)
 }
 
-func resourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, id)
+func resourceURL(client *golangsdk.ServiceClient, id string) string {
+	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
 
-func updateURL(c *golangsdk.ServiceClient, vpcid, id string) string {
-	return c.ServiceURL(c.ProjectID, rootpath, vpcid, resourcePath, id)
+func updateURL(client *golangsdk.ServiceClient, vpcID, id string) string {
+	return client.ServiceURL(client.ProjectID, rootPath, vpcID, resourcePath, id)
 }


### PR DESCRIPTION
### What this PR does / why we need it
Update subnets pkg

### Which issue this PR fixes
Resolves: #140 


unit
```
=== RUN   TestListSubnet
--- PASS: TestListSubnet (0.00s)
=== RUN   TestGetSubnet
--- PASS: TestGetSubnet (0.00s)
=== RUN   TestCreateSubnet
--- PASS: TestCreateSubnet (0.00s)
=== RUN   TestUpdateSubnet
--- PASS: TestUpdateSubnet (0.00s)
=== RUN   TestDeleteSubnet
--- PASS: TestDeleteSubnet (0.00s)
PASS

Process finished with the exit code 0
```

acceptance
```
=== RUN   TestSubnetList
--- PASS: TestSubnetList (3.37s)
=== RUN   TestSubnetsLifecycle
    helpers.go:206: Attempting to create vpc: acc-vpc-Tox
    helpers.go:210: Created vpc: 642adede-8f37-49a4-9f36-cbfcd93eedf0
    helpers.go:139: Attempting to create subnet: acc-subnet-u70
    helpers.go:145: Waitting for subnet bc3977fe-d8fe-474a-83d0-46fde40cb4fd to be active
    helpers.go:148: Created subnet: bc3977fe-d8fe-474a-83d0-46fde40cb4fd
    subnet_test.go:38: Attempting to update name of subnet to acc-subnet-orD
    helpers.go:154: Attempting to delete subnet: bc3977fe-d8fe-474a-83d0-46fde40cb4fd
    helpers.go:159: Waiting for subnet bc3977fe-d8fe-474a-83d0-46fde40cb4fd to be deleted
    helpers.go:163: Deleted subnet: bc3977fe-d8fe-474a-83d0-46fde40cb4fd
    helpers.go:216: Attempting to delete vpc: 642adede-8f37-49a4-9f36-cbfcd93eedf0
    helpers.go:221: Deleted vpc: 642adede-8f37-49a4-9f36-cbfcd93eedf0
--- PASS: TestSubnetsLifecycle (21.15s)
PASS

Process finished with the exit code 0
```