### PR TITLE
[SDK] Add `RegionID` in `ProviderClient`

### DIFF
--- a/acceptance/openstack/client_test.go
+++ b/acceptance/openstack/client_test.go
@@ -33,6 +33,9 @@ func TestAuthenticatedClient(t *testing.T) {
 	if cc.DomainID == "" {
 		t.Errorf("Domain ID is not set for the client")
 	}
+	if cc.RegionID == "" {
+		t.Errorf("Region ID is not set for the client")
+	}
 
 	// Find the storage service in the service catalog.
 	storage, err := openstack.NewObjectStorageV1(cc.ProviderClient, golangsdk.EndpointOpts{

--- a/auth_aksk_options.go
+++ b/auth_aksk_options.go
@@ -19,7 +19,7 @@ type AKSKAuthOptions struct {
 	// region
 	Region string
 
-	// cloud service domain, example: myhwclouds.com
+	// cloud service domain
 	Domain   string
 	DomainID string
 
@@ -41,7 +41,7 @@ type AKSKAuthOptions struct {
 	DelegatedProject string
 }
 
-// Implements the method of AuthOptionsProvider
+// GetIdentityEndpoint implements the method of AKSKAuthOptions
 func (opts AKSKAuthOptions) GetIdentityEndpoint() string {
 	return opts.IdentityEndpoint
 }

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -161,7 +161,7 @@ func v3auth(client *golangsdk.ProviderClient, endpoint string, opts tokens3.Auth
 
 	var result token3Result
 
-	if opts.AuthTokenID() != "" {
+	if opts.AuthTokenID() != "" { // TODO: Check token validity with Token-By-Token
 		v3Client.SetToken(opts.AuthTokenID())
 		result = tokens3.Get(v3Client, opts.AuthTokenID())
 	} else {
@@ -212,6 +212,7 @@ func v3auth(client *golangsdk.ProviderClient, endpoint string, opts tokens3.Auth
 		}
 		clientRegion = utils.GetRegion(*aOpts)
 	}
+	client.RegionID = clientRegion
 
 	client.EndpointLocator = func(opts golangsdk.EndpointOpts) (string, error) {
 		// use client region as default one
@@ -331,6 +332,8 @@ func v3AKSKAuth(client *golangsdk.ProviderClient, endpoint string, options golan
 	if err != nil {
 		return err
 	}
+	clientRegion := utils.GetRegionFromAKSK(options)
+	client.RegionID = clientRegion
 
 	client.EndpointLocator = func(opts golangsdk.EndpointOpts) (string, error) {
 		return V3EndpointURL(&tokens3.ServiceCatalog{

--- a/openstack/utils/utils.go
+++ b/openstack/utils/utils.go
@@ -83,6 +83,17 @@ func GetRegion(authOpts golangsdk.AuthOptions) string {
 	return getenv("OS_REGION_NAME", region)
 }
 
+// GetRegionFromAKSK returns the region that was specified in the auth options.
+// If a region was not set it returns value from env OS_REGION_NAME
+func GetRegionFromAKSK(authOpts golangsdk.AKSKAuthOptions) string {
+	name := authOpts.ProjectName
+	if name == "" {
+		name = authOpts.DelegatedProject
+	}
+	region := strings.Split(name, "_")[0]
+	return getenv("OS_REGION_NAME", region)
+}
+
 // getenv returns value from env is present or default value
 func getenv(key, fallback string) string {
 	value := os.Getenv(key)

--- a/provider_client.go
+++ b/provider_client.go
@@ -66,6 +66,9 @@ type ProviderClient struct {
 	// DomainID is the ID of project to which User is authorized.
 	DomainID string
 
+	// RegionID is the Name of region to which User is authorized.
+	RegionID string
+
 	// EndpointLocator describes how this provider discovers the endpoints for
 	// its constituent services.
 	EndpointLocator EndpointLocator


### PR DESCRIPTION
### What this PR does / why we need it
Add `regionID` in `providerClient`.

### Which issue this PR fixes
Relates to: https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1291

