### PR TITLE
Implement CSS snapshot configuration API

### DIFF
--- a/acceptance/openstack/css/v1/snapshots_test.go
+++ b/acceptance/openstack/css/v1/snapshots_test.go
@@ -1,0 +1,106 @@
+package v1
+
+import (
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/css/v1/clusters"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/css/v1/snapshots"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/obs"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestSnapshotWorkflow(t *testing.T) {
+	client, err := clients.NewCssV1Client()
+	th.AssertNoErr(t, err)
+
+	clusterID := createCluster(t, client)
+	defer deleteCluster(t, client, clusterID)
+
+	th.AssertNoErr(t, snapshots.Enable(client, clusterID).ExtractErr())
+	defer func() {
+		th.AssertNoErr(t, snapshots.Disable(client, clusterID).ExtractErr())
+	}()
+
+	policyOpts := snapshots.PolicyCreateOpts{
+		Prefix:     "snap-",
+		Period:     "00:00 GMT+03:00",
+		KeepDay:    1,
+		Enable:     "true",
+		DeleteAuto: "true",
+	}
+	th.AssertNoErr(t, snapshots.PolicyCreate(client, policyOpts, clusterID).ExtractErr())
+
+	bucketName := "snapshot-sdk-test-bucket"
+	createOpts := &obs.CreateBucketInput{
+		Bucket: bucketName,
+	}
+	obsClient, err := clients.NewOBSClient()
+	th.AssertNoErr(t, err)
+
+	_, err = obsClient.CreateBucket(createOpts)
+	th.AssertNoErr(t, err)
+
+	defer func() {
+		_, err = obsClient.DeleteBucket(bucketName)
+		th.AssertNoErr(t, err)
+	}()
+
+	basicOpts := snapshots.UpdateConfigurationOpts{
+		Bucket: bucketName,
+	}
+	err = snapshots.UpdateConfiguration(client, clusterID, basicOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	policy, err := snapshots.PolicyGet(client, clusterID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, basicOpts.Bucket, policy.Bucket)
+	th.AssertEquals(t, policyOpts.Prefix, policy.Prefix)
+	tools.PrintResource(t, policy)
+}
+
+func createCluster(t *testing.T, client *golangsdk.ServiceClient) string {
+	vpcID := clients.EnvOS.GetEnv("VPC_ID")
+	subnetID := clients.EnvOS.GetEnv("NETWORK_ID")
+
+	if vpcID == "" || subnetID == "" {
+		t.Skip("Both `VPC_ID` and `NETWORK_ID` need to be defined")
+	}
+
+	sgID := openstack.DefaultSecurityGroup(t)
+
+	opts := clusters.CreateOpts{
+		Name: tools.RandomString("snap-cluster-", 4),
+		Instance: &clusters.InstanceSpec{
+			Flavor: "css.medium.8",
+
+			Volume: &clusters.Volume{
+				Type: "COMMON",
+				Size: 40,
+			},
+			Nics: &clusters.Nics{
+				VpcID:           vpcID,
+				SubnetID:        subnetID,
+				SecurityGroupID: sgID,
+			},
+			AvailabilityZone: "eu-de-02",
+		},
+		InstanceNum: 1,
+		DiskEncryption: &clusters.DiskEncryption{
+			Encrypted: "0",
+		},
+	}
+	created, err := clusters.Create(client, opts).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertNoErr(t, clusters.WaitForClusterOperationSucces(client, created.ID, timeout))
+	return created.ID
+}
+
+func deleteCluster(t *testing.T, client *golangsdk.ServiceClient, id string) {
+	err := clusters.Delete(client, id).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/css/v1/snapshots/requests.go
+++ b/openstack/css/v1/snapshots/requests.go
@@ -112,10 +112,10 @@ type UpdateConfigurationOptsBuilder interface {
 type UpdateConfigurationOpts struct {
 	// OBS bucket used for index data backup.
 	// If there is snapshot data in an OBS bucket, only the OBS bucket is used and cannot be changed.
-	Bucket string `json:"bucket"`
+	Bucket string `json:"bucket" required:"true"`
 
 	// IAM agency used to access OBS.
-	Agency string `json:"agency"`
+	Agency string `json:"agency" required:"true"`
 
 	// Key ID used for snapshot encryption.
 	SnapshotCmkID string `json:"snapshotCmkId,omitempty"`

--- a/openstack/css/v1/snapshots/requests.go
+++ b/openstack/css/v1/snapshots/requests.go
@@ -104,3 +104,35 @@ func Delete(client *golangsdk.ServiceClient, clusterId, id string) (r ErrorResul
 	})
 	return
 }
+
+type UpdateConfigurationOptsBuilder interface {
+	ToUpdateConfigurationMap() (map[string]interface{}, error)
+}
+
+type UpdateConfigurationOpts struct {
+	// OBS bucket used for index data backup.
+	// If there is snapshot data in an OBS bucket, only the OBS bucket is used and cannot be changed.
+	Bucket string `json:"bucket"`
+
+	// IAM agency used to access OBS.
+	Agency string `json:"agency"`
+
+	// Key ID used for snapshot encryption.
+	SnapshotCmkID string `json:"snapshotCmkId,omitempty"`
+}
+
+func (opts UpdateConfigurationOpts) ToUpdateConfigurationMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+func UpdateConfiguration(client *golangsdk.ServiceClient, clusterID string, opts UpdateConfigurationOptsBuilder) (r ErrorResult) {
+	b, err := opts.ToUpdateConfigurationMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(configURL(client, clusterID), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/css/v1/snapshots/urls.go
+++ b/openstack/css/v1/snapshots/urls.go
@@ -22,6 +22,10 @@ func createURL(c *golangsdk.ServiceClient, clusterId string) string {
 	return c.ServiceURL("clusters", clusterId, "index_snapshot")
 }
 
+func configURL(c *golangsdk.ServiceClient, clusterId string) string {
+	return c.ServiceURL("clusters", clusterId, "index_snapshot", "setting")
+}
+
 // listURL used to query all snapshots of a cluster
 func listURL(c *golangsdk.ServiceClient, clusterId string) string {
 	return c.ServiceURL("clusters", clusterId, "index_snapshots")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Add `UpdateConfiguration` to CSS v1

Add acceptance tests for CSS v1 automatic snapshots configuration


### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->
Resolves #191

### Special notes for your reviewer

#### Acceptance
```
=== RUN   TestSnapshotWorkflow
    tools.go:72: {
          "keepday": 1,
          "period": "00:00 GMT+03:00",
          "prefix": "snap",
          "bucket": "snapshot-sdk-test-bucket",
          "basePath": "css_repository/snap-cluster-4gO2",
          "agency": "css_obs_agency",
          "enable": "true"
        }
--- PASS: TestSnapshotWorkflow (910.65s)
PASS

Process finished with the exit code 0
```