### PR TITLE
[CTS] Let empty `topic_id`

### DIFF
--- a/openstack/cts/v1/tracker/requests.go
+++ b/openstack/cts/v1/tracker/requests.go
@@ -97,7 +97,7 @@ type CreateOpts struct {
 
 type SimpleMessageNotification struct {
 	IsSupportSMN          bool     `json:"is_support_smn"`
-	TopicID               string   `json:"topic_id,omitempty"`
+	TopicID               string   `json:"topic_id"`
 	Operations            []string `json:"operations,omitempty"`
 	IsSendAllKeyOperation bool     `json:"is_send_all_key_operation"`
 	NeedNotifyUserList    []string `json:"need_notify_user_list,omitempty"`


### PR DESCRIPTION
### What this PR does / why we need it
Remove `omitempty` in `topic_id` field, because when SMN is disabled empty `topic_id` is required

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
```
=== RUN   TestTrackersLifecycle
    helpers.go:15: Attempting to create OBS bucket
    helpers.go:28: Created OBS Bucket: obs-cts-testn472p
    helpers.go:44: Attempting to create SMNv2 topic
    helpers.go:57: Created SMNv2 Topic: urn:smn:eu-de:5045c215010c440d91b2f7dce1f3753b:smn-cts-testgfvhr
    trackers_test.go:21: Attempting to create CTSv1 Tracker
    trackers_test.go:38: Created CTSv1 Tracker: system
    trackers_test.go:43: Attempting to update CTSv1 Tracker: system
    trackers_test.go:50: Updated CTSv1 Tracker: system
    trackers_test.go:32: Attempting to delete CTSv1 Tracker: system
    trackers_test.go:35: Deleted CTSv1 Tracker: system
    helpers.go:62: Attempting to delete SMNv2 topic: urn:smn:eu-de:5045c215010c440d91b2f7dce1f3753b:smn-cts-testgfvhr
    helpers.go:67: Deleted SMNv2 Topic: urn:smn:eu-de:5045c215010c440d91b2f7dce1f3753b:smn-cts-testgfvhr
    helpers.go:34: Attempting to delete OBS bucket: obs-cts-testn472p
    helpers.go:40: Deleted OBS Bucket: obs-cts-testn472p
--- PASS: TestTrackersLifecycle (10.84s)
PASS

Process finished with the exit code 0

```