### PR TITLE
[NAT] Implement `dnatrules` pkg

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/dnatrulest_test.go
+++ b/acceptance/openstack/networking/v2/extensions/dnatrulest_test.go
@@ -1,0 +1,45 @@
+package extensions
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/dnatrules"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestDnatRuleLifeCycle(t *testing.T) {
+	client, err := clients.NewNatV2Client()
+	th.AssertNoErr(t, err)
+
+	natGateway := createNatGateway(t, client)
+	defer deleteNatGateway(t, client, natGateway.ID)
+
+	elasticIp := createEip(t)
+	defer deleteEip(t, elasticIp.ID)
+
+	t.Logf("Attempting to create DNAT rule")
+	allServicePorts := 0
+	createOpts := dnatrules.CreateOpts{
+		NatGatewayID:        natGateway.ID,
+		InternalServicePort: &allServicePorts,
+		PrivateIp:           "192.168.1.100",
+		FloatingIpID:        elasticIp.ID,
+		ExternalServicePort: &allServicePorts,
+		Protocol:            "any",
+	}
+	dnatRule, err := dnatrules.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Created DNAT rule: %s", dnatRule.ID)
+
+	defer func() {
+		t.Logf("Attempting to delete DNAT rule: %s", dnatRule.ID)
+		err = dnatrules.Delete(client, dnatRule.ID).ExtractErr()
+		th.AssertNoErr(t, err)
+		t.Logf("Deleted DNAT rule: %s", dnatRule.ID)
+	}()
+
+	newDnatRule, err := dnatrules.Get(client, dnatRule.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, createOpts.NatGatewayID, newDnatRule.NatGatewayID)
+}

--- a/openstack/networking/v2/extensions/dnatrules/requests.go
+++ b/openstack/networking/v2/extensions/dnatrules/requests.go
@@ -1,0 +1,55 @@
+package dnatrules
+
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+// CreateOptsBuilder is an interface must satisfy to be used as Create
+// options.
+type CreateOptsBuilder interface {
+	ToDnatRuleCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new dnat rule
+// resource.
+type CreateOpts struct {
+	NatGatewayID        string `json:"nat_gateway_id" required:"true"`
+	PortID              string `json:"port_id,omitempty"`
+	PrivateIp           string `json:"private_ip,omitempty"`
+	InternalServicePort *int   `json:"internal_service_port" required:"true"`
+	FloatingIpID        string `json:"floating_ip_id" required:"true"`
+	ExternalServicePort *int   `json:"external_service_port" required:"true"`
+	Protocol            string `json:"protocol" required:"true"`
+}
+
+// ToDnatRuleCreateMap allows CreateOpts to satisfy the CreateOptsBuilder
+// interface
+func (opts CreateOpts) ToDnatRuleCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "dnat_rule")
+}
+
+// Create is a method by which can create a new dnat rule
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToDnatRuleCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}
+
+// Get is a method by which can get the detailed information of the specified
+// dnat rule.
+func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, id), &r.Body, nil)
+	return
+}
+
+// Delete is a method by which can be able to delete a dnat rule
+func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, id), nil)
+	return
+}

--- a/openstack/networking/v2/extensions/dnatrules/results.go
+++ b/openstack/networking/v2/extensions/dnatrules/results.go
@@ -1,0 +1,55 @@
+package dnatrules
+
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+// DnatRule is a struct that represents a dnat rule
+type DnatRule struct {
+	ID                  string `json:"id"`
+	TenantID            string `json:"tenant_id"`
+	NatGatewayID        string `json:"nat_gateway_id"`
+	PortID              string `json:"port_id"`
+	PrivateIp           string `json:"private_ip"`
+	InternalServicePort int    `json:"internal_service_port"`
+	FloatingIpID        string `json:"floating_ip_id"`
+	FloatingIpAddress   string `json:"floating_ip_address"`
+	ExternalServicePort int    `json:"external_service_port"`
+	Protocol            string `json:"protocol"`
+	Status              string `json:"status"`
+	AdminStateUp        bool   `json:"admin_state_up"`
+	CreatedAt           string `json:"created_at"`
+}
+
+// GetResult is a return struct of get method
+type GetResult struct {
+	golangsdk.Result
+}
+
+func (r GetResult) Extract() (*DnatRule, error) {
+	s := new(DnatRule)
+	err := r.Result.ExtractIntoStructPtr(s, "dnat_rule")
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// CreateResult is a return struct of create method
+type CreateResult struct {
+	golangsdk.Result
+}
+
+func (r CreateResult) Extract() (*DnatRule, error) {
+	s := new(DnatRule)
+	err := r.Result.ExtractIntoStructPtr(s, "dnat_rule")
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// DeleteResult is a return struct of delete method
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/openstack/networking/v2/extensions/dnatrules/urls.go
+++ b/openstack/networking/v2/extensions/dnatrules/urls.go
@@ -1,0 +1,13 @@
+package dnatrules
+
+import "github.com/opentelekomcloud/gophertelekomcloud"
+
+const resourcePath = "dnat_rules"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id)
+}


### PR DESCRIPTION
### What this PR does / why we need it
Implement `dnatrules` pkg

### Which issue this PR fixes
Resolves: #239

### Special notes for your reviewer
```
=== RUN   TestDnatRuleLifeCycle
    natgateways_test.go:46: Attempting to create Nat Gateway
    natgateways_test.go:67: Created Nat Gateway: 2299596d-8705-4a6b-a643-a672aedf1463
    helpers.go:17: Attempting to create eip/bandwidth
    helpers.go:33: Waiting for eip e4c7b197-5b70-42c7-87dc-8daa5da7d931 to be active
    helpers.go:40: Created eip/bandwidth: e4c7b197-5b70-42c7-87dc-8daa5da7d931
    dnatrulest_test.go:21: Attempting to create DNAT rule
    dnatrulest_test.go:33: Created DNAT rule: 70fc38b8-bd52-486f-84cb-2ab05479cc91
    dnatrulest_test.go:36: Attempting to delete DNAT rule: 70fc38b8-bd52-486f-84cb-2ab05479cc91
    dnatrulest_test.go:39: Deleted DNAT rule: 70fc38b8-bd52-486f-84cb-2ab05479cc91
    helpers.go:49: Attempting to delete eip/bandwidth: e4c7b197-5b70-42c7-87dc-8daa5da7d931
    helpers.go:55: Waitting for eip e4c7b197-5b70-42c7-87dc-8daa5da7d931 to be deleted
    helpers.go:60: Deleted eip/bandwidth: e4c7b197-5b70-42c7-87dc-8daa5da7d931
    natgateways_test.go:73: Attempting to delete Nat Gateway: 2299596d-8705-4a6b-a643-a672aedf1463
    natgateways_test.go:78: Nat Gateway is deleted: 2299596d-8705-4a6b-a643-a672aedf1463
--- PASS: TestDnatRuleLifeCycle (24.38s)
PASS

Process finished with the exit code 0
```