### PR TITLE
[SMN] Add new `OkCode` in `subscriptions` Delete call 

### DIFF
--- a/acceptance/openstack/smn/v2/helpers.go
+++ b/acceptance/openstack/smn/v2/helpers.go
@@ -1,0 +1,28 @@
+package v2
+
+import (
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/smn/v2/topics"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func createTopic(t *testing.T, client *golangsdk.ServiceClient) string {
+	t.Logf("Attempting to create SMN topic")
+	opts := topics.CreateOps{
+		Name: tools.RandomString("topic-", 3),
+	}
+	topic, err := topics.Create(client, opts).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Created SMN topic: %s", topic.TopicUrn)
+	return topic.TopicUrn
+}
+
+func deleteTopic(t *testing.T, client *golangsdk.ServiceClient, topicURN string) {
+	t.Logf("Attempting to delete SMN topic: %s", topicURN)
+	err := topics.Delete(client, topicURN).ExtractErr()
+	th.AssertNoErr(t, err)
+	t.Logf("Deleted SMN topic: %s", topicURN)
+}

--- a/acceptance/openstack/smn/v2/subscriptions_test.go
+++ b/acceptance/openstack/smn/v2/subscriptions_test.go
@@ -30,4 +30,8 @@ func TestTopicSubscriptionWorkflow(t *testing.T) {
 		th.AssertNoErr(t, err)
 		t.Logf("Deleted SMN subscription: %s", subscription.SubscriptionUrn)
 	}()
+
+	subscriptionList, err := subscriptions.List(client).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(subscriptionList))
 }

--- a/acceptance/openstack/smn/v2/subscriptions_test.go
+++ b/acceptance/openstack/smn/v2/subscriptions_test.go
@@ -1,0 +1,33 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/smn/v2/subscriptions"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestTopicSubscriptionWorkflow(t *testing.T) {
+	client, err := clients.NewSmnV2Client()
+	th.AssertNoErr(t, err)
+
+	topic := createTopic(t, client)
+	defer deleteTopic(t, client, topic)
+
+	t.Logf("Attempting to create SMN subscription")
+	createOpts := subscriptions.CreateOpts{
+		Endpoint: "example@email.com",
+		Protocol: "email",
+	}
+
+	subscription, err := subscriptions.Create(client, createOpts, topic).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Created SMN subscription: %s", subscription.SubscriptionUrn)
+	defer func() {
+		t.Logf("Attempting to delete SMN subscription: %s", subscription.SubscriptionUrn)
+		err := subscriptions.Delete(client, subscription.SubscriptionUrn).ExtractErr()
+		th.AssertNoErr(t, err)
+		t.Logf("Deleted SMN subscription: %s", subscription.SubscriptionUrn)
+	}()
+}

--- a/acceptance/openstack/smn/v2/topicattributes_test.go
+++ b/acceptance/openstack/smn/v2/topicattributes_test.go
@@ -4,11 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
-	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/smn/v2/topicattributes"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/smn/v2/topics"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
 
@@ -32,20 +29,6 @@ func TestTopicAttributeWorkflow(t *testing.T) {
 	th.AssertEquals(t, examplePolicy, attributes[attribute])
 
 	err = topicattributes.Delete(client, topic, attribute).ExtractErr()
-	th.AssertNoErr(t, err)
-}
-
-func createTopic(t *testing.T, client *golangsdk.ServiceClient) string {
-	opts := topics.CreateOps{
-		Name: tools.RandomString("topic-", 3),
-	}
-	topic, err := topics.Create(client, opts).Extract()
-	th.AssertNoErr(t, err)
-	return topic.TopicUrn
-}
-
-func deleteTopic(t *testing.T, client *golangsdk.ServiceClient, topicURN string) {
-	err := topics.Delete(client, topicURN).ExtractErr()
 	th.AssertNoErr(t, err)
 }
 

--- a/openstack/smn/v2/subscriptions/requests.go
+++ b/openstack/smn/v2/subscriptions/requests.go
@@ -5,14 +5,14 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack"
 )
 
-// CreateOpsBuilder is used for creating subscription parameters.
+// CreateOptsBuilder is used for creating subscription parameters.
 // any struct providing the parameters should implement this interface
-type CreateOpsBuilder interface {
+type CreateOptsBuilder interface {
 	ToSubscriptionCreateMap() (map[string]interface{}, error)
 }
 
-// CreateOps is a struct that contains all the parameters.
-type CreateOps struct {
+// CreateOpts is a struct that contains all the parameters.
+type CreateOpts struct {
 	// Message endpoint
 	Endpoint string `json:"endpoint" required:"true"`
 	// Protocol of the message endpoint
@@ -21,13 +21,13 @@ type CreateOps struct {
 	Remark string `json:"remark,omitempty"`
 }
 
-func (ops CreateOps) ToSubscriptionCreateMap() (map[string]interface{}, error) {
+func (ops CreateOpts) ToSubscriptionCreateMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(ops, "")
 }
 
 // Create a subscription with given parameters.
-func Create(client *golangsdk.ServiceClient, ops CreateOpsBuilder, topicUrn string) (r CreateResult) {
-	b, err := ops.ToSubscriptionCreateMap()
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder, topicUrn string) (r CreateResult) {
+	b, err := opts.ToSubscriptionCreateMap()
 	if err != nil {
 		r.Err = err
 		return
@@ -41,19 +41,22 @@ func Create(client *golangsdk.ServiceClient, ops CreateOpsBuilder, topicUrn stri
 	return
 }
 
-// delete a subscription via subscription urn
+// Delete a subscription via subscription urn
 func Delete(client *golangsdk.ServiceClient, subscriptionUrn string) (r DeleteResult) {
-	_, r.Err = client.Delete(deleteURL(client, subscriptionUrn), openstack.StdRequestOpts())
+	_, r.Err = client.Delete(deleteURL(client, subscriptionUrn), &golangsdk.RequestOpts{
+		OkCodes:     []int{200, 202, 204},
+		MoreHeaders: openstack.StdRequestOpts().MoreHeaders,
+	})
 	return
 }
 
-// list all the subscriptions
+// List all the subscriptions
 func List(client *golangsdk.ServiceClient) (r ListResult) {
 	_, r.Err = client.Get(listURL(client), &r.Body, openstack.StdRequestOpts())
 	return
 }
 
-// list all the subscriptions
+// ListFromTopic all the subscriptions from topic
 func ListFromTopic(client *golangsdk.ServiceClient, subscriptionUrn string) (r ListResult) {
 	_, r.Err = client.Get(listFromTopicURL(client, subscriptionUrn), &r.Body, openstack.StdRequestOpts())
 	return

--- a/openstack/smn/v2/subscriptions/results.go
+++ b/openstack/smn/v2/subscriptions/results.go
@@ -20,41 +20,33 @@ type SubscriptionGet struct {
 }
 
 // Extract will get the subscription object out of the commonResult object.
-func (r commonResult) Extract() (*Subscription, error) {
-	var s Subscription
-	err := r.ExtractInto(&s)
-	return &s, err
-}
-
-func (r commonResult) ExtractInto(v interface{}) error {
-	return r.Result.ExtractIntoStructPtr(v, "")
-}
-
-type commonResult struct {
-	golangsdk.Result
+func (r CreateResult) Extract() (*Subscription, error) {
+	s := new(Subscription)
+	err := r.ExtractIntoStructPtr(s, "")
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 // CreateResult contains the response body and error from a Create request.
 type CreateResult struct {
-	commonResult
+	golangsdk.Result
 }
 
 type DeleteResult struct {
 	golangsdk.ErrResult
 }
 
-type GetResult struct {
-	commonResult
-}
-
 type ListResult struct {
 	golangsdk.Result
 }
 
-func (lr ListResult) Extract() ([]SubscriptionGet, error) {
-	var a struct {
-		Subscriptions []SubscriptionGet `json:"subscriptions"`
+func (r ListResult) Extract() ([]SubscriptionGet, error) {
+	var s []SubscriptionGet
+	err := r.ExtractIntoSlicePtr(&s, "subscriptions")
+	if err != nil {
+		return nil, err
 	}
-	err := lr.Result.ExtractInto(&a)
-	return a.Subscriptions, err
+	return s, nil
 }

--- a/openstack/smn/v2/subscriptions/urls.go
+++ b/openstack/smn/v2/subscriptions/urls.go
@@ -2,18 +2,23 @@ package subscriptions
 
 import "github.com/opentelekomcloud/gophertelekomcloud"
 
+const (
+	rootPath   = "subscriptions"
+	topicsPath = "topics"
+)
+
 func createURL(c *golangsdk.ServiceClient, topicUrn string) string {
-	return c.ServiceURL("topics", topicUrn, "subscriptions")
+	return c.ServiceURL(topicsPath, topicUrn, rootPath)
 }
 
 func deleteURL(c *golangsdk.ServiceClient, subscriptionUrn string) string {
-	return c.ServiceURL("subscriptions", subscriptionUrn)
+	return c.ServiceURL(rootPath, subscriptionUrn)
 }
 
 func listURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL("subscriptions?offset=0&limit=100")
+	return c.ServiceURL(rootPath)
 }
 
 func listFromTopicURL(c *golangsdk.ServiceClient, topicUrn string) string {
-	return c.ServiceURL("topics", topicUrn, "subscriptions?offset=0&limit=100")
+	return c.ServiceURL(topicsPath, topicUrn, rootPath)
 }


### PR DESCRIPTION
### What this PR does / why we need it
Add `200` `OkCode` in `subscriptions` Delete call 

### Which issue this PR fixes
Fixes: #244

### Special notes for your reviewer
```
=== RUN   TestTopicSubscriptionWorkflow
    helpers.go:13: Attempting to create SMN topic
    helpers.go:19: Created SMN topic: urn:smn:eu-de:xxxx-z8Z
    subscriptions_test.go:18: Attempting to create SMN subscription
    subscriptions_test.go:26: Created SMN subscription: urn:smn:eu-de:xxxx-xxx
    subscriptions_test.go:28: Attempting to delete SMN subscription: urn:smn:eu-de:xxx-xxx
    subscriptions_test.go:31: Deleted SMN subscription: urn:smn:eu-de:xxx-z8Z
    helpers.go:24: Attempting to delete SMN topic: urn:smn:eu-de:xxxx-z8Z
    helpers.go:27: Deleted SMN topic: urn:smn:eu-de:xxxx-z8Z
--- PASS: TestTopicSubscriptionWorkflow (3.81s)
PASS

Process finished with the exit code 0
```