### PR TITLE
Add RDS instance restart to the RDS acceptance

### DIFF
--- a/acceptance/openstack/rds/v3/rds_test.go
+++ b/acceptance/openstack/rds/v3/rds_test.go
@@ -38,6 +38,11 @@ func TestRdsLifecycle(t *testing.T) {
 	defer deleteRDS(t, client, rds.Id)
 	th.AssertEquals(t, rds.Volume.Size, 100)
 
+	restart, err := instances.Restart(client, instances.RestartRdsInstanceOpts{Restart: "{}"}, rds.Id).Extract()
+	th.AssertNoErr(t, err)
+	err = instances.WaitForJobCompleted(client, 1200, restart.JobId)
+	th.AssertNoErr(t, err)
+
 	tagList := []tags.ResourceTag{
 		{
 			Key:   "muh",

--- a/openstack/rds/v3/instances/requests.go
+++ b/openstack/rds/v3/instances/requests.go
@@ -1,8 +1,6 @@
 package instances
 
 import (
-	"fmt"
-
 	"github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
@@ -165,7 +163,6 @@ func Restart(client *golangsdk.ServiceClient, opts RestartRdsInstanceBuilder, in
 		r.Err = err
 		return
 	}
-	fmt.Println("restart Rds instance body = ", b)
 	_, r.Err = client.Post(restartURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{202},
 	})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Add restart to `TestRdsLifecycle`

Remove redundant logging in `rds/v3/instances`

