### PR TITLE
Fix issue with wrong filtering of `vpc_subnet`

### DIFF
--- a/acceptance/openstack/networking/v1/subnet_test.go
+++ b/acceptance/openstack/networking/v1/subnet_test.go
@@ -26,6 +26,7 @@ func TestSubnetList(t *testing.T) {
 	filteredSubnets, err := subnets.List(client, listOpts)
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, 1, len(filteredSubnets))
+	th.AssertEquals(t, vpc.ID, filteredSubnets[0].VpcID)
 }
 
 func TestSubnetsLifecycle(t *testing.T) {

--- a/acceptance/openstack/networking/v1/subnet_test.go
+++ b/acceptance/openstack/networking/v1/subnet_test.go
@@ -13,10 +13,19 @@ func TestSubnetList(t *testing.T) {
 	client, err := clients.NewNetworkV1Client()
 	th.AssertNoErr(t, err)
 
-	allPages, err := subnets.List(client, subnets.ListOpts{})
-	th.AssertNoErr(t, err)
+	vpc := createVpc(t, client)
+	defer deleteVpc(t, client, vpc.ID)
 
-	tools.PrintResource(t, allPages)
+	subnet := createSubnet(t, client, vpc.ID)
+	defer deleteSubnet(t, client, subnet.VpcID, subnet.ID)
+
+	listOpts := subnets.ListOpts{
+		VpcID: vpc.ID,
+	}
+
+	filteredSubnets, err := subnets.List(client, listOpts)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(filteredSubnets))
 }
 
 func TestSubnetsLifecycle(t *testing.T) {

--- a/openstack/networking/v1/subnets/requests.go
+++ b/openstack/networking/v1/subnets/requests.go
@@ -92,7 +92,7 @@ func FilterSubnets(subnets []Subnet, opts ListOpts) ([]Subnet, error) {
 
 func subnetMatchesFilter(subnet *Subnet, filter map[string]interface{}) bool {
 	for key, expectedValue := range filter {
-		if sVal := getStructField(subnet, key); sVal != expectedValue {
+		if getStructField(subnet, key) != expectedValue {
 			return false
 		}
 	}

--- a/openstack/networking/v1/subnets/requests.go
+++ b/openstack/networking/v1/subnets/requests.go
@@ -15,32 +15,32 @@ import (
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
 	// ID is the unique identifier for the subnet.
-	ID string `json:"id,omitempty"`
+	ID string `json:",omitempty"`
 
 	// Name is the human readable name for the subnet. It does not have to be
 	// unique.
-	Name string `json:"name,omitempty"`
+	Name string `json:",omitempty"`
 
 	// Specifies the network segment on which the subnet resides.
-	CIDR string `json:"cidr,omitempty"`
+	CIDR string `json:",omitempty"`
 
 	// Status indicates whether or not a subnet is currently operational.
-	Status string `json:"status,omitempty"`
+	Status string `json:",omitempty"`
 
 	// Specifies the gateway of the subnet.
-	GatewayIP string `json:"gateway_ip,omitempty"`
+	GatewayIP string `json:",omitempty"`
 
 	// Specifies the IP address of DNS server 1 on the subnet.
-	PrimaryDNS string `json:"primary_dns,omitempty"`
+	PrimaryDNS string `json:",omitempty"`
 
 	// Specifies the IP address of DNS server 2 on the subnet.
-	SecondaryDNS string `json:"secondary_dns,omitempty"`
+	SecondaryDNS string `json:",omitempty"`
 
 	// Identifies the availability zone (AZ) to which the subnet belongs.
-	AvailabilityZone string `json:"availability_zone,omitempty"`
+	AvailabilityZone string `json:",omitempty"`
 
 	// Specifies the ID of the VPC to which the subnet belongs.
-	VpcID string `json:"vpc_id,omitempty"`
+	VpcID string `json:",omitempty"`
 }
 
 // List returns collection of
@@ -92,7 +92,7 @@ func FilterSubnets(subnets []Subnet, opts ListOpts) ([]Subnet, error) {
 
 func subnetMatchesFilter(subnet *Subnet, filter map[string]interface{}) bool {
 	for key, expectedValue := range filter {
-		if getStructField(subnet, key) != expectedValue {
+		if sVal := getStructField(subnet, key); sVal != expectedValue {
 			return false
 		}
 	}


### PR DESCRIPTION
```
=== RUN   TestSubnetList
    helpers.go:206: Attempting to create vpc: acc-vpc-bUB
    helpers.go:210: Created vpc: 23f26b51-88df-4fb8-8f3f-0b264346cf58
    helpers.go:139: Attempting to create subnet: acc-subnet-2Jg
    helpers.go:145: Waitting for subnet 0d7fcab7-0760-44bd-80dc-dd825a45f5df to be active
    helpers.go:148: Created subnet: 0d7fcab7-0760-44bd-80dc-dd825a45f5df
    helpers.go:154: Attempting to delete subnet: 0d7fcab7-0760-44bd-80dc-dd825a45f5df
    helpers.go:159: Waiting for subnet 0d7fcab7-0760-44bd-80dc-dd825a45f5df to be deleted
    helpers.go:163: Deleted subnet: 0d7fcab7-0760-44bd-80dc-dd825a45f5df
    helpers.go:216: Attempting to delete vpc: 23f26b51-88df-4fb8-8f3f-0b264346cf58
    helpers.go:221: Deleted vpc: 23f26b51-88df-4fb8-8f3f-0b264346cf58
--- PASS: TestSubnetList (19.58s)
=== RUN   TestSubnetsLifecycle
    helpers.go:206: Attempting to create vpc: acc-vpc-23w
    helpers.go:210: Created vpc: 03d31ee4-fbab-4b38-8238-3ef3b0648fff
    helpers.go:139: Attempting to create subnet: acc-subnet-iDs
    helpers.go:145: Waitting for subnet b288e32e-0d80-433f-9fc7-2c4ffcbd6eeb to be active
    helpers.go:148: Created subnet: b288e32e-0d80-433f-9fc7-2c4ffcbd6eeb
    subnet_test.go:47: Attempting to update name of subnet to acc-subnet-sR4
    helpers.go:154: Attempting to delete subnet: b288e32e-0d80-433f-9fc7-2c4ffcbd6eeb
    helpers.go:159: Waiting for subnet b288e32e-0d80-433f-9fc7-2c4ffcbd6eeb to be deleted
    helpers.go:163: Deleted subnet: b288e32e-0d80-433f-9fc7-2c4ffcbd6eeb
    helpers.go:216: Attempting to delete vpc: 03d31ee4-fbab-4b38-8238-3ef3b0648fff
    helpers.go:221: Deleted vpc: 03d31ee4-fbab-4b38-8238-3ef3b0648fff
--- PASS: TestSubnetsLifecycle (20.85s)
PASS

Process finished with the exit code 0
```