### PR TITLE
Add TOTP support for IAM

### DIFF
--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -438,15 +438,15 @@ type cc struct {
 func CloudAndClient() (*cc, error) {
 	cloud, err := EnvOS.Cloud()
 	if err != nil {
-		return nil, fmt.Errorf("error constructing cloud configuration: %s", err)
+		return nil, fmt.Errorf("error constructing cloud configuration: %w", err)
 	}
 	cloud, err = copyCloud(cloud)
 	if err != nil {
-		return nil, fmt.Errorf("error copying cloud: %s", err)
+		return nil, fmt.Errorf("error copying cloud: %w", err)
 	}
 	client, err := EnvOS.AuthenticatedClient()
 	if err != nil {
-		return nil, fmt.Errorf("error authenticating client")
+		return nil, err
 	}
 	return &cc{cloud, client}, nil
 }

--- a/errors.go
+++ b/errors.go
@@ -120,10 +120,16 @@ func (e ErrDefault400) Error() string {
 	return e.choseErrString()
 }
 func (e ErrDefault401) Error() string {
-	return "Authentication failed"
+	e.DefaultErrString = fmt.Sprintf(
+		"Authentication Failed, error message: %s", e.Body,
+	)
+	return e.choseErrString()
 }
 func (e ErrDefault403) Error() string {
-	return "Action Forbidden"
+	e.DefaultErrString = fmt.Sprintf(
+		"Action Forbidden, error message: %s", e.Body,
+	)
+	return e.choseErrString()
 }
 func (e ErrDefault404) Error() string {
 	e.DefaultErrString = fmt.Sprintf(
@@ -316,10 +322,6 @@ func redundantWithTokenErr(attribute string) string {
 	return fmt.Sprintf("%s may not be provided when authenticating with a TokenID", attribute)
 }
 
-func redundantWithUserID(attribute string) string {
-	return fmt.Sprintf("%s may not be provided when authenticating with a UserID", attribute)
-}
-
 // ErrAPIKeyProvided indicates that an APIKey was provided but can't be used.
 type ErrAPIKeyProvided struct{ BaseError }
 
@@ -376,20 +378,6 @@ func (e ErrUsernameOrUserID) Error() string {
 	return "Exactly one of Username and UserID must be provided for password authentication"
 }
 
-// ErrDomainIDWithUserID indicates that a DomainID was provided, but unnecessary because a UserID is being used.
-type ErrDomainIDWithUserID struct{ BaseError }
-
-func (e ErrDomainIDWithUserID) Error() string {
-	return redundantWithUserID("DomainID")
-}
-
-// ErrDomainNameWithUserID indicates that a DomainName was provided, but unnecessary because a UserID is being used.
-type ErrDomainNameWithUserID struct{ BaseError }
-
-func (e ErrDomainNameWithUserID) Error() string {
-	return redundantWithUserID("DomainName")
-}
-
 // ErrDomainIDOrDomainName indicates that a username was provided, but no domain to scope it.
 // It may also indicate that both a DomainID and a DomainName were provided at once.
 type ErrDomainIDOrDomainName struct{ BaseError }
@@ -431,4 +419,10 @@ type ErrScopeEmpty struct{ BaseError }
 
 func (e ErrScopeEmpty) Error() string {
 	return "You must provide either a Project or Domain in a Scope"
+}
+
+type ErrUserIDNotFound struct{ BaseError }
+
+func (e ErrUserIDNotFound) Error() string {
+	return "You must provide UserID for MFA"
 }

--- a/openstack/auth_env.go
+++ b/openstack/auth_env.go
@@ -44,6 +44,7 @@ func AuthOptionsFromEnv(envs ...*env) (golangsdk.AuthOptions, error) {
 		AgencyName:       e.GetEnv("AGENCY_NAME", "TARGET_AGENCY_NAME"),
 		AgencyDomainName: e.GetEnv("AGENCY_DOMAIN_NAME", "TARGET_DOMAIN_NAME"),
 		DelegatedProject: e.GetEnv("DELEGATED_PROJECT", "TARGET_DOMAIN_NAME"),
+		Passcode:         e.GetEnv("PASSCODE"),
 	}
 	return ao, nil
 }

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"reflect"
 	"regexp"
 	"strings"
@@ -89,8 +90,7 @@ func AuthenticatedClient(options golangsdk.AuthOptionsProvider) (*golangsdk.Prov
 		return nil, err
 	}
 
-	err = Authenticate(client, options)
-	if err != nil {
+	if err := Authenticate(client, options); err != nil {
 		return nil, err
 	}
 	return client, nil
@@ -113,6 +113,8 @@ func Authenticate(client *golangsdk.ProviderClient, options golangsdk.AuthOption
 	if isTokenAuthOptions {
 		switch chosen.ID {
 		case v3:
+			authOptions.Passcode = os.Getenv("OS_PASSCODE")
+
 			if authOptions.AgencyDomainName != "" && authOptions.AgencyName != "" {
 				return v3authWithAgency(client, endpoint, &authOptions, golangsdk.EndpointOpts{})
 			}
@@ -171,17 +173,17 @@ func v3auth(client *golangsdk.ProviderClient, endpoint string, opts tokens3.Auth
 
 	token, err := result.ExtractToken()
 	if err != nil {
-		return fmt.Errorf("error extracting token: %s", err)
+		return fmt.Errorf("error extracting token: %w", err)
 	}
 
 	project, err := result.ExtractProject()
 	if err != nil {
-		return fmt.Errorf("error extracting project info: %s", err)
+		return fmt.Errorf("error extracting project info: %w", err)
 	}
 
 	user, err := result.ExtractUser()
 	if err != nil {
-		return fmt.Errorf("error extracting user info: %s", err)
+		return fmt.Errorf("error extracting user info: %w", err)
 	}
 
 	serviceCatalog, err := result.ExtractServiceCatalog()

--- a/openstack/identity/v3/tokens/requests.go
+++ b/openstack/identity/v3/tokens/requests.go
@@ -1,6 +1,8 @@
 package tokens
 
-import "github.com/opentelekomcloud/gophertelekomcloud"
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+)
 
 // Scope allows a created token to be limited to a specific domain or project.
 type Scope struct {
@@ -54,6 +56,9 @@ type AuthOptions struct {
 	// authentication token ID.
 	TokenID string `json:"-"`
 
+	// Passcode is a Virtual MFA device verification code, which can be obtained on the MFA app.
+	Passcode string `json:"-"`
+
 	Scope Scope `json:"-"`
 }
 
@@ -67,12 +72,13 @@ func (opts *AuthOptions) ToTokenV3CreateMap(scope map[string]interface{}) (map[s
 		DomainName:  opts.DomainName,
 		AllowReauth: opts.AllowReauth,
 		TokenID:     opts.TokenID,
+		Passcode:    opts.Passcode,
 	}
 
 	return golangsdkAuthOpts.ToTokenV3CreateMap(scope)
 }
 
-// ToTokenV3CreateMap builds a scope request body from AuthOptions.
+// ToTokenV3ScopeMap builds a scope request body from AuthOptions.
 func (opts *AuthOptions) ToTokenV3ScopeMap() (map[string]interface{}, error) {
 	if opts.Scope.ProjectName != "" {
 		// ProjectName provided: either DomainID or DomainName must also be supplied.

--- a/openstack/identity/v3/tokens/testing/requests_test.go
+++ b/openstack/identity/v3/tokens/testing/requests_test.go
@@ -350,24 +350,6 @@ func TestCreateFailureBothDomain(t *testing.T) {
 	authTokenPostErr(t, options, nil, false, golangsdk.ErrDomainIDOrDomainName{})
 }
 
-func TestCreateFailureUserIDDomainID(t *testing.T) {
-	options := tokens.AuthOptions{
-		UserID:   "100",
-		Password: "stuff",
-		DomainID: "oops",
-	}
-	authTokenPostErr(t, options, nil, false, golangsdk.ErrDomainIDWithUserID{})
-}
-
-func TestCreateFailureUserIDDomainName(t *testing.T) {
-	options := tokens.AuthOptions{
-		UserID:     "100",
-		Password:   "sssh",
-		DomainName: "oops",
-	}
-	authTokenPostErr(t, options, nil, false, golangsdk.ErrDomainNameWithUserID{})
-}
-
 func TestCreateFailureScopeProjectNameAlone(t *testing.T) {
 	options := tokens.AuthOptions{UserID: "myself", Password: "swordfish"}
 	scope := &tokens.Scope{ProjectName: "notenough"}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it

Add `Passcode` auth option, env var: `OS_PASSCODE`

Add `topt` + `password` auth method

Make `401` and `403` errors more verbose

Remove redundant errors

Simplify some error messages

Enable token acceptance tests

Other style fixes

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->
Resolves #163 

### Acceptance

#### Token test with MFA enabled
```
=== RUN   TestGetToken
--- PASS: TestGetToken (3.02s)
PASS

Process finished with the exit code 0
```

