### PR TITLE
Refactoring: remove unused functions in `params`

### DIFF
--- a/params.go
+++ b/params.go
@@ -445,25 +445,3 @@ func BuildHeaders(opts interface{}) (map[string]string, error) {
 	// Return an error if the underlying type of 'opts' isn't a struct.
 	return optsMap, fmt.Errorf("options type is not a struct")
 }
-
-// IDSliceToQueryString takes a slice of elements and converts them into a query
-// string. For example, if name=foo and slice=[]int{20, 40, 60}, then the
-// result would be `?name=20&name=40&name=60'
-func IDSliceToQueryString(name string, ids []int) string {
-	str := ""
-	for k, v := range ids {
-		if k == 0 {
-			str += "?"
-		} else {
-			str += "&"
-		}
-		str += fmt.Sprintf("%s=%s", name, strconv.Itoa(v))
-	}
-	return str
-}
-
-// IntWithinRange returns TRUE if an integer falls within a defined range, and
-// FALSE if not.
-func IntWithinRange(val, min, max int) bool {
-	return val > min && val < max
-}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it

Minor refactoring

Those functions were not used, `IDSliceToQueryString` implemented inside `BuildQueryString` already
