### PR TITLE
Add possibility to enable `port_security`

### DIFF
--- a/acceptance/openstack/networking/v2/ports/helpers.go
+++ b/acceptance/openstack/networking/v2/ports/helpers.go
@@ -1,0 +1,27 @@
+package ports
+
+import (
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/networks"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func CreateNetwork(t *testing.T, client *golangsdk.ServiceClient) *networks.Network {
+	createName := tools.RandomString("network-", 3)
+	createOpts := networks.CreateOpts{
+		Name: createName,
+	}
+
+	network, err := networks.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	return network
+}
+
+func DeleteNetwork(t *testing.T, client *golangsdk.ServiceClient, networkID string) {
+	err := networks.Delete(client, networkID).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/acceptance/openstack/networking/v2/ports/ports_test.go
+++ b/acceptance/openstack/networking/v2/ports/ports_test.go
@@ -1,0 +1,69 @@
+package ports
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/ports"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestPortList(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	listOpts := ports.ListOpts{}
+	portPages, err := ports.List(client, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+	portList, err := ports.ExtractPorts(portPages)
+	th.AssertNoErr(t, err)
+
+	for _, port := range portList {
+		tools.PrintResource(t, port)
+	}
+}
+
+func TestPortLifecycle(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	network := CreateNetwork(t, client)
+	defer DeleteNetwork(t, client, network.ID)
+
+	createName := tools.RandomString("create-port-", 3)
+	adminStateUp := true
+	portSecurity := false
+	createOpts := ports.CreateOpts{
+		NetworkID:    network.ID,
+		Name:         createName,
+		AdminStateUp: &adminStateUp,
+		PortSecurity: &portSecurity,
+	}
+
+	port, err := ports.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, port)
+	th.AssertEquals(t, true, port.AdminStateUp)
+	th.AssertEquals(t, false, port.PortSecurity)
+	defer func() {
+		err := ports.Delete(client, port.ID).ExtractErr()
+		th.AssertNoErr(t, err)
+	}()
+
+	updateName := tools.RandomString("update-port-", 3)
+	portSecurity = true
+	updateOpts := &ports.UpdateOpts{
+		Name:         updateName,
+		PortSecurity: &portSecurity,
+	}
+
+	_, err = ports.Update(client, port.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	newPort, err := ports.Get(client, port.ID).Extract()
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, newPort)
+	th.AssertEquals(t, updateName, newPort.Name)
+	th.AssertEquals(t, true, newPort.PortSecurity)
+}

--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -88,6 +88,12 @@ type CreateOpts struct {
 	ProjectID           string        `json:"project_id,omitempty"`
 	SecurityGroups      *[]string     `json:"security_groups,omitempty"`
 	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs,omitempty"`
+	PortSecurity        *bool         `json:"port_security_enabled,omitempty"`
+}
+
+type ExtraDHCPOpts struct {
+	OptName  string `json:"opt_name,omitempty"`
+	OptValue string `json:"opt_value,omitempty"`
 }
 
 // ToPortCreateMap builds a request body from CreateOpts.
@@ -122,6 +128,7 @@ type UpdateOpts struct {
 	DeviceOwner         string         `json:"device_owner,omitempty"`
 	SecurityGroups      *[]string      `json:"security_groups,omitempty"`
 	AllowedAddressPairs *[]AddressPair `json:"allowed_address_pairs,omitempty"`
+	PortSecurity        *bool          `json:"port_security_enabled,omitempty"`
 }
 
 // ToPortUpdateMap builds a request body from UpdateOpts.

--- a/openstack/networking/v2/ports/results.go
+++ b/openstack/networking/v2/ports/results.go
@@ -101,6 +101,9 @@ type Port struct {
 
 	// Identifies the list of IP addresses the port will recognize/accept
 	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs"`
+
+	// Identifies the security option is enabled for the port.
+	PortSecurity bool `json:"port_security_enabled"`
 }
 
 // PortPage is the page returned by a pager when traversing over a collection


### PR DESCRIPTION
### What this PR does / why we need it
Add possibility to `enable/disable` networking_port_v2 security

### Which issue this PR fixes
Refers to: https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1043

### Acceptance tests

```
=== RUN   TestPortList
--- PASS: TestPortList (2.49s)
=== RUN   TestPortLifecycle
    helpers.go:17: Attempting to create network: network-a37
    helpers.go:22: Created network: 3c5ca8c7-50ba-48d9-8d77-9b27c918fb61
    ports_test.go:44: Attempting to create networking port: create-port-49v
    ports_test.go:56: Created networking port: eef4c60f-5c6f-4a6e-9c63-4bcd0ca1dbaa
    ports_test.go:65: Attempting to update networking port: eef4c60f-5c6f-4a6e-9c63-4bcd0ca1dbaa
    ports_test.go:70: Updated networking port: eef4c60f-5c6f-4a6e-9c63-4bcd0ca1dbaa
    helpers.go:28: Attempting to delete network: 3c5ca8c7-50ba-48d9-8d77-9b27c918fb61
    helpers.go:32: Deleted network: 3c5ca8c7-50ba-48d9-8d77-9b27c918fb61
--- PASS: TestPortLifecycle (7.01s)
```