### PR TITLE
[AS] Implement `policiesV2` pkg

### DIFF
--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -29,6 +29,18 @@ func NewAutoscalingV1Client() (*golangsdk.ServiceClient, error) {
 	})
 }
 
+// NewAutoscalingV2Client returns authenticated AutoScaling v2 client
+func NewAutoscalingV2Client() (*golangsdk.ServiceClient, error) {
+	cc, err := CloudAndClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return openstack.NewAutoScalingV2(cc.ProviderClient, golangsdk.EndpointOpts{
+		Region: cc.RegionName,
+	})
+}
+
 // NewBlockStorageV1Client returns a *ServiceClient for making calls
 // to the OpenStack Block Storage v1 API. An error will be returned
 // if authentication or client creation was not possible.

--- a/acceptance/openstack/autoscaling/helpers.go
+++ b/acceptance/openstack/autoscaling/helpers.go
@@ -1,0 +1,44 @@
+package autoscaling
+
+import (
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v1/groups"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func CreateAutoScalingGroup(t *testing.T, client *golangsdk.ServiceClient, networkID, vpcID, asName string) string {
+	defaultSGID := openstack.DefaultSecurityGroup(t)
+	deletePublicIP := true
+
+	createOpts := groups.CreateOpts{
+		Name: asName,
+		Networks: []groups.NetworkOpts{
+			{
+				ID: networkID,
+			},
+		},
+		SecurityGroup: []groups.SecurityGroupOpts{
+			{
+				ID: defaultSGID,
+			},
+		},
+		VpcID:            vpcID,
+		IsDeletePublicip: &deletePublicIP,
+	}
+	t.Logf("Attempting to create AutoScaling Group")
+	groupID, err := groups.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Created AutoScaling Group: %s", groupID)
+
+	return groupID
+}
+
+func DeleteAutoScalingGroup(t *testing.T, client *golangsdk.ServiceClient, groupID string) {
+	t.Logf("Attempting to delete AutoScaling Group")
+	err := groups.Delete(client, groupID).ExtractErr()
+	th.AssertNoErr(t, err)
+	t.Logf("Deleted AutoScaling Group: %s", groupID)
+}

--- a/acceptance/openstack/autoscaling/v2/policies_test.go
+++ b/acceptance/openstack/autoscaling/v2/policies_test.go
@@ -1,0 +1,82 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack/autoscaling"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v2/policies"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestPolicyLifecycle(t *testing.T) {
+	client, err := clients.NewAutoscalingV2Client()
+	th.AssertNoErr(t, err)
+
+	asPolicyCreateName := tools.RandomString("as-policy-create-", 3)
+	asGroupCreateName := tools.RandomString("as-group-create-", 3)
+	networkID := clients.EnvOS.GetEnv("NETWORK_ID")
+	vpcID := clients.EnvOS.GetEnv("VPC_ID")
+	if networkID == "" || vpcID == "" {
+		t.Skip("OS_NETWORK_ID or OS_VPC_ID env vars are missing but AS Policy test requires")
+	}
+	groupID := autoscaling.CreateAutoScalingGroup(t, client, networkID, vpcID, asGroupCreateName)
+	defer func() {
+		autoscaling.DeleteAutoScalingGroup(t, client, groupID)
+	}()
+
+	createOpts := policies.CreateOpts{
+		PolicyName:   asPolicyCreateName,
+		PolicyType:   "RECURRENCE",
+		ResourceID:   groupID,
+		ResourceType: "SCALING_GROUP",
+		SchedulePolicy: policies.SchedulePolicyOpts{
+			LaunchTime:      "10:30",
+			RecurrenceType:  "Weekly",
+			RecurrenceValue: "1,3,5",
+			EndTime:         "2040-12-31T10:30Z",
+		},
+		PolicyAction: policies.ActionOpts{
+			Operation:  "ADD",
+			Percentage: 15,
+		},
+	}
+
+	t.Logf("Attempting to create AutoScaling Policy")
+	policyID, err := policies.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Created AutoScaling Policy: %s", policyID)
+	defer func() {
+		t.Logf("Attempting to delete AutoScaling Policy")
+		err := policies.Delete(client, policyID).ExtractErr()
+		th.AssertNoErr(t, err)
+		t.Logf("Deleted AutoScaling Policy: %s", policyID)
+	}()
+
+	policy, err := policies.Get(client, policyID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, asPolicyCreateName, policy.PolicyName)
+	th.AssertEquals(t, 15, policy.PolicyAction.Percentage)
+	th.AssertEquals(t, "ADD", policy.PolicyAction.Operation)
+
+	t.Logf("Attempting to update AutoScaling policy")
+	asPolicyUpdateName := tools.RandomString("as-policy-update-", 3)
+
+	updateOpts := policies.UpdateOpts{
+		PolicyName: asPolicyUpdateName,
+		Action: policies.ActionOpts{
+			Percentage: 30,
+		},
+	}
+
+	policyID, err = policies.Update(client, policy.PolicyID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Updated AutoScaling Policy")
+
+	policy, err = policies.Get(client, policyID).Extract()
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, policy)
+	th.AssertEquals(t, asPolicyUpdateName, policy.PolicyName)
+	th.AssertEquals(t, 30, policy.PolicyAction.Percentage)
+}

--- a/openstack/autoscaling/v2/policies/requests.go
+++ b/openstack/autoscaling/v2/policies/requests.go
@@ -85,7 +85,7 @@ func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) 
 		return
 	}
 
-	_, r.Err = client.Put(updateURL(client, id), body, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Put(singleURL(client, id), body, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{200},
 	})
 	return
@@ -93,12 +93,12 @@ func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) 
 
 // Delete is a method which can be able to access to delete a policy of autoscaling
 func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
-	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	_, r.Err = client.Delete(singleURL(client, id), nil)
 	return
 }
 
 // Get is a method which can be able to access to get a policy detailed information
 func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
-	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	_, r.Err = client.Get(singleURL(client, id), &r.Body, nil)
 	return
 }

--- a/openstack/autoscaling/v2/policies/requests.go
+++ b/openstack/autoscaling/v2/policies/requests.go
@@ -1,0 +1,104 @@
+package policies
+
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+// CreateOptsBuilder is an interface by which can serialize the create parameters
+type CreateOptsBuilder interface {
+	ToPolicyCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts is a struct which will be used to create a policy
+type CreateOpts struct {
+	PolicyName     string             `json:"scaling_policy_name" required:"true"`
+	PolicyType     string             `json:"scaling_policy_type" required:"true"`
+	ResourceID     string             `json:"scaling_resource_id" required:"true"`
+	ResourceType   string             `json:"scaling_resource_type" required:"true"`
+	AlarmID        string             `json:"alarm_id,omitempty"`
+	SchedulePolicy SchedulePolicyOpts `json:"scheduled_policy,omitempty"`
+	PolicyAction   ActionOpts         `json:"scaling_policy_action,omitempty"`
+	CoolDownTime   int                `json:"cool_down_time,omitempty"`
+}
+
+type SchedulePolicyOpts struct {
+	LaunchTime      string `json:"launch_time" required:"true"`
+	RecurrenceType  string `json:"recurrence_type,omitempty"`
+	RecurrenceValue string `json:"recurrence_value,omitempty"`
+	StartTime       string `json:"start_time,omitempty"`
+	EndTime         string `json:"end_time,omitempty"`
+}
+
+type ActionOpts struct {
+	Operation  string `json:"operation,omitempty"`
+	Size       int    `json:"size,omitempty"`
+	Percentage int    `json:"percentage,omitempty"`
+	Limits     int    `json:"limits,omitempty"`
+}
+
+func (opts CreateOpts) ToPolicyCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method which can be able to access to create the policy of autoscaling
+// service.
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToPolicyCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// UpdateOptsBuilder is an interface which can build the map parameter of update function
+type UpdateOptsBuilder interface {
+	ToPolicyUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts is a struct which represents the parameters of update function
+type UpdateOpts struct {
+	PolicyName     string             `json:"scaling_policy_name,omitempty"`
+	PolicyType     string             `json:"scaling_policy_type,omitempty"`
+	ResourceID     string             `json:"scaling_resource_id,omitempty"`
+	ResourceType   string             `json:"scaling_resource_type,omitempty"`
+	AlarmID        string             `json:"alarm_id,omitempty"`
+	SchedulePolicy SchedulePolicyOpts `json:"scheduled_policy,omitempty"`
+	Action         ActionOpts         `json:"scaling_policy_action,omitempty"`
+	CoolDownTime   int                `json:"cool_down_time,omitempty"`
+}
+
+func (opts UpdateOpts) ToPolicyUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Update is a method which can be able to update the policy via accessing to the
+// autoscaling service with Put method and parameters
+func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	body, err := opts.ToPolicyUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Put(updateURL(client, id), body, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete is a method which can be able to access to delete a policy of autoscaling
+func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}
+
+// Get is a method which can be able to access to get a policy detailed information
+func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}

--- a/openstack/autoscaling/v2/policies/results.go
+++ b/openstack/autoscaling/v2/policies/results.go
@@ -1,0 +1,86 @@
+package policies
+
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+// CreateResult is a struct which represents the create result of policy
+type CreateResult struct {
+	golangsdk.Result
+}
+
+// Extract of CreateResult will deserialize the result of Creation
+func (r CreateResult) Extract() (string, error) {
+	var a struct {
+		ID string `json:"scaling_policy_id"`
+	}
+	err := r.Result.ExtractInto(&a)
+	return a.ID, err
+}
+
+// DeleteResult is a struct which represents the delete result.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+// Policy is a struct that represents the result of get policy
+type Policy struct {
+	PolicyID            string         `json:"scaling_policy_id"`
+	PolicyName          string         `json:"scaling_policy_name"`
+	ResourceID          string         `json:"scaling_resource_id"`
+	ScalingResourceType string         `json:"scaling_resource_type"`
+	PolicyStatus        string         `json:"policy_status"`
+	Type                string         `json:"scaling_policy_type"`
+	AlarmID             string         `json:"alarm_id"`
+	SchedulePolicy      SchedulePolicy `json:"scheduled_policy"`
+	PolicyAction        Action         `json:"scaling_policy_action"`
+	CoolDownTime        int            `json:"cool_down_time"`
+	CreateTime          string         `json:"create_time"`
+	Metadata            Metadata       `json:"meta_data"`
+}
+
+type SchedulePolicy struct {
+	LaunchTime      string `json:"launch_time"`
+	RecurrenceType  string `json:"recurrence_type"`
+	RecurrenceValue string `json:"recurrence_value"`
+	StartTime       string `json:"start_time"`
+	EndTime         string `json:"end_time"`
+}
+
+type Action struct {
+	Operation  string `json:"operation"`
+	Size       int    `json:"size"`
+	Percentage int    `json:"percentage"`
+	Limits     int    `json:"limits"`
+}
+
+type Metadata struct {
+	BandwidthShareType string `json:"metadata_bandwidth_share_type"`
+	EipID              string `json:"metadata_eip_id"`
+	EipAddress         string `json:"metadata_eip_address"`
+}
+
+// GetResult is a struct which represents the get result
+type GetResult struct {
+	golangsdk.Result
+}
+
+func (r GetResult) Extract() (Policy, error) {
+	var p Policy
+	err := r.Result.ExtractIntoStructPtr(&p, "scaling_policy")
+	return p, err
+}
+
+// UpdateResult is a struct from which can get the result of update method
+type UpdateResult struct {
+	golangsdk.Result
+}
+
+// Extract will deserialize the result to group id with string
+func (r UpdateResult) Extract() (string, error) {
+	var a struct {
+		ID string `json:"scaling_policy_id"`
+	}
+	err := r.Result.ExtractInto(&a)
+	return a.ID, err
+}

--- a/openstack/autoscaling/v2/policies/urls.go
+++ b/openstack/autoscaling/v2/policies/urls.go
@@ -12,17 +12,6 @@ func createURL(client *golangsdk.ServiceClient) string {
 	return client.ServiceURL(resourcePath)
 }
 
-// deleteURL will build the url of deletion
-// its pattern is endpoint/scaling_policy/<policy-id>
-func deleteURL(client *golangsdk.ServiceClient, id string) string {
+func singleURL(client *golangsdk.ServiceClient, id string) string {
 	return client.ServiceURL(resourcePath, id)
-}
-
-// getURL will build the get url of get function
-func getURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(resourcePath, id)
-}
-
-func updateURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(resourcePath, id)
 }

--- a/openstack/autoscaling/v2/policies/urls.go
+++ b/openstack/autoscaling/v2/policies/urls.go
@@ -1,0 +1,28 @@
+package policies
+
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+const resourcePath = "scaling_policy"
+
+// createURL will build the rest query url of creation
+// the create url is endpoint/scaling_policy
+func createURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL(resourcePath)
+}
+
+// deleteURL will build the url of deletion
+// its pattern is endpoint/scaling_policy/<policy-id>
+func deleteURL(client *golangsdk.ServiceClient, id string) string {
+	return client.ServiceURL(resourcePath, id)
+}
+
+// getURL will build the get url of get function
+func getURL(client *golangsdk.ServiceClient, id string) string {
+	return client.ServiceURL(resourcePath, id)
+}
+
+func updateURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id)
+}

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -636,6 +636,17 @@ func NewAutoScalingV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpt
 	return initClientOpts(client, eo, "asv1")
 }
 
+// NewAutoScalingV2 creates a ServiceClient that may be used to access the
+// auto-scaling service of OpenTelekomCloud public cloud
+func NewAutoScalingV2(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "asv1")
+	if err != nil {
+		return nil, err
+	}
+	sc.Endpoint = strings.Replace(sc.Endpoint, "v1", "v2", 1)
+	return sc, err
+}
+
 // NewNetworkV1 creates a ServiceClient that may be used with the v1 network
 // package.
 func NewNetworkV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {


### PR DESCRIPTION
### What this PR does / why we need it
Implement `policicesV2` pkg

### Which issue this PR fixes
Fixes: #202 

### Special notes for your reviewer
```
=== RUN   TestPolicyLifecycle
    helpers.go:31: Attempting to create AutoScaling Group
    helpers.go:34: Created AutoScaling Group: 62c550a3-aa1f-45f6-8467-bf58699bdb1d
    policies_test.go:48: Attempting to create AutoScaling Policy
    policies_test.go:51: Created AutoScaling Policy: b52a1523-1fcf-40e1-b96f-976c3eaba343
    policies_test.go:65: Attempting to update AutoScaling policy
    policies_test.go:79: Updated AutoScaling Policy
    tools.go:72: {
          "scaling_policy_id": "b52a1523-1fcf-40e1-b96f-976c3eaba343",
          "scaling_policy_name": "as-policy-update-kHz",
          "scaling_resource_id": "62c550a3-aa1f-45f6-8467-bf58699bdb1d",
          "scaling_resource_type": "SCALING_GROUP",
          "policy_status": "INSERVICE",
          "scaling_policy_type": "RECURRENCE",
          "alarm_id": "",
          "scheduled_policy": {
            "launch_time": "10:30",
            "recurrence_type": "Weekly",
            "recurrence_value": "1,3,5",
            "start_time": "",
            "end_time": "2040-12-31T10:30Z"
          },
          "scaling_policy_action": {
            "operation": "ADD",
            "size": 0,
            "percentage": 30,
            "limits": 0
          },
          "cool_down_time": 300,
          "create_time": "2021-07-05T15:03:49Z",
          "meta_data": {
            "metadata_bandwidth_share_type": "",
            "metadata_eip_id": "",
            "metadata_eip_address": ""
          }
        }
    policies_test.go:53: Attempting to delete AutoScaling Policy
    policies_test.go:56: Deleted AutoScaling Policy: b52a1523-1fcf-40e1-b96f-976c3eaba343
    helpers.go:40: Attempting to delete AutoScaling Group
    helpers.go:43: Deleted AutoScaling Group: 62c550a3-aa1f-45f6-8467-bf58699bdb1d
--- PASS: TestPolicyLifecycle (9.39s)
PASS

Process finished with the exit code 0
```