### PR TITLE
[RDS] Update schema in results

### DIFF
--- a/acceptance/openstack/rds/v3/rds_test.go
+++ b/acceptance/openstack/rds/v3/rds_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/rds/v3/instances"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
@@ -35,8 +36,20 @@ func TestRdsLifecycle(t *testing.T) {
 	// Create RDSv3 instance
 	rds := createRDS(t, client, cc.RegionName)
 	defer deleteRDS(t, client, rds.Id)
+	th.AssertEquals(t, rds.Volume.Size, 100)
 
-	tools.PrintResource(t, rds)
+	tagList := []tags.ResourceTag{
+		{
+			Key:   "muh",
+			Value: "value-create",
+		},
+		{
+			Key:   "kuh",
+			Value: "value-create",
+		},
+	}
+	err = tags.Create(client, "instances", rds.Id, tagList).ExtractErr()
+	th.AssertNoErr(t, err)
 
 	err = updateRDS(t, client, rds.Id)
 	th.AssertNoErr(t, err)
@@ -49,5 +62,6 @@ func TestRdsLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 	newRds, err := instances.ExtractRdsInstances(allPages)
 	th.AssertNoErr(t, err)
-	tools.PrintResource(t, newRds)
+	th.AssertEquals(t, newRds.Instances[0].Volume.Size, 200)
+	th.AssertEquals(t, len(newRds.Instances[0].Tags), 2)
 }

--- a/acceptance/openstack/rds/v3/rds_test.go
+++ b/acceptance/openstack/rds/v3/rds_test.go
@@ -62,6 +62,7 @@ func TestRdsLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 	newRds, err := instances.ExtractRdsInstances(allPages)
 	th.AssertNoErr(t, err)
+	th.AssertEquals(t, len(newRds.Instances), 1)
 	th.AssertEquals(t, newRds.Instances[0].Volume.Size, 200)
 	th.AssertEquals(t, len(newRds.Instances[0].Tags), 2)
 }

--- a/openstack/rds/v3/instances/results.go
+++ b/openstack/rds/v3/instances/results.go
@@ -2,6 +2,7 @@ package instances
 
 import (
 	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
 
@@ -126,12 +127,8 @@ type RdsInstanceResponse struct {
 	DiskEncryptionId    string            `json:"disk_encryption_id"`
 	EnterpriseProjectId string            `json:"enterprise_project_id"`
 	TimeZone            string            `json:"time_zone"`
-	Tags                []Tag             `json:"tags"`
-}
 
-type Tag struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Tags []tags.ResourceTag `json:"tags"`
 }
 
 type Nodes struct {

--- a/openstack/rds/v3/instances/results.go
+++ b/openstack/rds/v3/instances/results.go
@@ -126,6 +126,12 @@ type RdsInstanceResponse struct {
 	DiskEncryptionId    string            `json:"disk_encryption_id"`
 	EnterpriseProjectId string            `json:"enterprise_project_id"`
 	TimeZone            string            `json:"time_zone"`
+	Tags                []Tag             `json:"tags"`
+}
+
+type Tag struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 type Nodes struct {


### PR DESCRIPTION
### What this PR does / why we need it
Update RDSv3 instance results schema with `tags` field

### Which issue this PR fixes
Fixes: #154 

### Acceptance test
```
=== RUN   TestRdsLifecycle
    helpers.go:16: Attempting to create RDSv3
    helpers.go:60: Created RDSv3: adc5362db08f43448e1732815ea075eein03
    helpers.go:75: Attempting to increase volume size
    helpers.go:77: Update volume size could be done only in status `available`
    helpers.go:94: RDSv3 successfully updated: adc5362db08f43448e1732815ea075eein03
    helpers.go:66: Attempting to delete RDSv3: adc5362db08f43448e1732815ea075eein03
    helpers.go:71: RDSv3 instance deleted: adc5362db08f43448e1732815ea075eein03
--- PASS: TestRdsLifecycle (552.77s)
```
