### PR TITLE
Make `Volume.Size` optional

### DIFF
--- a/openstack/rds/v3/instances/requests.go
+++ b/openstack/rds/v3/instances/requests.go
@@ -57,7 +57,7 @@ type BackupStrategy struct {
 
 type Volume struct {
 	Type string `json:"type" required:"true"`
-	Size int    `json:"size" required:"true"`
+	Size int    `json:"size,omitempty"`
 }
 
 type ChargeInfo struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Read replicas don't have volume size defined

