### PR TITLE
[ECS] Unify EVS metadata field in ECSv1

### DIFF
--- a/acceptance/openstack/common.go
+++ b/acceptance/openstack/common.go
@@ -123,6 +123,13 @@ func GetCloudServerCreateOpts(t *testing.T) cloudservers.CreateOpts {
 
 	vpcID := clients.EnvOS.GetEnv("VPC_ID")
 	subnetID := clients.EnvOS.GetEnv("NETWORK_ID")
+	kmsID := clients.EnvOS.GetEnv("KMS_ID")
+	var encryption string
+	if kmsID != "" {
+		encryption = "1"
+	} else {
+		encryption = "0"
+	}
 
 	computeV2Client, err := clients.NewComputeV2Client()
 	th.AssertNoErr(t, err)
@@ -145,6 +152,16 @@ func GetCloudServerCreateOpts(t *testing.T) cloudservers.CreateOpts {
 		},
 		RootVolume: cloudservers.RootVolume{
 			VolumeType: "SATA",
+		},
+		DataVolumes: []cloudservers.DataVolume{
+			{
+				VolumeType: "SATA",
+				Size:       40,
+				Metadata: map[string]interface{}{
+					"__system__encrypted": encryption,
+					"__system__cmkid":     kmsID,
+				},
+			},
 		},
 		AvailabilityZone: az,
 	}

--- a/openstack/ecs/v1/cloudservers/requests.go
+++ b/openstack/ecs/v1/cloudservers/requests.go
@@ -182,7 +182,7 @@ type DataVolume struct {
 	DataImageID string `json:"data_image_id,omitempty"`
 
 	// EVS disk Metadata.
-	Metadata map[string]string `json:"metadata,omitempty"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
 type VolumeExtendParam struct {


### PR DESCRIPTION
### What this PR does / why we need it
Change ECSv1 `metadata` field from `map[string]string` to `map[string]interface{}`

### Which issue this PR fixes
Refers to: https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1112

### Special notes for your reviewer

```
=== RUN   TestCloudServerLifecycle
    common.go:173: Attempting to check ECSv1 createOpts
    cloudservers_test.go:21: CreateOpts are ok for creating a cloudServer
    common.go:179: Attempting to create ECSv1
    common.go:192: Created ECSv1 instance: 3b912b58-f186-4119-89d4-1cad106c3a63
    common.go:198: Attempting to delete ECSv1: 3b912b58-f186-4119-89d4-1cad106c3a63
    common.go:215: ECSv1 instance deleted: 3b912b58-f186-4119-89d4-1cad106c3a63
--- PASS: TestCloudServerLifecycle (226.87s)
PASS

Process finished with the exit code 0
```