### PR TITLE
Add `spec.type` to Node Pool create opts

### DIFF
--- a/openstack/cce/v3/nodepools/requests.go
+++ b/openstack/cce/v3/nodepools/requests.go
@@ -108,6 +108,8 @@ type CreateMetaData struct {
 
 // CreateSpec describes Node pools specification
 type CreateSpec struct {
+	// Node pool type. Currently, only `vm`(ECSs) are supported.
+	Type string `json:"type" required:"true"`
 	// Node template
 	NodeTemplate nodes.Spec `json:"nodeTemplate" required:"true"`
 	// Initial number of expected nodes

--- a/openstack/cce/v3/nodepools/results.go
+++ b/openstack/cce/v3/nodepools/results.go
@@ -5,7 +5,7 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/nodes"
 )
 
-// Describes the Node Pool Structure of cluster
+// ListNodePool - Describes the Node Pool Structure of cluster
 type ListNodePool struct {
 	// API type, fixed value "List"
 	Kind string `json:"kind"`
@@ -15,8 +15,10 @@ type ListNodePool struct {
 	NodePools []NodePool `json:"items"`
 }
 
-// Individual node pools of the cluster
+// NodePool - Individual node pools of the cluster
 type NodePool struct {
+	// Node pool type
+	Type string `json:"type" required:"true"`
 	//  API type, fixed value " Host "
 	Kind string `json:"kind"`
 	// API version, fixed value v3
@@ -37,7 +39,7 @@ type Metadata struct {
 	Id string `json:"uid"`
 }
 
-// Gives the current status of the node pool
+// Status - Gives the current status of the node pool
 type Status struct {
 	// The state of the node pool
 	Phase string `json:"phase"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Add `spec.type` to Node Pool create arguments

Fix  #152