### PR TITLE
[CCE] Add possibility to encrypt data volumes

### DIFF
--- a/openstack/cce/v3/nodes/requests.go
+++ b/openstack/cce/v3/nodes/requests.go
@@ -86,20 +86,19 @@ type FilterStruct struct {
 	Driller []string
 }
 
-// CreateOptsBuilder allows extensions to add additional parameters to the
-// Create request.
+// CreateOpts is a struct contains the parameters of creating Node
 type CreateOpts struct {
 	// API type, fixed value Node
 	Kind string `json:"kind" required:"true"`
 	// API version, fixed value v3
-	ApiVersion string `json:"apiversion" required:"true"`
+	ApiVersion string `json:"apiVersion" required:"true"`
 	// Metadata required to create a Node
 	Metadata CreateMetaData `json:"metadata"`
 	// specifications to create a Node
 	Spec Spec `json:"spec" required:"true"`
 }
 
-// Metadata required to create a Node
+// CreateMetaData required to create a Node
 type CreateMetaData struct {
 	// Node name
 	Name string `json:"name,omitempty"`
@@ -109,9 +108,8 @@ type CreateMetaData struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
-// Create accepts a CreateOpts struct and uses the values to create a new
-// logical Node. When it is created, the Node does not have an internal
-// interface
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
 type CreateOptsBuilder interface {
 	ToNodeCreateMap() (map[string]interface{}, error)
 }
@@ -123,20 +121,20 @@ func (opts CreateOpts) ToNodeCreateMap() (map[string]interface{}, error) {
 
 // Create accepts a CreateOpts struct and uses the values to create a new
 // logical node.
-func Create(c *golangsdk.ServiceClient, clusterid string, opts CreateOptsBuilder) (r CreateResult) {
+func Create(c *golangsdk.ServiceClient, clusterID string, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToNodeCreateMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
 	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{201}}
-	_, r.Err = c.Post(rootURL(c, clusterid), b, &r.Body, reqOpt)
+	_, r.Err = c.Post(rootURL(c, clusterID), b, &r.Body, reqOpt)
 	return
 }
 
 // Get retrieves a particular nodes based on its unique ID and cluster ID.
-func Get(c *golangsdk.ServiceClient, clusterid, nodeid string) (r GetResult) {
-	_, r.Err = c.Get(resourceURL(c, clusterid, nodeid), &r.Body, &golangsdk.RequestOpts{
+func Get(c *golangsdk.ServiceClient, clusterID, nodeID string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, clusterID, nodeID), &r.Body, &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
 		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: nil,
 	})
@@ -164,21 +162,21 @@ func (opts UpdateOpts) ToNodeUpdateMap() (map[string]interface{}, error) {
 }
 
 // Update allows nodes to be updated.
-func Update(c *golangsdk.ServiceClient, clusterid, nodeid string, opts UpdateOptsBuilder) (r UpdateResult) {
+func Update(c *golangsdk.ServiceClient, clusterID, nodeID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToNodeUpdateMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
-	_, r.Err = c.Put(resourceURL(c, clusterid, nodeid), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = c.Put(resourceURL(c, clusterID, nodeID), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{200},
 	})
 	return
 }
 
 // Delete will permanently delete a particular node based on its unique ID and cluster ID.
-func Delete(c *golangsdk.ServiceClient, clusterid, nodeid string) (r DeleteResult) {
-	_, r.Err = c.Delete(resourceURL(c, clusterid, nodeid), &golangsdk.RequestOpts{
+func Delete(c *golangsdk.ServiceClient, clusterID, nodeID string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, clusterID, nodeID), &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
 		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: nil,
 	})
@@ -186,8 +184,8 @@ func Delete(c *golangsdk.ServiceClient, clusterid, nodeid string) (r DeleteResul
 }
 
 // GetJobDetails retrieves a particular job based on its unique ID
-func GetJobDetails(c *golangsdk.ServiceClient, jobid string) (r GetResult) {
-	_, r.Err = c.Get(getJobURL(c, jobid), &r.Body, &golangsdk.RequestOpts{
+func GetJobDetails(c *golangsdk.ServiceClient, jobID string) (r GetResult) {
+	_, r.Err = c.Get(getJobURL(c, jobID), &r.Body, &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
 		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: nil,
 	})

--- a/openstack/cce/v3/nodes/results.go
+++ b/openstack/cce/v3/nodes/results.go
@@ -5,7 +5,7 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
 )
 
-// Describes the Node Structure of cluster
+// ListNode describes the Node Structure of cluster
 type ListNode struct {
 	// API type, fixed value "List"
 	Kind string `json:"kind"`
@@ -15,7 +15,7 @@ type ListNode struct {
 	Nodes []Nodes `json:"items"`
 }
 
-// Individual nodes of the cluster
+// Nodes of the cluster
 type Nodes struct {
 	//  API type, fixed value " Host "
 	Kind string `json:"kind"`
@@ -37,7 +37,7 @@ type Metadata struct {
 	Id string `json:"uid"`
 	// Node tag, key value pair format
 	Labels map[string]string `json:"labels,omitempty"`
-	// Node annotation, keyvalue pair format
+	// Node annotation, key/value pair format
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
@@ -77,13 +77,13 @@ type Spec struct {
 	Taints []TaintSpec `json:"taints,omitempty"`
 }
 
-// Gives the Nic spec of the node
+// NodeNicSpec spec of the node
 type NodeNicSpec struct {
 	// The primary Nic of the Node
 	PrimaryNic PrimaryNic `json:"primaryNic,omitempty"`
 }
 
-// Gives the Primary Nic of the node
+// PrimaryNic of the node
 type PrimaryNic struct {
 	// The Subnet ID of the primary Nic
 	SubnetId string `json:"subnetId,omitempty"`
@@ -100,7 +100,7 @@ type TaintSpec struct {
 	Effect string `json:"effect" required:"true"`
 }
 
-// Gives the current status of the node
+// Status gives the current status of the node
 type Status struct {
 	// The state of the Node
 	Phase string `json:"phase"`
@@ -133,10 +133,12 @@ type UserPassword struct {
 }
 
 type VolumeSpec struct {
-	// Disk size in GB
+	// Disk Size in GB
 	Size int `json:"size" required:"true"`
-	// Disk type
+	// Disk VolumeType
 	VolumeType string `json:"volumetype" required:"true"`
+	// Metadata contains data disk encryption information
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 	// Disk extension parameter
 	ExtendParam string `json:"extendParam,omitempty"`
 }
@@ -191,7 +193,7 @@ type Conditions struct {
 	Reason string `json:"reason"`
 }
 
-// Describes the Job Structure
+// Job Structure
 type Job struct {
 	// API type, fixed value "Job"
 	Kind string `json:"kind"`

--- a/openstack/cce/v3/nodes/testing/requests_test.go
+++ b/openstack/cce/v3/nodes/testing/requests_test.go
@@ -130,13 +130,13 @@ func TestCreateV3Node(t *testing.T) {
 
 		th.TestJSONRequest(t, r, `
 			{
-	  "apiversion": "v3",
+	  "apiVersion": "v3",
 	  "kind": "Node",
 	  "metadata": {
 	    "name": "test-node"
 	  },
 	  "spec": {
-	    "az": "cn-east-2a",
+	    "az": "eu-de-01",
 	    "count": 1,
         "extendParam": {
         },
@@ -177,11 +177,23 @@ func TestCreateV3Node(t *testing.T) {
 	options := nodes.CreateOpts{Kind: "Node",
 		ApiVersion: "v3",
 		Metadata:   nodes.CreateMetaData{Name: "test-node"},
-		Spec: nodes.Spec{Flavor: "s3.large.2", Az: "cn-east-2a",
-			Login:       nodes.LoginSpec{SshKey: "test-keypair"},
-			RootVolume:  nodes.VolumeSpec{Size: 40, VolumeType: "SATA"},
-			DataVolumes: []nodes.VolumeSpec{{Size: 100, VolumeType: "SATA"}},
-			Count:       1},
+		Spec: nodes.Spec{
+			Flavor: "s3.large.2", Az: "eu-de-01",
+			Login: nodes.LoginSpec{
+				SshKey: "test-keypair",
+			},
+			RootVolume: nodes.VolumeSpec{
+				Size:       40,
+				VolumeType: "SATA",
+			},
+			DataVolumes: []nodes.VolumeSpec{
+				{
+					Size:       100,
+					VolumeType: "SATA",
+				},
+			},
+			Count: 1,
+		},
 	}
 	actual, err := nodes.Create(fake.ServiceClient(), "cec124c2-58f1-11e8-ad73-0255ac101926", options).Extract()
 	th.AssertNoErr(t, err)


### PR DESCRIPTION
### What this PR does / why we need it
Add possibility to set data volume `metadata` for encryption with KMS

### Which issue this PR fixes
Refers to: https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1109

```
=== RUN   TestNodes
--- PASS: TestNodes (731.13s)
=== RUN   TestNodes/TestNodeLifecycle
    --- PASS: TestNodes/TestNodeLifecycle (341.20s)
PASS

Process finished with the exit code 0
```