### PR TITLE
[VPC] Add possibility to filter eips with List request

### DIFF
--- a/acceptance/openstack/networking/v1/eips_test.go
+++ b/acceptance/openstack/networking/v1/eips_test.go
@@ -14,16 +14,22 @@ func TestEipList(t *testing.T) {
 	client, err := clients.NewNetworkV1Client()
 	th.AssertNoErr(t, err)
 
-	listOpts := eips.ListOpts{}
-	eipPages, err := eips.List(client, listOpts).AllPages()
-	th.AssertNoErr(t, err)
-
-	eipList, err := eips.ExtractEips(eipPages)
-	th.AssertNoErr(t, err)
-
-	for _, eip := range eipList {
-		tools.PrintResource(t, eip)
+	elasticIP := createEip(t, client, 100)
+	listOpts := eips.ListOpts{
+		BandwidthID: elasticIP.BandwidthID,
 	}
+	defer func() {
+		deleteEip(t, client, elasticIP.ID)
+
+		elasticIPs, err := eips.List(client, listOpts)
+		th.AssertNoErr(t, err)
+		th.AssertEquals(t, 0, len(elasticIPs))
+	}()
+
+	elasticIPs, err := eips.List(client, listOpts)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(elasticIPs))
+	th.AssertEquals(t, elasticIP.ID, elasticIPs[0].ID)
 }
 
 func TestEipLifecycle(t *testing.T) {

--- a/acceptance/openstack/networking/v1/helpers.go
+++ b/acceptance/openstack/networking/v1/helpers.go
@@ -81,7 +81,7 @@ func createEip(t *testing.T, client *golangsdk.ServiceClient, bandwidthSize int)
 
 	t.Logf("Created eip/bandwidth: %s", newEip.ID)
 
-	return &newEip
+	return newEip
 }
 
 func deleteEip(t *testing.T, client *golangsdk.ServiceClient, eipID string) {

--- a/openstack/networking/v1/eips/requests.go
+++ b/openstack/networking/v1/eips/requests.go
@@ -22,13 +22,13 @@ type ListOpts struct {
 	// Status indicates whether or not a ElasticIP is currently operational.
 	Status string `json:",omitempty"`
 
-	// Specifies the gateway of the subnet.
+	// PrivateIPAddress of the resource with assigned ElasticIP.
 	PrivateIPAddress string `json:",omitempty"`
 
-	// Specifies the IP address of DNS server 1 on the subnet.
+	// PortID of the resource with assigned ElasticIP.
 	PortID string `json:",omitempty"`
 
-	// Specifies the IP address of DNS server 2 on the subnet.
+	// BandwidthID of the ElasticIP.
 	BandwidthID string `json:",omitempty"`
 }
 

--- a/openstack/networking/v1/eips/requests.go
+++ b/openstack/networking/v1/eips/requests.go
@@ -1,6 +1,9 @@
 package eips
 
 import (
+	"encoding/json"
+	"reflect"
+
 	"github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
@@ -13,11 +16,20 @@ type ListOptsBuilder interface {
 
 // ListOpts filters the results returned by the List() function.
 type ListOpts struct {
-	// Marker specifies the start resource ID of pagination query
-	Marker string `q:"marker"`
+	// ID is the unique identifier for the ElasticIP.
+	ID string `json:",omitempty"`
 
-	// Limit specifies the number of records returned on each page.
-	Limit int `q:"limit"`
+	// Status indicates whether or not a ElasticIP is currently operational.
+	Status string `json:",omitempty"`
+
+	// Specifies the gateway of the subnet.
+	PrivateIPAddress string `json:",omitempty"`
+
+	// Specifies the IP address of DNS server 1 on the subnet.
+	PortID string `json:",omitempty"`
+
+	// Specifies the IP address of DNS server 2 on the subnet.
+	BandwidthID string `json:",omitempty"`
 }
 
 // ToEipListQuery formats a ListOpts into a query string.
@@ -30,20 +42,62 @@ func (opts ListOpts) ToEipListQuery() (string, error) {
 }
 
 // List instructs OpenStack to provide a list of flavors.
-func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]PublicIp, error) {
 	url := rootURL(client)
-	if opts != nil {
-		query, err := opts.ToEipListQuery()
-		if err != nil {
-			return pagination.Pager{Err: err}
-		}
-		url += query
-	}
-	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		p := EipPage{pagination.MarkerPageBase{PageResult: r}}
 		p.MarkerPageBase.Owner = p
 		return p
-	})
+	}).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	allPublicIPs, err := ExtractEips(pages)
+	if err != nil {
+		return nil, err
+	}
+
+	return FilterPublicIPs(allPublicIPs, opts)
+}
+
+func FilterPublicIPs(publicIPs []PublicIp, opts ListOpts) ([]PublicIp, error) {
+	matchOptsByte, err := json.Marshal(opts)
+	if err != nil {
+		return nil, err
+	}
+	var matchOpts map[string]interface{}
+	err = json.Unmarshal(matchOptsByte, &matchOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(matchOpts) == 0 {
+		return publicIPs, nil
+	}
+
+	var refinedPublicIPs []PublicIp
+	for _, publicIP := range publicIPs {
+		if publicIPMatchesFilter(&publicIP, matchOpts) {
+			refinedPublicIPs = append(refinedPublicIPs, publicIP)
+		}
+	}
+	return refinedPublicIPs, nil
+}
+
+func publicIPMatchesFilter(publicIP *PublicIp, filter map[string]interface{}) bool {
+	for key, expectedValue := range filter {
+		if getStructField(publicIP, key) != expectedValue {
+			return false
+		}
+	}
+	return true
+}
+
+func getStructField(v *PublicIp, field string) string {
+	r := reflect.ValueOf(v)
+	f := reflect.Indirect(r).FieldByName(field)
+	return f.String()
 }
 
 // ApplyOptsBuilder is an interface by which can build the request body of public ip

--- a/openstack/networking/v1/eips/results.go
+++ b/openstack/networking/v1/eips/results.go
@@ -10,12 +10,10 @@ type ApplyResult struct {
 	golangsdk.Result
 }
 
-func (r ApplyResult) Extract() (PublicIp, error) {
-	var ip struct {
-		Ip PublicIp `json:"publicip"`
-	}
-	err := r.Result.ExtractInto(&ip)
-	return ip.Ip, err
+func (r ApplyResult) Extract() (*PublicIp, error) {
+	s := new(PublicIp)
+	err := r.ExtractIntoStructPtr(s, "publicip")
+	return s, err
 }
 
 // PublicIp is a struct that represents a public ip
@@ -39,12 +37,10 @@ type GetResult struct {
 	golangsdk.Result
 }
 
-func (r GetResult) Extract() (PublicIp, error) {
-	var Ip struct {
-		Ip PublicIp `json:"publicip"`
-	}
-	err := r.Result.ExtractInto(&Ip)
-	return Ip.Ip, err
+func (r GetResult) Extract() (*PublicIp, error) {
+	s := new(PublicIp)
+	err := r.ExtractIntoStructPtr(s, "publicip")
+	return s, err
 }
 
 // DeleteResult is a struct of delete result
@@ -57,10 +53,10 @@ type UpdateResult struct {
 	golangsdk.Result
 }
 
-func (r UpdateResult) Extract() (PublicIp, error) {
-	var ip PublicIp
-	err := r.Result.ExtractIntoStructPtr(&ip, "publicip")
-	return ip, err
+func (r UpdateResult) Extract() (*PublicIp, error) {
+	s := new(PublicIp)
+	err := r.ExtractIntoStructPtr(s, "publicip")
+	return s, err
 }
 
 // EipPage is a single page of Flavor results.
@@ -88,9 +84,7 @@ func (r EipPage) LastMarker() (string, error) {
 
 // ExtractEips extracts and returns Public IPs. It is used while iterating over a public ips.
 func ExtractEips(r pagination.Page) ([]PublicIp, error) {
-	var s struct {
-		PublicIPs []PublicIp `json:"publicips"`
-	}
-	err := (r.(EipPage)).ExtractInto(&s)
-	return s.PublicIPs, err
+	var s []PublicIp
+	err := (r.(EipPage)).ExtractIntoSlicePtr(&s, "publicips")
+	return s, err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Add possibility to Filter Results in List request

### Which issue this PR fixes
Refers to: https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1022

```
=== RUN   TestEipList
    helpers.go:59: Attempting to create eip/bandwidth
    helpers.go:75: Waiting for eip c888dd6a-7748-4219-a5bd-8813d8e52a0b to be active
    helpers.go:82: Created eip/bandwidth: c888dd6a-7748-4219-a5bd-8813d8e52a0b
    helpers.go:88: Attempting to delete eip/bandwidth: c888dd6a-7748-4219-a5bd-8813d8e52a0b
    helpers.go:94: Waitting for eip c888dd6a-7748-4219-a5bd-8813d8e52a0b to be deleted
    helpers.go:99: Deleted eip/bandwidth: c888dd6a-7748-4219-a5bd-8813d8e52a0b
--- PASS: TestEipList (12.64s)
=== RUN   TestEipLifecycle
    helpers.go:59: Attempting to create eip/bandwidth
    helpers.go:75: Waiting for eip f583bfed-a810-42fa-91d0-91f4fe1c54fb to be active
    helpers.go:82: Created eip/bandwidth: f583bfed-a810-42fa-91d0-91f4fe1c54fb
    helpers.go:88: Attempting to delete eip/bandwidth: f583bfed-a810-42fa-91d0-91f4fe1c54fb
    helpers.go:94: Waitting for eip f583bfed-a810-42fa-91d0-91f4fe1c54fb to be deleted
    helpers.go:99: Deleted eip/bandwidth: f583bfed-a810-42fa-91d0-91f4fe1c54fb
--- PASS: TestEipLifecycle (8.20s)
=== RUN   TestEipTagsLifecycle
    helpers.go:59: Attempting to create eip/bandwidth
    helpers.go:75: Waiting for eip 00fa5ea1-d115-4d97-8521-1da613154ec3 to be active
    helpers.go:82: Created eip/bandwidth: 00fa5ea1-d115-4d97-8521-1da613154ec3
    eips_test.go:75: Assert of length between `createOptsTags` and `tags.Get()`
    helpers.go:88: Attempting to delete eip/bandwidth: 00fa5ea1-d115-4d97-8521-1da613154ec3
    helpers.go:94: Waitting for eip 00fa5ea1-d115-4d97-8521-1da613154ec3 to be deleted
    helpers.go:99: Deleted eip/bandwidth: 00fa5ea1-d115-4d97-8521-1da613154ec3
--- PASS: TestEipTagsLifecycle (12.42s)
PASS

Process finished with the exit code 0
```
