### PR TITLE
[VPC] Improve eips pkg List query

### DIFF
--- a/acceptance/openstack/networking/v1/eips_test.go
+++ b/acceptance/openstack/networking/v1/eips_test.go
@@ -30,6 +30,7 @@ func TestEipList(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, 1, len(elasticIPs))
 	th.AssertEquals(t, elasticIP.ID, elasticIPs[0].ID)
+	th.AssertEquals(t, elasticIP.PublicAddress, elasticIPs[0].PublicAddress)
 }
 
 func TestEipLifecycle(t *testing.T) {

--- a/openstack/networking/v1/eips/requests.go
+++ b/openstack/networking/v1/eips/requests.go
@@ -25,6 +25,9 @@ type ListOpts struct {
 	// PrivateIPAddress of the resource with assigned ElasticIP.
 	PrivateIPAddress string `json:",omitempty"`
 
+	// PublicIPAddress of the ElasticIP.
+	PublicIPAddress string `json:",omitempty"`
+
 	// PortID of the resource with assigned ElasticIP.
 	PortID string `json:",omitempty"`
 


### PR DESCRIPTION
Add possibility to query ElasticIPs with `PublicIP`

```
=== RUN   TestEipList
    helpers.go:59: Attempting to create eip/bandwidth
    helpers.go:75: Waiting for eip ac4ab428-1f22-4c46-b8bf-1b3f8b96f215 to be active
    helpers.go:82: Created eip/bandwidth: ac4ab428-1f22-4c46-b8bf-1b3f8b96f215
    helpers.go:88: Attempting to delete eip/bandwidth: ac4ab428-1f22-4c46-b8bf-1b3f8b96f215
    helpers.go:94: Waitting for eip ac4ab428-1f22-4c46-b8bf-1b3f8b96f215 to be deleted
    helpers.go:99: Deleted eip/bandwidth: ac4ab428-1f22-4c46-b8bf-1b3f8b96f215
--- PASS: TestEipList (12.80s)
=== RUN   TestEipLifecycle
    helpers.go:59: Attempting to create eip/bandwidth
    helpers.go:75: Waiting for eip bce24658-20c7-4a25-be40-24aeb2962b99 to be active
    helpers.go:82: Created eip/bandwidth: bce24658-20c7-4a25-be40-24aeb2962b99
    helpers.go:88: Attempting to delete eip/bandwidth: bce24658-20c7-4a25-be40-24aeb2962b99
    helpers.go:94: Waitting for eip bce24658-20c7-4a25-be40-24aeb2962b99 to be deleted
    helpers.go:99: Deleted eip/bandwidth: bce24658-20c7-4a25-be40-24aeb2962b99
--- PASS: TestEipLifecycle (8.28s)
=== RUN   TestEipTagsLifecycle
    helpers.go:59: Attempting to create eip/bandwidth
    helpers.go:75: Waiting for eip 9ba1e303-32a2-4417-9033-163069adb7c3 to be active
    helpers.go:82: Created eip/bandwidth: 9ba1e303-32a2-4417-9033-163069adb7c3
    eips_test.go:76: Assert of length between `createOptsTags` and `tags.Get()`
    helpers.go:88: Attempting to delete eip/bandwidth: 9ba1e303-32a2-4417-9033-163069adb7c3
    helpers.go:94: Waitting for eip 9ba1e303-32a2-4417-9033-163069adb7c3 to be deleted
    helpers.go:99: Deleted eip/bandwidth: 9ba1e303-32a2-4417-9033-163069adb7c3
--- PASS: TestEipTagsLifecycle (12.55s)
PASS

Process finished with the exit code 0
```