### PR TITLE
[CSBS] Fix issues with wrong UnMarshalling

### DIFF
--- a/acceptance/openstack/csbs/v1/backup_test.go
+++ b/acceptance/openstack/csbs/v1/backup_test.go
@@ -1,0 +1,50 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/csbs/v1/backup"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestBackupList(t *testing.T) {
+	client, err := clients.NewCsbsV1Client()
+	th.AssertNoErr(t, err)
+
+	backupList, err := backup.List(client, backup.ListOpts{})
+	th.AssertNoErr(t, err)
+
+	for _, element := range backupList {
+		tools.PrintResource(t, element)
+	}
+}
+
+func TestBackupLifeCycle(t *testing.T) {
+	client, err := clients.NewCsbsV1Client()
+	th.AssertNoErr(t, err)
+
+	computeClient, err := clients.NewComputeV1Client()
+	th.AssertNoErr(t, err)
+
+	ecs := openstack.CreateCloudServer(t, computeClient, openstack.GetCloudServerCreateOpts(t))
+	defer func() {
+		openstack.DeleteCloudServer(t, computeClient, ecs.ID)
+	}()
+
+	backupName := tools.RandomString("backup-", 3)
+	createOpts := backup.CreateOpts{
+		BackupName:   backupName,
+		Description:  "bla-bla",
+		ResourceType: "OS::Nova::Server",
+	}
+
+	csbsBackup, err := backup.Create(client, ecs.ID, createOpts).ExtractBackup()
+	th.AssertNoErr(t, err)
+	defer func() {
+		err := backup.Delete(client, csbsBackup.CheckpointId).ExtractErr()
+		th.AssertNoErr(t, err)
+	}()
+}

--- a/acceptance/openstack/csbs/v1/backups_test.go
+++ b/acceptance/openstack/csbs/v1/backups_test.go
@@ -1,0 +1,1 @@
+package v1

--- a/acceptance/openstack/csbs/v1/backups_test.go
+++ b/acceptance/openstack/csbs/v1/backups_test.go
@@ -1,1 +1,0 @@
-package v1

--- a/openstack/csbs/v1/backup/requests.go
+++ b/openstack/csbs/v1/backup/requests.go
@@ -35,7 +35,7 @@ func List(c *golangsdk.ServiceClient, opts ListOpts) ([]Backup, error) {
 	}
 	u := listURL(c) + q.String()
 	pages, err := pagination.NewPager(c, u, func(r pagination.PageResult) pagination.Page {
-		return csbsBackupPage{pagination.LinkedPageBase{PageResult: r}}
+		return СsbsBackupPage{pagination.LinkedPageBase{PageResult: r}}
 	}).AllPages()
 
 	if err != nil {

--- a/openstack/csbs/v1/backup/requests.go
+++ b/openstack/csbs/v1/backup/requests.go
@@ -35,7 +35,7 @@ func List(c *golangsdk.ServiceClient, opts ListOpts) ([]Backup, error) {
 	}
 	u := listURL(c) + q.String()
 	pages, err := pagination.NewPager(c, u, func(r pagination.PageResult) pagination.Page {
-		return BackupPage{pagination.LinkedPageBase{PageResult: r}}
+		return csbsBackupPage{pagination.LinkedPageBase{PageResult: r}}
 	}).AllPages()
 
 	if err != nil {

--- a/openstack/csbs/v1/backup/requests.go
+++ b/openstack/csbs/v1/backup/requests.go
@@ -2,13 +2,9 @@ package backup
 
 import (
 	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
-
-type ResourceTag struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
 
 // ListOpts allows the filtering and sorting of paginated collections through
 // the API. Filtering is achieved by passing in struct field values that map to
@@ -60,7 +56,6 @@ func List(c *golangsdk.ServiceClient, opts ListOpts) ([]Backup, error) {
 }
 
 func FilterBackupsById(backups []Backup, filterId string) ([]Backup, error) {
-
 	var refinedBackups []Backup
 
 	for _, backup := range backups {
@@ -82,11 +77,12 @@ type CreateOptsBuilder interface {
 // CreateOpts contains the options for create a Backup. This object is
 // passed to backup.Create().
 type CreateOpts struct {
-	BackupName   string        `json:"backup_name,omitempty"`
-	Description  string        `json:"description,omitempty"`
-	ResourceType string        `json:"resource_type,omitempty"`
-	Tags         []ResourceTag `json:"tags,omitempty"`
-	ExtraInfo    interface{}   `json:"extra_info,omitempty"`
+	BackupName   string             `json:"backup_name,omitempty"`
+	Description  string             `json:"description,omitempty"`
+	ResourceType string             `json:"resource_type,omitempty"`
+	Incremental  *bool              `json:"incremental,omitempty"`
+	Tags         []tags.ResourceTag `json:"tags,omitempty"`
+	ExtraInfo    interface{}        `json:"extra_info,omitempty"`
 }
 
 // ToBackupCreateMap assembles a request body based on the contents of a
@@ -98,13 +94,13 @@ func (opts CreateOpts) ToBackupCreateMap() (map[string]interface{}, error) {
 // Create will create a new backup based on the values in CreateOpts. To extract
 // the checkpoint object from the response, call the Extract method on the
 // CreateResult.
-func Create(client *golangsdk.ServiceClient, resourceId string, opts CreateOptsBuilder) (r CreateResult) {
+func Create(client *golangsdk.ServiceClient, resourceID string, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToBackupCreateMap()
 	if err != nil {
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(rootURL(client, resourceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(rootURL(client, resourceID), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{200},
 	})
 	return
@@ -151,16 +147,15 @@ func QueryResourceBackupCapability(client *golangsdk.ServiceClient, opts Resourc
 
 // Get will get a single backup with specific ID. To extract the Backup object from the response,
 // call the ExtractBackup method on the GetResult.
-func Get(client *golangsdk.ServiceClient, backupId string) (r GetResult) {
-	_, r.Err = client.Get(getURL(client, backupId), &r.Body, nil)
+func Get(client *golangsdk.ServiceClient, backupID string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, backupID), &r.Body, nil)
 
 	return
-
 }
 
 // Delete will delete an existing backup.
-func Delete(client *golangsdk.ServiceClient, checkpoint_id string) (r DeleteResult) {
-	_, r.Err = client.Delete(deleteURL(client, checkpoint_id), &golangsdk.RequestOpts{
+func Delete(client *golangsdk.ServiceClient, checkpointID string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, checkpointID), &golangsdk.RequestOpts{
 		OkCodes:      []int{200},
 		JSONResponse: nil,
 	})

--- a/openstack/csbs/v1/backup/results.go
+++ b/openstack/csbs/v1/backup/results.go
@@ -1,21 +1,19 @@
 package backup
 
 import (
-	"encoding/json"
-	"strconv"
-	"time"
-
 	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
 
 type Checkpoint struct {
 	Status         string         `json:"status"`
-	CreatedAt      time.Time      `json:"-"`
+	CreatedAt      string         `json:"created_at"`
 	Id             string         `json:"id"`
 	ResourceGraph  string         `json:"resource_graph"`
 	ProjectId      string         `json:"project_id"`
 	ProtectionPlan ProtectionPlan `json:"protection_plan"`
+	ExtraInfo      string         `json:"extra_info"`
 }
 
 type ProtectionPlan struct {
@@ -25,10 +23,10 @@ type ProtectionPlan struct {
 }
 
 type BackupResource struct {
-	ID        string `json:"id"`
-	Type      string `json:"type"`
-	Name      string `json:"name"`
-	ExtraInfo string `json:"-"`
+	ID        string      `json:"id"`
+	Type      string      `json:"type"`
+	Name      string      `json:"name"`
+	ExtraInfo interface{} `json:"extra_info"`
 }
 
 type ResourceCapability struct {
@@ -37,48 +35,6 @@ type ResourceCapability struct {
 	ErrorCode    string `json:"error_code"`
 	ErrorMsg     string `json:"error_msg"`
 	ResourceId   string `json:"resource_id"`
-}
-
-// UnmarshalJSON helps to unmarshal Checkpoint fields into needed values.
-func (r *Checkpoint) UnmarshalJSON(b []byte) error {
-	type tmp Checkpoint
-	var s struct {
-		tmp
-		CreatedAt golangsdk.JSONRFC3339MilliNoZ `json:"created_at"`
-	}
-	err := json.Unmarshal(b, &s)
-	if err != nil {
-		return err
-	}
-	*r = Checkpoint(s.tmp)
-
-	r.CreatedAt = time.Time(s.CreatedAt)
-
-	return err
-}
-
-// UnmarshalJSON helps to unmarshal BackupResource fields into needed values.
-func (r *BackupResource) UnmarshalJSON(b []byte) error {
-	type tmp BackupResource
-	var s struct {
-		tmp
-		ExtraInfo interface{} `json:"extra_info"`
-	}
-	err := json.Unmarshal(b, &s)
-	if err != nil {
-		return err
-	}
-
-	*r = BackupResource(s.tmp)
-
-	switch t := s.ExtraInfo.(type) {
-	case float64:
-		r.ID = strconv.FormatFloat(t, 'f', -1, 64)
-	case string:
-		r.ID = t
-	}
-
-	return err
 }
 
 func (r commonResult) ExtractQueryResponse() ([]ResourceCapability, error) {
@@ -90,18 +46,18 @@ func (r commonResult) ExtractQueryResponse() ([]ResourceCapability, error) {
 }
 
 type Backup struct {
-	CheckpointId string        `json:"checkpoint_id"`
-	CreatedAt    time.Time     `json:"-"`
-	ExtendInfo   ExtendInfo    `json:"extend_info"`
-	Id           string        `json:"id"`
-	Name         string        `json:"name"`
-	ResourceId   string        `json:"resource_id"`
-	Status       string        `json:"status"`
-	UpdatedAt    time.Time     `json:"-"`
-	VMMetadata   VMMetadata    `json:"backup_data"`
-	Description  string        `json:"description"`
-	Tags         []ResourceTag `json:"tags"`
-	ResourceType string        `json:"resource_type"`
+	CheckpointId string             `json:"checkpoint_id"`
+	CreatedAt    string             `json:"created_at"`
+	ExtendInfo   ExtendInfo         `json:"extend_info"`
+	Id           string             `json:"id"`
+	Name         string             `json:"name"`
+	ResourceId   string             `json:"resource_id"`
+	Status       string             `json:"status"`
+	UpdatedAt    string             `json:"updated_at"`
+	VMMetadata   VMMetadata         `json:"backup_data"`
+	Description  string             `json:"description"`
+	Tags         []tags.ResourceTag `json:"tags"`
+	ResourceType string             `json:"resource_type"`
 }
 
 type ExtendInfo struct {
@@ -121,7 +77,7 @@ type ExtendInfo struct {
 	Size                 int            `json:"size"`
 	SpaceSavingRatio     int            `json:"space_saving_ratio"`
 	VolumeBackups        []VolumeBackup `json:"volume_backups"`
-	FinishedAt           time.Time      `json:"-"`
+	FinishedAt           string         `json:"finished_at"`
 	TaskId               string         `json:"taskid"`
 	HypervisorType       string         `json:"hypervisor_type"`
 	SupportedRestoreMode string         `json:"supported_restore_mode"`
@@ -158,44 +114,6 @@ type VolumeBackup struct {
 	SpaceSavingRatio int    `json:"space_saving_ratio"`
 	Status           string `json:"status"`
 	SourceVolumeName string `json:"source_volume_name"`
-}
-
-// UnmarshalJSON helps to unmarshal Backup fields into needed values.
-func (r *Backup) UnmarshalJSON(b []byte) error {
-	type tmp Backup
-	var s struct {
-		tmp
-		CreatedAt golangsdk.JSONRFC3339MilliNoZ `json:"created_at"`
-		UpdatedAt golangsdk.JSONRFC3339MilliNoZ `json:"updated_at"`
-	}
-	err := json.Unmarshal(b, &s)
-	if err != nil {
-		return err
-	}
-	*r = Backup(s.tmp)
-
-	r.CreatedAt = time.Time(s.CreatedAt)
-	r.UpdatedAt = time.Time(s.UpdatedAt)
-
-	return err
-}
-
-// UnmarshalJSON helps to unmarshal ExtendInfo fields into needed values.
-func (r *ExtendInfo) UnmarshalJSON(b []byte) error {
-	type tmp ExtendInfo
-	var s struct {
-		tmp
-		FinishedAt golangsdk.JSONRFC3339MilliNoZ `json:"finished_at"`
-	}
-	err := json.Unmarshal(b, &s)
-	if err != nil {
-		return err
-	}
-	*r = ExtendInfo(s.tmp)
-
-	r.FinishedAt = time.Time(s.FinishedAt)
-
-	return err
 }
 
 // Extract will get the checkpoint object from the commonResult

--- a/openstack/csbs/v1/backup/results.go
+++ b/openstack/csbs/v1/backup/results.go
@@ -19,10 +19,10 @@ type Checkpoint struct {
 type ProtectionPlan struct {
 	Id              string               `json:"id"`
 	Name            string               `json:"name"`
-	BackupResources []csbsBackupResource `json:"resources"`
+	BackupResources []СsbsBackupResource `json:"resources"`
 }
 
-type csbsBackupResource struct {
+type СsbsBackupResource struct {
 	ID        string      `json:"id"`
 	Type      string      `json:"type"`
 	Name      string      `json:"name"`
@@ -137,16 +137,16 @@ func (r GetResult) Extract() (*Backup, error) {
 	return s, nil
 }
 
-// csbsBackupPage is the page returned by a pager when traversing over a
+// СsbsBackupPage is the page returned by a pager when traversing over a
 // collection of backups.
-type csbsBackupPage struct {
+type СsbsBackupPage struct {
 	pagination.LinkedPageBase
 }
 
 // NextPageURL is invoked when a paginated collection of backups has reached
 // the end of a page and the pager seeks to traverse over a new one. In order
 // to do this, it needs to construct the next page's URL.
-func (r csbsBackupPage) NextPageURL() (string, error) {
+func (r СsbsBackupPage) NextPageURL() (string, error) {
 	var s struct {
 		Links []golangsdk.Link `json:"checkpoint_items_links"`
 	}
@@ -157,18 +157,18 @@ func (r csbsBackupPage) NextPageURL() (string, error) {
 	return golangsdk.ExtractNextURL(s.Links)
 }
 
-// IsEmpty checks whether a csbsBackupPage struct is empty.
-func (r csbsBackupPage) IsEmpty() (bool, error) {
+// IsEmpty checks whether a СsbsBackupPage struct is empty.
+func (r СsbsBackupPage) IsEmpty() (bool, error) {
 	is, err := ExtractBackups(r)
 	return len(is) == 0, err
 }
 
-// ExtractBackups accepts a Page struct, specifically a csbsBackupPage struct,
+// ExtractBackups accepts a Page struct, specifically a СsbsBackupPage struct,
 // and extracts the elements into a slice of Backup structs. In other words,
 // a generic collection is mapped into a relevant slice.
 func ExtractBackups(r pagination.Page) ([]Backup, error) {
 	var s []Backup
-	err := (r.(csbsBackupPage)).ExtractIntoSlicePtr(&s, "checkpoint_items")
+	err := (r.(СsbsBackupPage)).ExtractIntoSlicePtr(&s, "checkpoint_items")
 	if err != nil {
 		return nil, err
 	}

--- a/openstack/csbs/v1/backup/results.go
+++ b/openstack/csbs/v1/backup/results.go
@@ -13,7 +13,7 @@ type Checkpoint struct {
 	ResourceGraph  string         `json:"resource_graph"`
 	ProjectId      string         `json:"project_id"`
 	ProtectionPlan ProtectionPlan `json:"protection_plan"`
-	ExtraInfo      string         `json:"extra_info"`
+	ExtraInfo      interface{}    `json:"extra_info"`
 }
 
 type ProtectionPlan struct {

--- a/openstack/csbs/v1/backup/results.go
+++ b/openstack/csbs/v1/backup/results.go
@@ -182,7 +182,7 @@ type CreateResult struct {
 }
 
 type DeleteResult struct {
-	commonResult
+	golangsdk.ErrResult
 }
 
 type GetResult struct {

--- a/openstack/csbs/v1/backup/testing/fixtures.go
+++ b/openstack/csbs/v1/backup/testing/fixtures.go
@@ -1,8 +1,8 @@
 package testing
 
 const (
-	backupEndpoint     = "/checkpoint_items"
-	checkpoint_item_id = "7b99acfd-18c3-4f26-9d39-b4ebd2ea3e12"
+	backupEndpoint   = "/checkpoint_items"
+	checkpointItemID = "7b99acfd-18c3-4f26-9d39-b4ebd2ea3e12"
 )
 
 var getResponse = `

--- a/openstack/csbs/v1/backup/testing/requests_test.go
+++ b/openstack/csbs/v1/backup/testing/requests_test.go
@@ -24,7 +24,7 @@ func TestGet(t *testing.T) {
 		_, _ = fmt.Fprint(w, getResponse)
 	})
 
-	s, err := backup.Get(fake.ServiceClient(), checkpointItemID).ExtractBackup()
+	s, err := backup.Get(fake.ServiceClient(), checkpointItemID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, "7b99acfd-18c3-4f26-9d39-b4ebd2ea3e12", s.Id)
 	th.AssertEquals(t, "backup-c2c", s.Name)

--- a/openstack/csbs/v1/backup/testing/requests_test.go
+++ b/openstack/csbs/v1/backup/testing/requests_test.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
-	"github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/csbs/v1/backup"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 	fake "github.com/opentelekomcloud/gophertelekomcloud/testhelper/client"
@@ -16,7 +14,7 @@ func TestGet(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	th.Mux.HandleFunc(backupEndpoint+"/"+checkpoint_item_id, func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc(backupEndpoint+"/"+checkpointItemID, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
@@ -26,7 +24,7 @@ func TestGet(t *testing.T) {
 		_, _ = fmt.Fprint(w, getResponse)
 	})
 
-	s, err := backup.Get(fake.ServiceClient(), checkpoint_item_id).ExtractBackup()
+	s, err := backup.Get(fake.ServiceClient(), checkpointItemID).ExtractBackup()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, "7b99acfd-18c3-4f26-9d39-b4ebd2ea3e12", s.Id)
 	th.AssertEquals(t, "backup-c2c", s.Name)
@@ -129,7 +127,6 @@ func TestList(t *testing.T) {
 		t.Errorf("Failed to extract backups: %v", err)
 	}
 
-	var FinishedAt, _ = time.Parse(golangsdk.RFC3339MilliNoZ, "2018-08-14T08:31:08.720800")
 	expected := []backup.Backup{
 		{
 			Status: "available",
@@ -153,7 +150,7 @@ func TestList(t *testing.T) {
 				FailReason:           "",
 				ResourceAz:           "eu-de-02",
 				ImageType:            "backup",
-				FinishedAt:           FinishedAt,
+				FinishedAt:           "2018-08-14T08:31:08.720800",
 				AverageSpeed:         19,
 				CopyStatus:           "na",
 				Incremental:          false,

--- a/openstack/csbs/v1/backup/urls.go
+++ b/openstack/csbs/v1/backup/urls.go
@@ -3,22 +3,22 @@ package backup
 import "github.com/opentelekomcloud/gophertelekomcloud"
 
 const rootPath = "providers"
-const ProviderID = "fc4d5750-22e7-4798-8a46-f48f62c4c1da"
+const providerID = "fc4d5750-22e7-4798-8a46-f48f62c4c1da"
 
-func rootURL(c *golangsdk.ServiceClient, resourceid string) string {
-	return c.ServiceURL(rootPath, ProviderID, "resources", resourceid, "action")
+func rootURL(c *golangsdk.ServiceClient, resourceID string) string {
+	return c.ServiceURL(rootPath, providerID, "resources", resourceID, "action")
 }
 
 func resourceURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(rootPath, ProviderID, "resources", "action")
+	return c.ServiceURL(rootPath, providerID, "resources", "action")
 }
 
-func getURL(c *golangsdk.ServiceClient, checkpoint_item_id string) string {
-	return c.ServiceURL("checkpoint_items", checkpoint_item_id)
+func getURL(c *golangsdk.ServiceClient, checkpointItemID string) string {
+	return c.ServiceURL("checkpoint_items", checkpointItemID)
 }
 
-func deleteURL(c *golangsdk.ServiceClient, checkpoint_id string) string {
-	return c.ServiceURL(rootPath, ProviderID, "checkpoints", checkpoint_id)
+func deleteURL(c *golangsdk.ServiceClient, checkpointID string) string {
+	return c.ServiceURL(rootPath, providerID, "checkpoints", checkpointID)
 }
 
 func listURL(c *golangsdk.ServiceClient) string {


### PR DESCRIPTION
### What this PR does / why we need it
Fix issues with wrong UnMarshallings in `backup` pkg

### Which issue this PR fixes
Fixes: #232

### Special notes for your reviewer

```
=== RUN   TestBackupList
--- PASS: TestBackupList (6.82s)
=== RUN   TestBackupLifeCycle
    common.go:179: Attempting to create ECSv1
    common.go:192: Created ECSv1 instance: eb2efbcd-f1c4-4371-9723-4a8498689686
    backup_test.go:38: Check if resource is protectable
    backup_test.go:50: Resource is protectable
    backup_test.go:58: Attempting to create CSBS backup
    backup_test.go:79: Created CSBS backup: db0aebce-c2e6-4fe1-9f6c-e317c9d6d941
    backup_test.go:81: Resource is protectable
    backup_test.go:62: Attempting to delete CSBS backup: db0aebce-c2e6-4fe1-9f6c-e317c9d6d941
    backup_test.go:68: Deleted CSBS backup: db0aebce-c2e6-4fe1-9f6c-e317c9d6d941
    common.go:198: Attempting to delete ECSv1: eb2efbcd-f1c4-4371-9723-4a8498689686
    common.go:215: ECSv1 instance deleted: eb2efbcd-f1c4-4371-9723-4a8498689686
--- PASS: TestBackupLifeCycle (500.33s)
PASS

Process finished with the exit code 0
```