### PR TITLE
[NAT] Add acceptance test for `snatrules` pkg

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/helpers.go
+++ b/acceptance/openstack/networking/v2/extensions/helpers.go
@@ -1,0 +1,89 @@
+package extensions
+
+import (
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/eips"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func createEip(t *testing.T) *eips.PublicIp {
+	client, err := clients.NewNetworkV1Client()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to create eip/bandwidth")
+	eipCreateOpts := eips.ApplyOpts{
+		IP: eips.PublicIpOpts{
+			Type: "5_bgp",
+		},
+		Bandwidth: eips.BandwidthOpts{
+			ShareType: "PER",
+			Name:      tools.RandomString("acc-band-", 3),
+			Size:      100,
+		},
+	}
+
+	eip, err := eips.Apply(client, eipCreateOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	// wait to be DOWN
+	t.Logf("Waiting for eip %s to be active", eip.ID)
+	err = waitForEipToActive(client, eip.ID, 600)
+	th.AssertNoErr(t, err)
+
+	newEip, err := eips.Get(client, eip.ID).Extract()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Created eip/bandwidth: %s", newEip.ID)
+
+	return newEip
+}
+
+func deleteEip(t *testing.T, eipID string) {
+	client, err := clients.NewNetworkV1Client()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to delete eip/bandwidth: %s", eipID)
+
+	err = eips.Delete(client, eipID).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	// wait to be deleted
+	t.Logf("Waitting for eip %s to be deleted", eipID)
+
+	err = waitForEipToDelete(client, eipID, 600)
+	th.AssertNoErr(t, err)
+
+	t.Logf("Deleted eip/bandwidth: %s", eipID)
+}
+
+func waitForEipToActive(client *golangsdk.ServiceClient, eipID string, secs int) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		eip, err := eips.Get(client, eipID).Extract()
+		if err != nil {
+			return false, err
+		}
+		if eip.Status == "DOWN" {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}
+
+func waitForEipToDelete(client *golangsdk.ServiceClient, eipID string, secs int) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		_, err := eips.Get(client, eipID).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return true, nil
+			}
+			return false, err
+		}
+
+		return false, nil
+	})
+}

--- a/acceptance/openstack/networking/v2/extensions/snatrules_test.go
+++ b/acceptance/openstack/networking/v2/extensions/snatrules_test.go
@@ -1,0 +1,41 @@
+package extensions
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/snatrules"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestSnatRuleLifeCycle(t *testing.T) {
+	client, err := clients.NewNatV2Client()
+	th.AssertNoErr(t, err)
+
+	natGateway := createNatGateway(t, client)
+	defer deleteNatGateway(t, client, natGateway.ID)
+
+	elasticIp := createEip(t)
+	defer deleteEip(t, elasticIp.ID)
+
+	t.Logf("Attempting to create SNAT rule")
+	createOpts := snatrules.CreateOpts{
+		NatGatewayID: natGateway.ID,
+		NetworkID:    natGateway.InternalNetworkID,
+		FloatingIPID: elasticIp.ID,
+	}
+	snatRule, err := snatrules.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Created SNAT rule: %s", snatRule.ID)
+
+	defer func() {
+		t.Logf("Attempting to delete SNAT rule: %s", snatRule.ID)
+		err = snatrules.Delete(client, snatRule.ID).ExtractErr()
+		th.AssertNoErr(t, err)
+		t.Logf("Deleted SNAT rule: %s", snatRule.ID)
+	}()
+
+	newSnatRule, err := snatrules.Get(client, snatRule.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, createOpts.NatGatewayID, newSnatRule.NatGatewayID)
+}

--- a/openstack/networking/v2/extensions/snatrules/results.go
+++ b/openstack/networking/v2/extensions/snatrules/results.go
@@ -27,7 +27,10 @@ type GetResult struct {
 func (r GetResult) Extract() (*SnatRule, error) {
 	s := new(SnatRule)
 	err := r.Result.ExtractIntoStructPtr(s, "snat_rule")
-	return s, err
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 // CreateResult is a return struct of create method
@@ -38,7 +41,10 @@ type CreateResult struct {
 func (r CreateResult) Extract() (*SnatRule, error) {
 	s := new(SnatRule)
 	err := r.Result.ExtractIntoStructPtr(s, "snat_rule")
-	return s, err
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 // DeleteResult is a return struct of delete method

--- a/openstack/networking/v2/extensions/snatrules/results.go
+++ b/openstack/networking/v2/extensions/snatrules/results.go
@@ -16,6 +16,7 @@ type SnatRule struct {
 	AdminStateUp      bool   `json:"admin_state_up"`
 	Cidr              string `json:"cidr"`
 	SourceType        string `json:"source_type"`
+	CreatedAt         string `json:"created_at"`
 }
 
 // GetResult is a return struct of get method
@@ -23,10 +24,10 @@ type GetResult struct {
 	golangsdk.Result
 }
 
-func (r GetResult) Extract() (SnatRule, error) {
-	var SR SnatRule
-	err := r.Result.ExtractIntoStructPtr(&SR, "snat_rule")
-	return SR, err
+func (r GetResult) Extract() (*SnatRule, error) {
+	s := new(SnatRule)
+	err := r.Result.ExtractIntoStructPtr(s, "snat_rule")
+	return s, err
 }
 
 // CreateResult is a return struct of create method
@@ -34,10 +35,10 @@ type CreateResult struct {
 	golangsdk.Result
 }
 
-func (r CreateResult) Extract() (SnatRule, error) {
-	var SR SnatRule
-	err := r.Result.ExtractIntoStructPtr(&SR, "snat_rule")
-	return SR, err
+func (r CreateResult) Extract() (*SnatRule, error) {
+	s := new(SnatRule)
+	err := r.Result.ExtractIntoStructPtr(s, "snat_rule")
+	return s, err
 }
 
 // DeleteResult is a return struct of delete method


### PR DESCRIPTION
### What this PR does / why we need it
Add acceptance test for `snatrules` pkg

### Special notes for your reviewer
```
=== RUN   TestSnatRuleLifeCycle
    natgateways_test.go:46: Attempting to create Nat Gateway
    natgateways_test.go:67: Created Nat Gateway: c690d747-02b2-41b5-92a3-ed5e24d3443a
    helpers.go:17: Attempting to create eip/bandwidth
    helpers.go:33: Waiting for eip 8dc02eab-b5a5-471a-bb8b-30d1d753b594 to be active
    helpers.go:40: Created eip/bandwidth: 8dc02eab-b5a5-471a-bb8b-30d1d753b594
    snatrules_test.go:21: Attempting to create SNAT rule
    snatrules_test.go:29: Created SNAT rule: 1b29ae48-1403-48b6-8e44-0371abbe0857
    snatrules_test.go:32: Attempting to delete SNAT rule: 1b29ae48-1403-48b6-8e44-0371abbe0857
    snatrules_test.go:35: Deleted SNAT rule: 1b29ae48-1403-48b6-8e44-0371abbe0857
    helpers.go:49: Attempting to delete eip/bandwidth: 8dc02eab-b5a5-471a-bb8b-30d1d753b594
    helpers.go:55: Waitting for eip 8dc02eab-b5a5-471a-bb8b-30d1d753b594 to be deleted
    helpers.go:60: Deleted eip/bandwidth: 8dc02eab-b5a5-471a-bb8b-30d1d753b594
    natgateways_test.go:73: Attempting to delete Nat Gateway: c690d747-02b2-41b5-92a3-ed5e24d3443a
    natgateways_test.go:78: Nat Gateway is deleted: c690d747-02b2-41b5-92a3-ed5e24d3443a
--- PASS: TestSnatRuleLifeCycle (21.28s)
PASS

Process finished with the exit code 0
```