### PR TITLE
[WAF] Implement missing TLS settings in requests

### DIFF
--- a/acceptance/openstack/waf/v1/domains_test.go
+++ b/acceptance/openstack/waf/v1/domains_test.go
@@ -84,6 +84,7 @@ func TestDomainLifecycle(t *testing.T) {
 				Port:           443,
 			},
 		},
+		Cipher:        "cipher_2",
 		Proxy:         &iTrue,
 		SipHeaderName: "default",
 		SipHeaderList: []string{"X-Forwarded-For"},
@@ -94,6 +95,7 @@ func TestDomainLifecycle(t *testing.T) {
 	th.AssertEquals(t, createOpts.HostName, domain.HostName)
 	th.AssertEquals(t, cert.Id, domain.CertificateId)
 	th.AssertEquals(t, len(createOpts.Server), len(domain.Server))
+	th.AssertEquals(t, createOpts.Cipher, domain.Cipher)
 
 	updateOpts := domains.UpdateOpts{
 		TLS:    "TLS v1.1",

--- a/acceptance/openstack/waf/v1/domains_test.go
+++ b/acceptance/openstack/waf/v1/domains_test.go
@@ -5,6 +5,7 @@ import (
 
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/waf/v1/certificates"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/waf/v1/domains"
@@ -14,68 +15,53 @@ import (
 
 func prepareIp(t *testing.T) *floatingips.FloatingIP {
 	client, err := clients.NewNetworkV2Client()
-	if err != nil {
-		t.Errorf("fail to make network v2 client: %s", err)
-	}
+	th.AssertNoErr(t, err)
 	ip, err := floatingips.Create(client, floatingips.CreateOpts{
 		FloatingNetworkID: "0a2228f2-7f8a-45f1-8e09-9039e1d09975", // this value is hardcoded in tf OTC provider
 	}).Extract()
-	if err != nil {
-		t.Errorf("fail to create floating IP: %s", err)
-	}
+	th.AssertNoErr(t, err)
 	return ip
 }
 
 func preparePolicy(t *testing.T, client *golangsdk.ServiceClient) *policies.Policy {
-	cert, err := policies.Create(client, policies.CreateOpts{Name: "waf_policy_1"}).Extract()
-	if err != nil {
-		t.Errorf("fail to create WAF policy: %s", err)
-	}
+	randomName := tools.RandomString("waf_policy_", 3)
+	cert, err := policies.Create(client, policies.CreateOpts{Name: randomName}).Extract()
+	th.AssertNoErr(t, err)
 	return cert
 }
 
 func prepareCertificate(t *testing.T, client *golangsdk.ServiceClient) *certificates.Certificate {
+	randomName := tools.RandomString("waf_cert_", 3)
 	cert, err := certificates.Create(client, certificates.CreateOpts{
-		Name:    "waf_cert_1",
+		Name:    randomName,
 		Content: testCert,
 		Key:     testKey,
 	}).Extract()
-	if err != nil {
-		t.Errorf("fail to create WAF certificate: %s", err)
-	}
+	th.AssertNoErr(t, err)
 	return cert
 }
 
 func cleanupIP(t *testing.T, ipID string) {
 	client, err := clients.NewNetworkV2Client()
-	if err != nil {
-		t.Errorf("fail to make network v2 client: %s", err)
-	}
+	th.AssertNoErr(t, err)
 	err = floatingips.Delete(client, ipID).ExtractErr()
-	if err != nil {
-		t.Errorf("fail to delete floating IP: %s", err)
-	}
+	th.AssertNoErr(t, err)
 }
 
 func cleanupPolicy(t *testing.T, client *golangsdk.ServiceClient, policyID string) {
 	err := policies.Delete(client, policyID).ExtractErr()
-	if err != nil {
-		t.Errorf("fail to remove WAF policy: %s", err)
-	}
+	th.AssertNoErr(t, err)
 }
+
 func cleanupCertificate(t *testing.T, client *golangsdk.ServiceClient, certID string) {
 	err := certificates.Delete(client, certID).ExtractErr()
-	if err != nil {
-		t.Errorf("fail to remove WAF certificate: %s", err)
-	}
+	th.AssertNoErr(t, err)
 }
 
 // TestDomainLifecycle is simple "all-in-one" test for waf domain
 func TestDomainLifecycle(t *testing.T) {
 	client, err := clients.NewWafV1Client()
-	if err != nil {
-		t.Fatalf("Unable to create a WAFv1 client: %s", err)
-	}
+	th.AssertNoErr(t, err)
 
 	ip := prepareIp(t)
 	defer cleanupIP(t, ip.ID)
@@ -87,23 +73,36 @@ func TestDomainLifecycle(t *testing.T) {
 	defer cleanupPolicy(t, client, policy.Id)
 
 	iTrue := true
-	domain, err := domains.Create(client, domains.CreateOpts{
+	createOpts := domains.CreateOpts{
 		HostName:      "a.com",
 		CertificateId: cert.Id,
 		Server: []domains.ServerOpts{
 			{
 				ClientProtocol: "HTTPS",
-				ServerProtocol: "HTTP",
+				ServerProtocol: "HTTPS",
 				Address:        ip.FloatingIP,
-				Port:           80,
+				Port:           443,
 			},
 		},
 		Proxy:         &iTrue,
 		SipHeaderName: "default",
 		SipHeaderList: []string{"X-Forwarded-For"},
-	}).Extract()
-	th.AssertNoErr(t, err)
-	if err := domains.Delete(client, domain.Id).ExtractErr(); err != nil {
-		t.Errorf("failed to delete domain: %s", err)
 	}
+
+	domain, err := domains.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, createOpts.HostName, domain.HostName)
+	th.AssertEquals(t, cert.Id, domain.CertificateId)
+	th.AssertEquals(t, len(createOpts.Server), len(domain.Server))
+
+	updateOpts := domains.UpdateOpts{
+		TLS:    "TLS v1.1",
+		Cipher: "cipher_1",
+	}
+	domain, err = domains.Update(client, domain.Id, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, updateOpts.Cipher, domain.Cipher)
+
+	err = domains.Delete(client, domain.Id).ExtractErr()
+	th.AssertNoErr(t, err)
 }

--- a/openstack/waf/v1/domains/requests.go
+++ b/openstack/waf/v1/domains/requests.go
@@ -21,6 +21,10 @@ type CreateOpts struct {
 	Server []ServerOpts `json:"server" required:"true"`
 	// Whether proxy is configured
 	Proxy *bool `json:"proxy" required:"true"`
+	// TLS version
+	TLS string `json:"tls,omitempty"`
+	// Cipher suite version
+	Cipher string `json:"cipher,omitempty"`
 	// The type of the source IP header
 	SipHeaderName string `json:"sip_header_name,omitempty"`
 	// The HTTP request header for identifying the real source IP.

--- a/openstack/waf/v1/domains/requests.go
+++ b/openstack/waf/v1/domains/requests.go
@@ -69,6 +69,10 @@ type UpdateOpts struct {
 	Server []ServerOpts `json:"server,omitempty"`
 	// Whether proxy is configured
 	Proxy *bool `json:"proxy,omitempty"`
+	// TLS version
+	TLS string `json:"tls,omitempty"`
+	// Cipher suite version
+	Cipher string `json:"cipher,omitempty"`
 	// The type of the source IP header
 	SipHeaderName string `json:"sip_header_name,omitempty"`
 	// The HTTP request header for identifying the real source IP.
@@ -87,8 +91,9 @@ func Update(c *golangsdk.ServiceClient, domainID string, opts UpdateOptsBuilder)
 		r.Err = err
 		return
 	}
-	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
-	_, r.Err = c.Put(resourceURL(c, domainID), b, nil, reqOpt)
+	_, r.Err = c.Put(resourceURL(c, domainID), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
 	return
 }
 

--- a/openstack/waf/v1/domains/results.go
+++ b/openstack/waf/v1/domains/results.go
@@ -75,12 +75,6 @@ type UpdateResult struct {
 	commonResult
 }
 
-// UpdateTLSResult represents the result of a update operation. Call its Extract
-// method to interpret it as a Domain.
-type UpdateTLSResult struct {
-	commonResult
-}
-
 // GetResult represents the result of a get operation. Call its Extract
 // method to interpret it as a Domain.
 type GetResult struct {

--- a/openstack/waf/v1/domains/results.go
+++ b/openstack/waf/v1/domains/results.go
@@ -25,6 +25,10 @@ type Domain struct {
 	AccessStatus int `json:"access_status"`
 	// Protocol type
 	Protocol string `json:"protocol"`
+	// TLS version
+	TLS string `json:"tls"`
+	// Cipher suite
+	Cipher string `json:"cipher"`
 	// Certificate ID
 	CertificateId string `json:"certificate_id"`
 	// The original server information
@@ -54,9 +58,9 @@ type commonResult struct {
 
 // Extract is a function that accepts a result and extracts a domain.
 func (r commonResult) Extract() (*Domain, error) {
-	var response Domain
-	err := r.ExtractInto(&response)
-	return &response, err
+	s := new(Domain)
+	err := r.ExtractIntoStructPtr(s, "")
+	return s, err
 }
 
 // CreateResult represents the result of a create operation. Call its Extract
@@ -68,6 +72,12 @@ type CreateResult struct {
 // UpdateResult represents the result of a update operation. Call its Extract
 // method to interpret it as a Domain.
 type UpdateResult struct {
+	commonResult
+}
+
+// UpdateTLSResult represents the result of a update operation. Call its Extract
+// method to interpret it as a Domain.
+type UpdateTLSResult struct {
 	commonResult
 }
 


### PR DESCRIPTION
### What this PR does / why we need it
Implement missing TLS/cipher params in Create/Update operations
Fix issue with empty response after Update

### Which issue this PR fixes
Closes: #179
Referes to: https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1092

### Special notes for your reviewer

```
=== RUN   TestDomainLifecycle
--- PASS: TestDomainLifecycle (13.02s)
PASS

Process finished with the exit code 0
```
