### PR TITLE
[RDS] Add acceptance test for RDSv3 `read-replica`

### DIFF
--- a/acceptance/openstack/rds/v3/helpers.go
+++ b/acceptance/openstack/rds/v3/helpers.go
@@ -25,6 +25,7 @@ func createRDS(t *testing.T, client *golangsdk.ServiceClient, region string) *in
 
 	vpcID := clients.EnvOS.GetEnv("VPC_ID")
 	subnetID := clients.EnvOS.GetEnv("NETWORK_ID")
+	kmsID := clients.EnvOS.GetEnv("KMS_ID")
 	if vpcID == "" || subnetID == "" {
 		t.Skip("One of OS_VPC_ID or OS_NETWORK_ID env vars is missing but RDS test requires using existing network")
 	}
@@ -39,6 +40,7 @@ func createRDS(t *testing.T, client *golangsdk.ServiceClient, region string) *in
 		VpcId:            vpcID,
 		SubnetId:         subnetID,
 		SecurityGroupId:  openstack.DefaultSecurityGroup(t),
+		DiskEncryptionId: kmsID,
 
 		Volume: &instances.Volume{
 			Type: "COMMON",


### PR DESCRIPTION
### What this PR does / why we need it
Add acceptance test for RDSv3 `read-replica`

### Which issue this PR fixes
Refers to: https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1392

### Special notes for your reviewer
```
=== RUN   TestRdsReadReplicaLifecycle
    helpers.go:16: Attempting to create RDSv3
    helpers.go:62: Created RDSv3: cc6ff249b682478c94915dee0d43e7b4in03
    rds_test.go:107: Attempting to create RDSv3 Read Replica
    rds_test.go:136: Created RDSv3 Read Replica: 1aa193c9a9324edfa40e830ac620c587in03
    rds_test.go:139: Attempting to delete RDSv3 Read Replica: 1aa193c9a9324edfa40e830ac620c587in03
    rds_test.go:142: RDSv3 Read Replica instance deleted: 1aa193c9a9324edfa40e830ac620c587in03
    helpers.go:68: Attempting to delete RDSv3: cc6ff249b682478c94915dee0d43e7b4in03
    helpers.go:73: RDSv3 instance deleted: cc6ff249b682478c94915dee0d43e7b4in03
--- PASS: TestRdsReadReplicaLifecycle (798.33s)
PASS

Process finished with the exit code 0
```