### PR TITLE
[CSS] Add `SnapshotCmkID` to get policy result

### DIFF
--- a/acceptance/openstack/css/v1/snapshots_test.go
+++ b/acceptance/openstack/css/v1/snapshots_test.go
@@ -47,6 +47,7 @@ func TestSnapshotWorkflow(t *testing.T) {
 	policy, err := snapshots.PolicyGet(client, clusterID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, basicOpts.Bucket, policy.Bucket)
+	th.AssertEquals(t, basicOpts.SnapshotCmkID, policy.SnapshotCmkID)
 	th.AssertEquals(t, policyOpts.Prefix, policy.Prefix)
 	tools.PrintResource(t, policy)
 }

--- a/openstack/css/v1/snapshots/results.go
+++ b/openstack/css/v1/snapshots/results.go
@@ -8,13 +8,14 @@ import (
 
 // Policy contains all the information associated with a snapshot policy.
 type Policy struct {
-	KeepDay  int    `json:"keepday"`
-	Period   string `json:"period"`
-	Prefix   string `json:"prefix"`
-	Bucket   string `json:"bucket"`
-	BasePath string `json:"basePath"`
-	Agency   string `json:"agency"`
-	Enable   string `json:"enable"`
+	KeepDay       int    `json:"keepday"`
+	Period        string `json:"period"`
+	Prefix        string `json:"prefix"`
+	Bucket        string `json:"bucket"`
+	BasePath      string `json:"basePath"`
+	Agency        string `json:"agency"`
+	Enable        string `json:"enable"`
+	SnapshotCmkID string `json:"snapshotCmkId"`
 }
 
 // Snapshot contains all the information associated with a Cluster Snapshot.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Add `SnapshotCmkID` to result of querying automatic snapshot policy

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->
Fixes #196 

### Special notes for your reviewer
#### Acceptance:
```
=== RUN   TestSnapshotWorkflow
    tools.go:72: {
          "keepday": 1,
          "period": "00:00 GMT+03:00",
          "prefix": "snap",
          "bucket": "snapshot-sdk-test-bucket",
          "basePath": "css_repository/snap-cluster-UJWm",
          "agency": "css_obs_agency",
          "enable": "true",
          "snapshotCmkId": ""
        }
--- PASS: TestSnapshotWorkflow (882.04s)
PASS

Process finished with the exit code 0

```