### PR TITLE
[ELB] Update `v3` client

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -774,7 +774,12 @@ func NewELBV2(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*gol
 
 // NewELBV3 creates a ServiceClient that may be used to access the ELBv3 service.
 func NewELBV3(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
-	return initClientOpts(client, eo, "elbv3")
+	sc, err := initClientOpts(client, eo, "elbv3")
+	if err != nil {
+		return nil, err
+	}
+	sc.ResourceBase = sc.Endpoint + "elb/"
+	return sc, nil
 }
 
 // NewRDSV1 creates a ServiceClient that may be used to access the RDS service.

--- a/openstack/elb/v3/certificates/urls.go
+++ b/openstack/elb/v3/certificates/urls.go
@@ -2,7 +2,6 @@ package certificates
 
 import (
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
-	v3 "github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3"
 )
 
 const (
@@ -10,9 +9,9 @@ const (
 )
 
 func rootURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(v3.RootPath, resourcePath)
+	return c.ServiceURL(resourcePath)
 }
 
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(v3.RootPath, resourcePath, id)
+	return c.ServiceURL(resourcePath, id)
 }

--- a/openstack/elb/v3/flavors/urls.go
+++ b/openstack/elb/v3/flavors/urls.go
@@ -2,7 +2,6 @@ package flavors
 
 import (
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
-	v3 "github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3"
 )
 
 const (
@@ -10,9 +9,9 @@ const (
 )
 
 func listURL(sc *golangsdk.ServiceClient) string {
-	return sc.ServiceURL(v3.RootPath, resourcePath)
+	return sc.ServiceURL(resourcePath)
 }
 
 func getURL(sc *golangsdk.ServiceClient, flavorID string) string {
-	return sc.ServiceURL(v3.RootPath, resourcePath, flavorID)
+	return sc.ServiceURL(resourcePath, flavorID)
 }

--- a/openstack/elb/v3/listeners/urls.go
+++ b/openstack/elb/v3/listeners/urls.go
@@ -2,7 +2,6 @@ package listeners
 
 import (
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
-	v3 "github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3"
 )
 
 const (
@@ -10,9 +9,9 @@ const (
 )
 
 func rootURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(v3.RootPath, resourcePath)
+	return c.ServiceURL(resourcePath)
 }
 
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(v3.RootPath, resourcePath, id)
+	return c.ServiceURL(resourcePath, id)
 }

--- a/openstack/elb/v3/loadbalancers/urls.go
+++ b/openstack/elb/v3/loadbalancers/urls.go
@@ -2,7 +2,6 @@ package loadbalancers
 
 import (
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3"
 )
 
 const (
@@ -11,13 +10,13 @@ const (
 )
 
 func rootURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(v3.RootPath, resourcePath)
+	return c.ServiceURL(resourcePath)
 }
 
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(v3.RootPath, resourcePath, id)
+	return c.ServiceURL(resourcePath, id)
 }
 
 func statusURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(v3.RootPath, resourcePath, id, statusPath)
+	return c.ServiceURL(resourcePath, id, statusPath)
 }

--- a/openstack/elb/v3/urls_common.go
+++ b/openstack/elb/v3/urls_common.go
@@ -1,5 +1,0 @@
-package v3
-
-const (
-	RootPath = "elb"
-)


### PR DESCRIPTION
### What this PR does / why we need it
Simplify v3 pkgs `urls`

### Which issue this PR fixes
Resolves: #255

### Special notes for your reviewer
```
=== RUN   TestListenerLifecycle
    helpers.go:16: Attempting to create ELBv3 LoadBalancer
    helpers.go:61: Created ELBv3 LoadBalancer: 4c3099ea-b628-4637-adcc-801bd0862c8c
    helpers.go:74: Attempting to create ELBv3 certificate
    helpers.go:141: Created ELBv3 certificate: f94c498e24274e4ba287f8ac504e075a
    listeners_test.go:23: Attempting to create ELBv3 Listener
    listeners_test.go:51: Created ELBv3 Listener: 3b607b42-7efc-44cd-a29b-a5312a6120ee
    listeners_test.go:53: Attempting to update ELBv3 Listener: 3b607b42-7efc-44cd-a29b-a5312a6120ee
    listeners_test.go:62: Updated ELBv3 Listener: 3b607b42-7efc-44cd-a29b-a5312a6120ee
    listeners_test.go:43: Attempting to delete ELBv3 Listener: 3b607b42-7efc-44cd-a29b-a5312a6120ee
    listeners_test.go:46: Deleted ELBv3 Listener: 3b607b42-7efc-44cd-a29b-a5312a6120ee
    helpers.go:147: Attempting to delete ELBv3 certificate: f94c498e24274e4ba287f8ac504e075a
    helpers.go:150: Deleted ELBv3 certificate: f94c498e24274e4ba287f8ac504e075a
    helpers.go:67: Attempting to delete ELBv3 LoadBalancer: 4c3099ea-b628-4637-adcc-801bd0862c8c
    helpers.go:70: Deleted ELBv3 LoadBalancer: 4c3099ea-b628-4637-adcc-801bd0862c8c
--- PASS: TestListenerLifecycle (12.26s)
PASS

Process finished with the exit code 0
```