### PR TITLE
Remove redundant `Env` interface

### DIFF
--- a/openstack/auth_env.go
+++ b/openstack/auth_env.go
@@ -25,7 +25,7 @@ by sourcing an `openrc` file), then:
 	opts, err := openstack.AuthOptionsFromEnv()
 	provider, err := openstack.AuthenticatedClient(opts)
 */
-func AuthOptionsFromEnv(envs ...*env) (golangsdk.AuthOptions, error) {
+func AuthOptionsFromEnv(envs ...*Env) (golangsdk.AuthOptions, error) {
 	e := NewEnv(defaultPrefix)
 	if len(envs) > 0 {
 		e = envs[0]

--- a/openstack/loader_test.go
+++ b/openstack/loader_test.go
@@ -65,7 +65,7 @@ func restoreBackup(t *testing.T, files ...string) {
 	}
 }
 
-func checkLazyness(t *testing.T, env Env, expected bool) {
+func checkLazyness(t *testing.T, env *Env, expected bool) {
 	authUrl0 := "http://url:0"
 	_ = os.Setenv("OS_AUTH_URL", authUrl0)
 	cloud0, err := env.Cloud()


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
The single-use interface is considered an incorrect approach:
https://github.com/golang/go/wiki/CodeReviewComments#interfaces

NB! b/w compatibility can be broken
