### PR TITLE
[ELB] Implement `listeners` v3 pkg

### DIFF
--- a/acceptance/openstack/elb/v3/certificates_test.go
+++ b/acceptance/openstack/elb/v3/certificates_test.go
@@ -30,9 +30,7 @@ func TestCertificateLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	certificateID := createCertificate(t, client)
-	defer func() {
-		deleteCertificate(t, client, certificateID)
-	}()
+	defer deleteCertificate(t, client, certificateID)
 
 	t.Logf("Attempting to update ELBv3 certificate: %s", certificateID)
 	certName := tools.RandomString("update-cert-", 3)

--- a/acceptance/openstack/elb/v3/certificates_test.go
+++ b/acceptance/openstack/elb/v3/certificates_test.go
@@ -29,94 +29,24 @@ func TestCertificateLifecycle(t *testing.T) {
 	client, err := clients.NewElbV3Client(t)
 	th.AssertNoErr(t, err)
 
-	t.Logf("Attempting to create ELBv3 certificate")
-	certName := tools.RandomString("create-cert-", 3)
-
-	privateKey := `
------BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
-qEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYldiE6Vp8HH5BSKaCWKVg8lGWg1
-UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb3iyNBmiZ8aZhGw2pI1YwR+15
-MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dzQ8z1JXWdg8/9Zx7Ktvgwu5PQ
-M3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5mf2DPkVgM08XAgaLJcLigwD5
-13koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwIDAQABAoIBACU9S5fjD9/jTMXA
-DRs08A+gGgZUxLn0xk+NAPX3LyB1tfdkCaFB8BccLzO6h3KZuwQOBPv6jkdvEDbx
-Nwyw3eA/9GJsIvKiHc0rejdvyPymaw9I8MA7NbXHaJrY7KpqDQyk6sx+aUTcy5jg
-iMXLWdwXYHhJ/1HVOo603oZyiS6HZeYU089NDUcX+1SJi3e5Ke0gPVXEqCq1O11/
-rh24bMxnwZo4PKBWdcMBN5Zf/4ij9vrZE+fFzW7vGBO48A5lvZxWU2U5t/OZQRtN
-1uLOHmMFa0FIF2aWbTVfwdUWAFsvAOkHj9VV8BXOUwKOUuEktdkfAlvrxmsFrO/H
-yDeYYPkCgYEA/S55CBbR0sMXpSZ56uRn8JHApZJhgkgvYr+FqDlJq/e92nAzf01P
-RoEBUajwrnf1ycevN/SDfbtWzq2XJGqhWdJmtpO16b7KBsC6BdRcH6dnOYh31jgA
-vABMIP3wzI4zSVTyxRE8LDuboytF1mSCeV5tHYPQTZNwrplDnLQhywcCgYEAw8Yc
-Uk/eiFr3hfH/ZohMfV5p82Qp7DNIGRzw8YtVG/3+vNXrAXW1VhugNhQY6L+zLtJC
-aKn84ooup0m3YCg0hvINqJuvzfsuzQgtjTXyaE0cEwsjUusOmiuj09vVx/3U7siK
-Hdjd2ICPCvQ6Q8tdi8jV320gMs05AtaBkZdsiWUCgYEAtLw4Kk4f+xTKDFsrLUNf
-75wcqhWVBiwBp7yQ7UX4EYsJPKZcHMRTk0EEcAbpyaJZE3I44vjp5ReXIHNLMfPs
-uvI34J4Rfot0LN3n7cFrAi2+wpNo+MOBwrNzpRmijGP2uKKrq4JiMjFbKV/6utGF
-Up7VxfwS904JYpqGaZctiIECgYA1A6nZtF0riY6ry/uAdXpZHL8ONNqRZtWoT0kD
-79otSVu5ISiRbaGcXsDExC52oKrSDAgFtbqQUiEOFg09UcXfoR6HwRkba2CiDwve
-yHQLQI5Qrdxz8Mk0gIrNrSM4FAmcW9vi9z4kCbQyoC5C+4gqeUlJRpDIkQBWP2Y4
-2ct/bQKBgHv8qCsQTZphOxc31BJPa2xVhuv18cEU3XLUrVfUZ/1f43JhLp7gynS2
-ep++LKUi9D0VGXY8bqvfJjbECoCeu85vl8NpCXwe/LoVoIn+7KaVIZMwqoGMfgNl
-nEqm7HWkNxHhf8A6En/IjleuddS1sf9e/x+TJN1Xhnt9W6pe7Fk1
------END RSA PRIVATE KEY-----`
-	cert := `
------BEGIN CERTIFICATE-----
-MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
-BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
-CQYDVQQLDAJ4eDELMAkGA1UEAwwCeHgxGTAXBgkqhkiG9w0BCQEWCnh4QDE2My5j
-b20wHhcNMTcxMjA0MDM0MjQ5WhcNMjAxMjAzMDM0MjQ5WjBpMQswCQYDVQQGEwJ4
-eDELMAkGA1UECAwCeHgxCzAJBgNVBAcMAnh4MQswCQYDVQQKDAJ4eDELMAkGA1UE
-CwwCeHgxCzAJBgNVBAMMAnh4MRkwFwYJKoZIhvcNAQkBFgp4eEAxNjMuY29tMIIB
-IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN
-2s8tZ/6LC3X82fajpVsYqF1xqEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYld
-iE6Vp8HH5BSKaCWKVg8lGWg1UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb
-3iyNBmiZ8aZhGw2pI1YwR+15MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dz
-Q8z1JXWdg8/9Zx7Ktvgwu5PQM3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5
-mf2DPkVgM08XAgaLJcLigwD513koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwID
-AQABo1AwTjAdBgNVHQ4EFgQUo5A2tIu+bcUfvGTD7wmEkhXKFjcwHwYDVR0jBBgw
-FoAUo5A2tIu+bcUfvGTD7wmEkhXKFjcwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0B
-AQsFAAOCAQEAWJ2rS6Mvlqk3GfEpboezx2J3X7l1z8Sxoqg6ntwB+rezvK3mc9H0
-83qcVeUcoH+0A0lSHyFN4FvRQL6X1hEheHarYwJK4agb231vb5erasuGO463eYEG
-r4SfTuOm7SyiV2xxbaBKrXJtpBp4WLL/s+LF+nklKjaOxkmxUX0sM4CTA7uFJypY
-c8Tdr8lDDNqoUtMD8BrUCJi+7lmMXRcC3Qi3oZJW76ja+kZA5mKVFPd1ATih8TbA
-i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
-i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+8Kg==
------END CERTIFICATE-----`
-
-	createOpts := certificates.CreateOpts{
-		Name:        certName,
-		Description: "some interesting certificate",
-		Type:        "server",
-		PrivateKey:  privateKey,
-		Certificate: cert,
-	}
-
-	certificate, err := certificates.Create(client, createOpts).Extract()
-	th.AssertNoErr(t, err)
+	certificateID := createCertificate(t, client)
 	defer func() {
-		t.Logf("Attempting to delete ELBv3 certificate: %s", certificate.ID)
-		err := certificates.Delete(client, certificate.ID).ExtractErr()
-		th.AssertNoErr(t, err)
-		t.Logf("Deleted ELBv3 certificate: %s", certificate.ID)
+		deleteCertificate(t, client, certificateID)
 	}()
-	th.AssertEquals(t, createOpts.Name, certificate.Name)
-	th.AssertEquals(t, createOpts.Description, certificate.Description)
-	t.Logf("Created ELBv3 certificate: %s", certificate.ID)
 
-	t.Logf("Attempting to update ELBv3 certificate: %s", certificate.ID)
-	certName = tools.RandomString("update-cert-", 3)
+	t.Logf("Attempting to update ELBv3 certificate: %s", certificateID)
+	certName := tools.RandomString("update-cert-", 3)
 	emptyDescription := ""
 	updateOpts := certificates.UpdateOpts{
 		Name:        certName,
 		Description: &emptyDescription,
 	}
 
-	_, err = certificates.Update(client, certificate.ID, updateOpts).Extract()
+	_, err = certificates.Update(client, certificateID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
-	t.Logf("Updated ELBv3 certificate: %s", certificate.ID)
+	t.Logf("Updated ELBv3 certificate: %s", certificateID)
 
-	newCertificate, err := certificates.Get(client, certificate.ID).Extract()
+	newCertificate, err := certificates.Get(client, certificateID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, updateOpts.Name, newCertificate.Name)
 	th.AssertEquals(t, emptyDescription, newCertificate.Description)

--- a/acceptance/openstack/elb/v3/helpers.go
+++ b/acceptance/openstack/elb/v3/helpers.go
@@ -1,0 +1,151 @@
+package v3
+
+import (
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3/certificates"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3/loadbalancers"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func createLoadBalancer(t *testing.T, client *golangsdk.ServiceClient) string {
+	t.Logf("Attempting to create ELBv3 LoadBalancer")
+	lbName := tools.RandomString("create-lb-", 3)
+	adminStateUp := true
+
+	vpcID := clients.EnvOS.GetEnv("VPC_ID")
+	networkID := clients.EnvOS.GetEnv("NETWORK_ID")
+	subnetID := clients.EnvOS.GetEnv("SUBNET_ID")
+	if networkID == "" || vpcID == "" || subnetID == "" {
+		t.Skip("OS_NETWORK_ID/OS_VPC_ID/OS_SUBNET_ID env vars are missing but LBv3 test requires")
+	}
+
+	az := clients.EnvOS.GetEnv("AVAILABILITY_ZONE")
+	if az == "" {
+		az = "eu-nl-01"
+	}
+
+	createOpts := loadbalancers.CreateOpts{
+		Name:                 lbName,
+		Description:          "some interesting loadbalancer",
+		VipSubnetCidrID:      subnetID,
+		VpcID:                vpcID,
+		AvailabilityZoneList: []string{az},
+		Tags: []tags.ResourceTag{
+			{
+				Key:   "gophertelekomcloud",
+				Value: "loadbalancer",
+			},
+		},
+		AdminStateUp: &adminStateUp,
+		PublicIp: &loadbalancers.PublicIp{
+			NetworkType: "5_bgp",
+			Bandwidth: loadbalancers.Bandwidth{
+				Name:       "elb_eip_traffic",
+				Size:       10,
+				ChargeMode: "traffic",
+				ShareType:  "PER",
+			},
+		},
+		ElbSubnetIDs: []string{networkID},
+	}
+
+	loadbalancer, err := loadbalancers.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, createOpts.Name, loadbalancer.Name)
+	th.AssertEquals(t, createOpts.Description, loadbalancer.Description)
+	t.Logf("Created ELBv3 LoadBalancer: %s", loadbalancer.ID)
+
+	return loadbalancer.ID
+}
+
+func deleteLoadbalancer(t *testing.T, client *golangsdk.ServiceClient, loadbalancerID string) {
+	t.Logf("Attempting to delete ELBv3 LoadBalancer: %s", loadbalancerID)
+	err := loadbalancers.Delete(client, loadbalancerID).ExtractErr()
+	th.AssertNoErr(t, err)
+	t.Logf("Deleted ELBv3 LoadBalancer: %s", loadbalancerID)
+}
+
+func createCertificate(t *testing.T, client *golangsdk.ServiceClient) string {
+	t.Logf("Attempting to create ELBv3 certificate")
+	certName := tools.RandomString("create-cert-", 3)
+
+	privateKey := `
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
+qEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYldiE6Vp8HH5BSKaCWKVg8lGWg1
+UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb3iyNBmiZ8aZhGw2pI1YwR+15
+MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dzQ8z1JXWdg8/9Zx7Ktvgwu5PQ
+M3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5mf2DPkVgM08XAgaLJcLigwD5
+13koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwIDAQABAoIBACU9S5fjD9/jTMXA
+DRs08A+gGgZUxLn0xk+NAPX3LyB1tfdkCaFB8BccLzO6h3KZuwQOBPv6jkdvEDbx
+Nwyw3eA/9GJsIvKiHc0rejdvyPymaw9I8MA7NbXHaJrY7KpqDQyk6sx+aUTcy5jg
+iMXLWdwXYHhJ/1HVOo603oZyiS6HZeYU089NDUcX+1SJi3e5Ke0gPVXEqCq1O11/
+rh24bMxnwZo4PKBWdcMBN5Zf/4ij9vrZE+fFzW7vGBO48A5lvZxWU2U5t/OZQRtN
+1uLOHmMFa0FIF2aWbTVfwdUWAFsvAOkHj9VV8BXOUwKOUuEktdkfAlvrxmsFrO/H
+yDeYYPkCgYEA/S55CBbR0sMXpSZ56uRn8JHApZJhgkgvYr+FqDlJq/e92nAzf01P
+RoEBUajwrnf1ycevN/SDfbtWzq2XJGqhWdJmtpO16b7KBsC6BdRcH6dnOYh31jgA
+vABMIP3wzI4zSVTyxRE8LDuboytF1mSCeV5tHYPQTZNwrplDnLQhywcCgYEAw8Yc
+Uk/eiFr3hfH/ZohMfV5p82Qp7DNIGRzw8YtVG/3+vNXrAXW1VhugNhQY6L+zLtJC
+aKn84ooup0m3YCg0hvINqJuvzfsuzQgtjTXyaE0cEwsjUusOmiuj09vVx/3U7siK
+Hdjd2ICPCvQ6Q8tdi8jV320gMs05AtaBkZdsiWUCgYEAtLw4Kk4f+xTKDFsrLUNf
+75wcqhWVBiwBp7yQ7UX4EYsJPKZcHMRTk0EEcAbpyaJZE3I44vjp5ReXIHNLMfPs
+uvI34J4Rfot0LN3n7cFrAi2+wpNo+MOBwrNzpRmijGP2uKKrq4JiMjFbKV/6utGF
+Up7VxfwS904JYpqGaZctiIECgYA1A6nZtF0riY6ry/uAdXpZHL8ONNqRZtWoT0kD
+79otSVu5ISiRbaGcXsDExC52oKrSDAgFtbqQUiEOFg09UcXfoR6HwRkba2CiDwve
+yHQLQI5Qrdxz8Mk0gIrNrSM4FAmcW9vi9z4kCbQyoC5C+4gqeUlJRpDIkQBWP2Y4
+2ct/bQKBgHv8qCsQTZphOxc31BJPa2xVhuv18cEU3XLUrVfUZ/1f43JhLp7gynS2
+ep++LKUi9D0VGXY8bqvfJjbECoCeu85vl8NpCXwe/LoVoIn+7KaVIZMwqoGMfgNl
+nEqm7HWkNxHhf8A6En/IjleuddS1sf9e/x+TJN1Xhnt9W6pe7Fk1
+-----END RSA PRIVATE KEY-----`
+	cert := `
+-----BEGIN CERTIFICATE-----
+MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
+BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
+CQYDVQQLDAJ4eDELMAkGA1UEAwwCeHgxGTAXBgkqhkiG9w0BCQEWCnh4QDE2My5j
+b20wHhcNMTcxMjA0MDM0MjQ5WhcNMjAxMjAzMDM0MjQ5WjBpMQswCQYDVQQGEwJ4
+eDELMAkGA1UECAwCeHgxCzAJBgNVBAcMAnh4MQswCQYDVQQKDAJ4eDELMAkGA1UE
+CwwCeHgxCzAJBgNVBAMMAnh4MRkwFwYJKoZIhvcNAQkBFgp4eEAxNjMuY29tMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN
+2s8tZ/6LC3X82fajpVsYqF1xqEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYld
+iE6Vp8HH5BSKaCWKVg8lGWg1UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb
+3iyNBmiZ8aZhGw2pI1YwR+15MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dz
+Q8z1JXWdg8/9Zx7Ktvgwu5PQM3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5
+mf2DPkVgM08XAgaLJcLigwD513koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwID
+AQABo1AwTjAdBgNVHQ4EFgQUo5A2tIu+bcUfvGTD7wmEkhXKFjcwHwYDVR0jBBgw
+FoAUo5A2tIu+bcUfvGTD7wmEkhXKFjcwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0B
+AQsFAAOCAQEAWJ2rS6Mvlqk3GfEpboezx2J3X7l1z8Sxoqg6ntwB+rezvK3mc9H0
+83qcVeUcoH+0A0lSHyFN4FvRQL6X1hEheHarYwJK4agb231vb5erasuGO463eYEG
+r4SfTuOm7SyiV2xxbaBKrXJtpBp4WLL/s+LF+nklKjaOxkmxUX0sM4CTA7uFJypY
+c8Tdr8lDDNqoUtMD8BrUCJi+7lmMXRcC3Qi3oZJW76ja+kZA5mKVFPd1ATih8TbA
+i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
+i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+8Kg==
+-----END CERTIFICATE-----`
+
+	createOpts := certificates.CreateOpts{
+		Name:        certName,
+		Description: "some interesting certificate",
+		Type:        "server",
+		PrivateKey:  privateKey,
+		Certificate: cert,
+	}
+
+	certificate, err := certificates.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, createOpts.Name, certificate.Name)
+	th.AssertEquals(t, createOpts.Description, certificate.Description)
+	t.Logf("Created ELBv3 certificate: %s", certificate.ID)
+
+	return certificate.ID
+}
+
+func deleteCertificate(t *testing.T, client *golangsdk.ServiceClient, certificateID string) {
+	t.Logf("Attempting to delete ELBv3 certificate: %s", certificateID)
+	err := certificates.Delete(client, certificateID).ExtractErr()
+	th.AssertNoErr(t, err)
+	t.Logf("Deleted ELBv3 certificate: %s", certificateID)
+}

--- a/acceptance/openstack/elb/v3/listeners_test.go
+++ b/acceptance/openstack/elb/v3/listeners_test.go
@@ -15,14 +15,10 @@ func TestListenerLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	loadbalancerID := createLoadBalancer(t, client)
-	defer func() {
-		deleteLoadbalancer(t, client, loadbalancerID)
-	}()
+	defer deleteLoadbalancer(t, client, loadbalancerID)
 
 	certificateID := createCertificate(t, client)
-	defer func() {
-		deleteCertificate(t, client, certificateID)
-	}()
+	defer deleteCertificate(t, client, certificateID)
 
 	t.Logf("Attempting to create ELBv3 Listener")
 	listenerName := tools.RandomString("create-listener-", 3)

--- a/acceptance/openstack/elb/v3/listeners_test.go
+++ b/acceptance/openstack/elb/v3/listeners_test.go
@@ -1,0 +1,72 @@
+package v3
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3/listeners"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestListenerLifecycle(t *testing.T) {
+	client, err := clients.NewElbV3Client(t)
+	th.AssertNoErr(t, err)
+
+	loadbalancerID := createLoadBalancer(t, client)
+	defer func() {
+		deleteLoadbalancer(t, client, loadbalancerID)
+	}()
+
+	certificateID := createCertificate(t, client)
+	defer func() {
+		deleteCertificate(t, client, certificateID)
+	}()
+
+	t.Logf("Attempting to create ELBv3 Listener")
+	listenerName := tools.RandomString("create-listener-", 3)
+
+	createOpts := listeners.CreateOpts{
+		DefaultTlsContainerRef: certificateID,
+		Description:            "some interesting description",
+		LoadbalancerID:         loadbalancerID,
+		Name:                   listenerName,
+		Protocol:               "HTTPS",
+		ProtocolPort:           443,
+		Tags: []tags.ResourceTag{
+			{
+				Key:   "gophertelekomcloud",
+				Value: "listener",
+			},
+		},
+	}
+
+	listener, err := listeners.Create(client, createOpts).Extract()
+	defer func() {
+		t.Logf("Attempting to delete ELBv3 Listener: %s", listener.ID)
+		err := listeners.Delete(client, listener.ID).ExtractErr()
+		th.AssertNoErr(t, err)
+		t.Logf("Deleted ELBv3 Listener: %s", listener.ID)
+	}()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, createOpts.Name, listener.Name)
+	th.AssertEquals(t, createOpts.Description, listener.Description)
+	t.Logf("Created ELBv3 Listener: %s", listener.ID)
+
+	t.Logf("Attempting to update ELBv3 Listener: %s", listener.ID)
+	listenerName = tools.RandomString("update-listener-", 3)
+	emptyDescription := ""
+	updateOpts := listeners.UpdateOpts{
+		Description: &emptyDescription,
+		Name:        listenerName,
+	}
+	_, err = listeners.Update(client, listener.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Updated ELBv3 Listener: %s", listener.ID)
+
+	newListener, err := listeners.Get(client, listener.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, updateOpts.Name, newListener.Name)
+	th.AssertEquals(t, emptyDescription, newListener.Description)
+}

--- a/acceptance/openstack/elb/v3/loadbalancers_test.go
+++ b/acceptance/openstack/elb/v3/loadbalancers_test.go
@@ -30,9 +30,7 @@ func TestLoadBalancerLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	loadbalancerID := createLoadBalancer(t, client)
-	defer func() {
-		deleteLoadbalancer(t, client, loadbalancerID)
-	}()
+	defer deleteLoadbalancer(t, client, loadbalancerID)
 
 	t.Logf("Attempting to update ELBv3 LoadBalancer: %s", loadbalancerID)
 	lbName := tools.RandomString("update-lb-", 3)

--- a/acceptance/openstack/elb/v3/loadbalancers_test.go
+++ b/acceptance/openstack/elb/v3/loadbalancers_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3/loadbalancers"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
@@ -30,72 +29,24 @@ func TestLoadBalancerLifecycle(t *testing.T) {
 	client, err := clients.NewElbV3Client(t)
 	th.AssertNoErr(t, err)
 
-	t.Logf("Attempting to create ELBv3 LoadBalancer")
-	lbName := tools.RandomString("create-lb-", 3)
-	adminStateUp := true
-
-	vpcID := clients.EnvOS.GetEnv("VPC_ID")
-	networkID := clients.EnvOS.GetEnv("NETWORK_ID")
-	subnetID := clients.EnvOS.GetEnv("SUBNET_ID")
-	if networkID == "" || vpcID == "" || subnetID == "" {
-		t.Skip("OS_NETWORK_ID/OS_VPC_ID/OS_SUBNET_ID env vars are missing but LBv3 test requires")
-	}
-
-	az := clients.EnvOS.GetEnv("AVAILABILITY_ZONE")
-	if az == "" {
-		az = "eu-nl-01"
-	}
-
-	createOpts := loadbalancers.CreateOpts{
-		Name:                 lbName,
-		Description:          "some interesting loadbalancer",
-		VipSubnetCidrID:      subnetID,
-		VpcID:                vpcID,
-		AvailabilityZoneList: []string{az},
-		Tags: []tags.ResourceTag{
-			{
-				Key:   "gophertelekomcloud",
-				Value: "loadbalancer",
-			},
-		},
-		AdminStateUp: &adminStateUp,
-		PublicIp: &loadbalancers.PublicIp{
-			NetworkType: "5_bgp",
-			Bandwidth: loadbalancers.Bandwidth{
-				Name:       "elb_eip_traffic",
-				Size:       10,
-				ChargeMode: "traffic",
-				ShareType:  "PER",
-			},
-		},
-		ElbSubnetIDs: []string{networkID},
-	}
-
-	loadbalancer, err := loadbalancers.Create(client, createOpts).Extract()
-	th.AssertNoErr(t, err)
+	loadbalancerID := createLoadBalancer(t, client)
 	defer func() {
-		t.Logf("Attempting to delete ELBv3 LoadBalancer: %s", loadbalancer.ID)
-		err := loadbalancers.Delete(client, loadbalancer.ID).ExtractErr()
-		th.AssertNoErr(t, err)
-		t.Logf("Deleted ELBv3 LoadBalancer: %s", loadbalancer.ID)
+		deleteLoadbalancer(t, client, loadbalancerID)
 	}()
-	th.AssertEquals(t, createOpts.Name, loadbalancer.Name)
-	th.AssertEquals(t, createOpts.Description, loadbalancer.Description)
-	t.Logf("Created ELBv3 LoadBalancer: %s", loadbalancer.ID)
 
-	t.Logf("Attempting to update ELBv3 LoadBalancer: %s", loadbalancer.ID)
-	lbName = tools.RandomString("update-lb-", 3)
+	t.Logf("Attempting to update ELBv3 LoadBalancer: %s", loadbalancerID)
+	lbName := tools.RandomString("update-lb-", 3)
 	emptyDescription := ""
 	updateOpts := loadbalancers.UpdateOpts{
 		Name:        lbName,
 		Description: &emptyDescription,
 	}
 
-	_, err = loadbalancers.Update(client, loadbalancer.ID, updateOpts).Extract()
+	_, err = loadbalancers.Update(client, loadbalancerID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
-	t.Logf("Updated ELBv3 LoadBalancer: %s", loadbalancer.ID)
+	t.Logf("Updated ELBv3 LoadBalancer: %s", loadbalancerID)
 
-	newLoadbalancer, err := loadbalancers.Get(client, loadbalancer.ID).Extract()
+	newLoadbalancer, err := loadbalancers.Get(client, loadbalancerID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, updateOpts.Name, newLoadbalancer.Name)
 	th.AssertEquals(t, emptyDescription, newLoadbalancer.Description)

--- a/openstack/elb/v3/certificates/urls.go
+++ b/openstack/elb/v3/certificates/urls.go
@@ -1,16 +1,18 @@
 package certificates
 
-import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	v3 "github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3"
+)
 
 const (
-	rootPath     = "elb"
 	resourcePath = "certificates"
 )
 
 func rootURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(rootPath, resourcePath)
+	return c.ServiceURL(v3.RootPath, resourcePath)
 }
 
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(rootPath, resourcePath, id)
+	return c.ServiceURL(v3.RootPath, resourcePath, id)
 }

--- a/openstack/elb/v3/flavors/urls.go
+++ b/openstack/elb/v3/flavors/urls.go
@@ -1,16 +1,18 @@
 package flavors
 
-import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	v3 "github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3"
+)
 
 const (
-	rootPath     = "elb"
 	resourcePath = "flavors"
 )
 
 func listURL(sc *golangsdk.ServiceClient) string {
-	return sc.ServiceURL(rootPath, resourcePath)
+	return sc.ServiceURL(v3.RootPath, resourcePath)
 }
 
 func getURL(sc *golangsdk.ServiceClient, flavorID string) string {
-	return sc.ServiceURL(rootPath, resourcePath, flavorID)
+	return sc.ServiceURL(v3.RootPath, resourcePath, flavorID)
 }

--- a/openstack/elb/v3/listeners/requests.go
+++ b/openstack/elb/v3/listeners/requests.go
@@ -1,0 +1,226 @@
+package listeners
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
+)
+
+// Protocol represents a listener protocol.
+type Protocol string
+
+// Supported attributes for create/update operations.
+const (
+	ProtocolTCP   Protocol = "TCP"
+	ProtocolUDP   Protocol = "UDP"
+	ProtocolHTTP  Protocol = "HTTP"
+	ProtocolHTTPS Protocol = "HTTPS"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToListenerCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts represents options for creating a listener.
+type CreateOpts struct {
+	// The administrative state of the Listener. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// the ID of the CA certificate used by the listener.
+	CAContainerRef string `json:"client_ca_tls_container_ref,omitempty"`
+
+	// The ID of the default pool with which the Listener is associated.
+	DefaultPoolID string `json:"default_pool_id,omitempty"`
+
+	// A reference to a Barbican container of TLS secrets.
+	DefaultTlsContainerRef string `json:"default_tls_container_ref,omitempty"`
+
+	// Human-readable description for the Listener.
+	Description string `json:"description,omitempty"`
+
+	// whether to use HTTP2.
+	Http2Enable *bool `json:"http2_enable,omitempty"`
+
+	// The load balancer on which to provision this listener.
+	LoadbalancerID string `json:"loadbalancer_id" required:"true"`
+
+	// Human-readable name for the Listener. Does not have to be unique.
+	Name string `json:"name,omitempty"`
+
+	// ProjectID is only required if the caller has an admin role and wants
+	// to create a pool for another project.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// The protocol - can either be TCP, HTTP or HTTPS.
+	Protocol Protocol `json:"protocol" required:"true"`
+
+	// The port on which to listen for client traffic.
+	ProtocolPort int `json:"protocol_port" required:"true"`
+
+	// A list of references to TLS secrets.
+	SniContainerRefs []string `json:"sni_container_refs,omitempty"`
+
+	// A list of Tags.
+	Tags []tags.ResourceTag `json:"tags,omitempty"`
+
+	// Specifies the security policy used by the listener.
+	TlsCiphersPolicy string `json:"tls_ciphers_policy,omitempty"`
+
+	// Whether enable member retry
+	EnableMemberRetry *bool `json:"enable_member_retry,omitempty"`
+
+	// The keepalive timeout of the Listener.
+	KeepAliveTimeout *int `json:"keepalive_timeout,omitempty"`
+
+	// The client timeout of the Listener.
+	ClientTimeout *int `json:"client_timeout,omitempty"`
+
+	// The member timeout of the Listener.
+	MemberTimeout *int `json:"member_timeout,omitempty"`
+
+	// The IpGroup of the Listener.
+	IpGroup *IpGroup `json:"ipgroup,omitempty"`
+
+	// The http insert headers of the Listener.
+	InsertHeaders *InsertHeaders `json:"insert_headers,omitempty"`
+
+	// Transparent client ip enable
+	TransparentClientIP *bool `json:"transparent_client_ip_enable,omitempty"`
+
+	// Enhance L7policy enable
+	EnhanceL7policy *bool `json:"enhance_l7policy_enable,omitempty"`
+}
+
+type IpGroup struct {
+	IpGroupID string `json:"ipgroup_id" required:"true"`
+	Enable    *bool  `json:"enable_ipgroup,omitempty"`
+	Type      string `json:"type,omitempty"`
+}
+
+type InsertHeaders struct {
+	ForwardedELBIP   *bool `json:"X-Forwarded-ELB-IP,omitempty"`
+	ForwardedPort    *bool `json:"X-Forwarded-Port,omitempty"`
+	ForwardedForPort *bool `json:"X-Forwarded-For-Port,omitempty"`
+	ForwardedHost    *bool `json:"X-Forwarded-Host" required:"true"`
+}
+
+// ToListenerCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToListenerCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "listener")
+}
+
+// Create is an operation which provisions a new Listeners based on the
+// configuration defined in the CreateOpts struct. Once the request is
+// validated and progress has started on the provisioning process, a
+// CreateResult will be returned.
+//
+// Users with an admin role can create Listeners on behalf of other tenants by
+// specifying a TenantID attribute different from their own.
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToListenerCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client), b, &r.Body, nil)
+	return
+}
+
+// Get retrieves a particular Listeners based on its unique ID.
+func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, id), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToListenerUpdateMap() (map[string]interface{}, error)
+}
+
+type IpGroupUpdate struct {
+	IpGroupId string `json:"ipgroup_id,omitempty"`
+	Type      string `json:"type,omitempty"`
+}
+
+// UpdateOpts represents options for updating a Listener.
+type UpdateOpts struct {
+	// The administrative state of the Listener. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// the ID of the CA certificate used by the listener.
+	CAContainerRef *string `json:"client_ca_tls_container_ref,omitempty"`
+
+	// The ID of the default pool with which the Listener is associated.
+	DefaultPoolID string `json:"default_pool_id,omitempty"`
+
+	// A reference to a container of TLS secrets.
+	DefaultTlsContainerRef *string `json:"default_tls_container_ref,omitempty"`
+
+	// Human-readable description for the Listener.
+	Description *string `json:"description,omitempty"`
+
+	// whether to use HTTP2.
+	Http2Enable *bool `json:"http2_enable,omitempty"`
+
+	// Human-readable name for the Listener. Does not have to be unique.
+	Name string `json:"name,omitempty"`
+
+	// A list of references to TLS secrets.
+	SniContainerRefs *[]string `json:"sni_container_refs,omitempty"`
+
+	// Specifies the security policy used by the listener.
+	TlsCiphersPolicy *string `json:"tls_ciphers_policy,omitempty"`
+
+	// Whether enable member retry
+	EnableMemberRetry *bool `json:"enable_member_retry,omitempty"`
+
+	// The keepalive timeout of the Listener.
+	KeepAliveTimeout *int `json:"keepalive_timeout,omitempty"`
+
+	// The client timeout of the Listener.
+	ClientTimeout *int `json:"client_timeout,omitempty"`
+
+	// The member timeout of the Listener.
+	MemberTimeout *int `json:"member_timeout,omitempty"`
+
+	// The IpGroup of the Listener.
+	IpGroup *IpGroupUpdate `json:"ipgroup,omitempty"`
+
+	// The http insert headers of the Listener.
+	InsertHeaders *InsertHeaders `json:"insert_headers,omitempty"`
+
+	// Transparent client ip enable
+	TransparentClientIP *bool `json:"transparent_client_ip_enable,omitempty"`
+
+	// Enhance L7policy enable
+	EnhanceL7policy *bool `json:"enhance_l7policy_enable,omitempty"`
+}
+
+// ToListenerUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToListenerUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "listener")
+}
+
+// Update is an operation which modifies the attributes of the specified
+// Listener.
+func Update(client *golangsdk.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+	b, err := opts.ToListenerUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(resourceURL(client, id), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	return
+}
+
+// Delete will permanently delete a particular Listeners based on its unique ID.
+func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, id), nil)
+	return
+}

--- a/openstack/elb/v3/listeners/requests.go
+++ b/openstack/elb/v3/listeners/requests.go
@@ -207,7 +207,7 @@ func (opts UpdateOpts) ToListenerUpdateMap() (map[string]interface{}, error) {
 
 // Update is an operation which modifies the attributes of the specified
 // Listener.
-func Update(client *golangsdk.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToListenerUpdateMap()
 	if err != nil {
 		r.Err = err

--- a/openstack/elb/v3/listeners/results.go
+++ b/openstack/elb/v3/listeners/results.go
@@ -1,0 +1,133 @@
+package listeners
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
+)
+
+// Listener is the primary load balancing configuration object that specifies
+// the loadbalancer and port on which client traffic is received, as well
+// as other details such as the load balancing method to be use, protocol, etc.
+type Listener struct {
+	// The unique ID for the Listener.
+	ID string `json:"id"`
+
+	// The administrative state of the Listener. A valid value is true (UP) or false (DOWN).
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// The ID of the CA certificate used by the listener.
+	CAContainerRef string `json:"client_ca_tls_container_ref"`
+
+	// The maximum number of connections allowed for the Loadbalancer.
+	// Default is -1, meaning no limit.
+	ConnectionLimit int `json:"connection_limit"`
+
+	// Specifies the time when the listener was created.
+	CreatedAt string `json:"created_at"`
+
+	// Specifies the time when the listener was updated.
+	UpdatedAt string `json:"updated_at"`
+
+	// The UUID of default pool. Must have compatible protocol with listener.
+	DefaultPoolID string `json:"default_pool_id"`
+
+	// A reference to a Barbican container of TLS secrets.
+	DefaultTlsContainerRef string `json:"default_tls_container_ref"`
+
+	// Human-readable description for the Listener.
+	Description string `json:"description"`
+
+	// whether to use HTTP2.
+	Http2Enable bool `json:"http2_enable"`
+
+	// A list of load balancer IDs.
+	Loadbalancers []LoadBalancerID `json:"loadbalancers"`
+
+	// Human-readable name for the Listener. Does not have to be unique.
+	Name string `json:"name"`
+
+	// Specifies the ProjectID where the listener is used.
+	ProjectID string `json:"project_id"`
+
+	// The protocol to loadbalancer. A valid value is TCP, HTTP, or HTTPS.
+	Protocol string `json:"protocol"`
+
+	// The port on which to listen to client traffic that is associated with the
+	// Loadbalancer. A valid value is from 0 to 65535.
+	ProtocolPort int `json:"protocol_port"`
+
+	// The list of references to TLS secrets.
+	SniContainerRefs []string `json:"sni_container_refs"`
+
+	// Lists the Tags.
+	Tags []tags.ResourceTag `json:"tags"`
+
+	// Specifies the security policy used by the listener.
+	TlsCiphersPolicy string `json:"tls_ciphers_policy"`
+
+	// Whether enable member retry
+	EnableMemberRetry bool `json:"enable_member_retry"`
+
+	// The keepalive timeout of the Listener.
+	KeepAliveTimeout int `json:"keepalive_timeout"`
+
+	// The client timeout of the Listener.
+	ClientTimeout int `json:"client_timeout"`
+
+	// The member timeout of the Listener.
+	MemberTimeout int `json:"member_timeout"`
+
+	// The ipgroup of the Listener.
+	IpGroup IpGroup `json:"ipgroup"`
+
+	// The http insert headers of the Listener.
+	InsertHeaders InsertHeaders `json:"insert_headers"`
+
+	// Transparent client ip enable
+	TransparentClientIP bool `json:"transparent_client_ip_enable"`
+
+	// Enhance L7policy enable
+	EnhanceL7policy bool `json:"enhance_l7policy_enable"`
+}
+
+type LoadBalancerID struct {
+	ID string `json:"id"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a listener.
+func (r commonResult) Extract() (*Listener, error) {
+	s := new(Listener)
+	err := r.ExtractIntoStructPtr(s, "listener")
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Listener.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Listener.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Listener.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/openstack/elb/v3/listeners/urls.go
+++ b/openstack/elb/v3/listeners/urls.go
@@ -1,0 +1,16 @@
+package listeners
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+const (
+	rootPath     = "elb"
+	resourcePath = "listeners"
+)
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath, resourcePath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id)
+}

--- a/openstack/elb/v3/listeners/urls.go
+++ b/openstack/elb/v3/listeners/urls.go
@@ -1,16 +1,18 @@
 package listeners
 
-import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	v3 "github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3"
+)
 
 const (
-	rootPath     = "elb"
 	resourcePath = "listeners"
 )
 
 func rootURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(rootPath, resourcePath)
+	return c.ServiceURL(v3.RootPath, resourcePath)
 }
 
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(rootPath, resourcePath, id)
+	return c.ServiceURL(v3.RootPath, resourcePath, id)
 }

--- a/openstack/elb/v3/loadbalancers/urls.go
+++ b/openstack/elb/v3/loadbalancers/urls.go
@@ -1,21 +1,23 @@
 package loadbalancers
 
-import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3"
+)
 
 const (
-	rootPath     = "elb"
 	resourcePath = "loadbalancers"
 	statusPath   = "statuses"
 )
 
 func rootURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(rootPath, resourcePath)
+	return c.ServiceURL(v3.RootPath, resourcePath)
 }
 
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(rootPath, resourcePath, id)
+	return c.ServiceURL(v3.RootPath, resourcePath, id)
 }
 
 func statusURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(rootPath, resourcePath, id, statusPath)
+	return c.ServiceURL(v3.RootPath, resourcePath, id, statusPath)
 }

--- a/openstack/elb/v3/urls_common.go
+++ b/openstack/elb/v3/urls_common.go
@@ -1,0 +1,5 @@
+package v3
+
+const (
+	RootPath = "elb"
+)


### PR DESCRIPTION
### What this PR does / why we need it
Implement Dedicated Load Balancer `listeners` pkg

### Which issue this PR fixes
Refers to: #248

### Special notes for your reviewer
```
=== RUN   TestListenerLifecycle
    helpers.go:16: Attempting to create ELBv3 LoadBalancer
    helpers.go:61: Created ELBv3 LoadBalancer: f54b5a8f-5d49-43f8-97e0-da3fc93bd34c
    helpers.go:74: Attempting to create ELBv3 certificate
    helpers.go:141: Created ELBv3 certificate: 4d565438f6fd4578801bca95665e8e25
    listeners_test.go:23: Attempting to create ELBv3 Listener
    listeners_test.go:51: Created ELBv3 Listener: 21909b68-7fa2-4181-b653-6094c2957f5d
    listeners_test.go:53: Attempting to update ELBv3 Listener: 21909b68-7fa2-4181-b653-6094c2957f5d
    listeners_test.go:62: Updated ELBv3 Listener: 21909b68-7fa2-4181-b653-6094c2957f5d
    listeners_test.go:43: Attempting to delete ELBv3 Listener: 21909b68-7fa2-4181-b653-6094c2957f5d
    listeners_test.go:46: Deleted ELBv3 Listener: 21909b68-7fa2-4181-b653-6094c2957f5d
    helpers.go:147: Attempting to delete ELBv3 certificate: 4d565438f6fd4578801bca95665e8e25
    helpers.go:150: Deleted ELBv3 certificate: 4d565438f6fd4578801bca95665e8e25
    helpers.go:67: Attempting to delete ELBv3 LoadBalancer: f54b5a8f-5d49-43f8-97e0-da3fc93bd34c
    helpers.go:70: Deleted ELBv3 LoadBalancer: f54b5a8f-5d49-43f8-97e0-da3fc93bd34c
--- PASS: TestListenerLifecycle (12.73s)
PASS

Process finished with the exit code 0
```
