### PR TITLE
[VPCEP] Fix waiting for service deletion

### DIFF
--- a/acceptance/openstack/vpcep/services_test.go
+++ b/acceptance/openstack/vpcep/services_test.go
@@ -78,6 +78,12 @@ func TestServicesWorkflow(t *testing.T) {
 	err = services.WaitForServiceStatus(client, svc.ID, services.StatusAvailable, 30)
 	th.AssertNoErr(t, err)
 
+	defer func() {
+		err := services.Delete(client, svc.ID).ExtractErr()
+		th.AssertNoErr(t, err)
+		th.AssertNoErr(t, services.WaitForServiceStatus(client, svc.ID, services.StatusDeleted, 30))
+	}()
+
 	pages, err := services.List(client, &services.ListOpts{
 		ID: svc.ID,
 	}).AllPages()
@@ -104,9 +110,4 @@ func TestServicesWorkflow(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, fmt.Sprintf("%s.%s.%s", client.RegionID, uOpts.ServiceName, svc.ID), updated.ServiceName)
-
-	defer func() {
-		err := services.Delete(client, svc.ID).ExtractErr()
-		th.AssertNoErr(t, err)
-	}()
 }

--- a/openstack/vpcep/v1/services/requests.go
+++ b/openstack/vpcep/v1/services/requests.go
@@ -188,7 +188,7 @@ func WaitForServiceStatus(client *golangsdk.ServiceClient, id string, status Sta
 	return golangsdk.WaitFor(timeout, func() (bool, error) {
 		srv, err := Get(client, id).Extract()
 		if err != nil {
-			if _, ok := err.(golangsdk.Err404er); ok && status == StatusDeleted {
+			if _, ok := err.(golangsdk.ErrDefault404); ok && status == StatusDeleted {
 				return true, nil
 			}
 			return false, fmt.Errorf("error waiting for service to have status %s: %w", status, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Replace `Err404er` interface with `ErrDefault404` in `services.WaitForServiceStatus`

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->
Fixes #263

### Special notes for your reviewer
```
=== RUN   TestListPublicServices
--- PASS: TestListPublicServices (1.07s)
=== RUN   TestServicesWorkflow
--- PASS: TestServicesWorkflow (10.92s)
PASS

Process finished with the exit code 0
```
