### PR TITLE
[ELB] Implement `monitors` v3 pkg

### DIFF
--- a/acceptance/openstack/elb/v3/monitors_test.go
+++ b/acceptance/openstack/elb/v3/monitors_test.go
@@ -43,6 +43,7 @@ func TestMonitorLifecycle(t *testing.T) {
 		Delay:      1,
 		Timeout:    30,
 		MaxRetries: 3,
+		URLPath:    "/",
 		Name:       monitorName,
 	}
 	monitor, err := monitors.Create(client, createOpts).Extract()

--- a/acceptance/openstack/elb/v3/monitors_test.go
+++ b/acceptance/openstack/elb/v3/monitors_test.go
@@ -39,7 +39,7 @@ func TestMonitorLifecycle(t *testing.T) {
 	monitorName := tools.RandomString("create-monitor-", 3)
 	createOpts := monitors.CreateOpts{
 		PoolID:     poolID,
-		Type:       "HTTP",
+		Type:       monitors.TypeHTTP,
 		Delay:      1,
 		Timeout:    30,
 		MaxRetries: 3,
@@ -48,17 +48,17 @@ func TestMonitorLifecycle(t *testing.T) {
 	}
 	monitor, err := monitors.Create(client, createOpts).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, createOpts.Name, monitor.Name)
-	th.AssertEquals(t, createOpts.Type, monitor.Type)
-	th.AssertEquals(t, createOpts.MaxRetries, monitor.MaxRetries)
-	t.Logf("Created ELBv3 Monitor: %s", monitor.ID)
-
 	defer func() {
-		t.Logf("Attempting to Delete ELBv3 Monitor")
+		t.Logf("Attempting to Delete ELBv3 Monitor: %s", monitor.ID)
 		err := monitors.Delete(client, monitor.ID).ExtractErr()
 		th.AssertNoErr(t, err)
 		t.Logf("Deleted ELBv3 Monitor: %s", monitor.ID)
 	}()
+
+	th.AssertEquals(t, createOpts.Name, monitor.Name)
+	th.AssertEquals(t, createOpts.Type, monitor.Type)
+	th.AssertEquals(t, createOpts.MaxRetries, monitor.MaxRetries)
+	t.Logf("Created ELBv3 Monitor: %s", monitor.ID)
 
 	t.Logf("Attempting to Update ELBv3 Monitor")
 	monitorName = tools.RandomString("update-monitor-", 3)

--- a/acceptance/openstack/elb/v3/monitors_test.go
+++ b/acceptance/openstack/elb/v3/monitors_test.go
@@ -69,6 +69,7 @@ func TestMonitorLifecycle(t *testing.T) {
 		Name:       monitorName,
 	}
 	_, err = monitors.Update(client, monitor.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
 	t.Logf("Updated ELBv3 Monitor: %s", monitor.ID)
 
 	newMonitor, err := monitors.Get(client, monitor.ID).Extract()

--- a/acceptance/openstack/elb/v3/monitors_test.go
+++ b/acceptance/openstack/elb/v3/monitors_test.go
@@ -1,0 +1,79 @@
+package v3
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/elb/v3/monitors"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestMonitorList(t *testing.T) {
+	client, err := clients.NewElbV3Client(t)
+	th.AssertNoErr(t, err)
+
+	listOpts := monitors.ListOpts{}
+	monitorPages, err := monitors.List(client, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+
+	monitorList, err := monitors.ExtractMonitors(monitorPages)
+	th.AssertNoErr(t, err)
+
+	for _, monitor := range monitorList {
+		tools.PrintResource(t, monitor)
+	}
+}
+
+func TestMonitorLifecycle(t *testing.T) {
+	client, err := clients.NewElbV3Client(t)
+	th.AssertNoErr(t, err)
+
+	loadbalancerID := createLoadBalancer(t, client)
+	defer deleteLoadbalancer(t, client, loadbalancerID)
+
+	poolID := createPool(t, client, loadbalancerID)
+	defer deletePool(t, client, poolID)
+
+	t.Logf("Attempting to Create ELBv3 Monitor")
+	monitorName := tools.RandomString("create-monitor-", 3)
+	createOpts := monitors.CreateOpts{
+		PoolID:     poolID,
+		Type:       "HTTP",
+		Delay:      1,
+		Timeout:    30,
+		MaxRetries: 3,
+		Name:       monitorName,
+	}
+	monitor, err := monitors.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, createOpts.Name, monitor.Name)
+	th.AssertEquals(t, createOpts.Type, monitor.Type)
+	th.AssertEquals(t, createOpts.MaxRetries, monitor.MaxRetries)
+	t.Logf("Created ELBv3 Monitor: %s", monitor.ID)
+
+	defer func() {
+		t.Logf("Attempting to Delete ELBv3 Monitor")
+		err := monitors.Delete(client, monitor.ID).ExtractErr()
+		th.AssertNoErr(t, err)
+		t.Logf("Deleted ELBv3 Monitor: %s", monitor.ID)
+	}()
+
+	t.Logf("Attempting to Update ELBv3 Monitor")
+	monitorName = tools.RandomString("update-monitor-", 3)
+	updateOpts := monitors.UpdateOpts{
+		Delay:      3,
+		Timeout:    35,
+		MaxRetries: 5,
+		Name:       monitorName,
+	}
+	_, err = monitors.Update(client, monitor.ID, updateOpts).Extract()
+	t.Logf("Updated ELBv3 Monitor: %s", monitor.ID)
+
+	newMonitor, err := monitors.Get(client, monitor.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, updateOpts.Name, newMonitor.Name)
+	th.AssertEquals(t, updateOpts.Timeout, newMonitor.Timeout)
+	th.AssertEquals(t, updateOpts.Delay, newMonitor.Delay)
+	th.AssertEquals(t, updateOpts.MaxRetries, newMonitor.MaxRetries)
+}

--- a/openstack/elb/v3/monitors/requests.go
+++ b/openstack/elb/v3/monitors/requests.go
@@ -68,12 +68,14 @@ func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Page
 	})
 }
 
+type Type string
+
 // Constants that represent approved monitoring types.
 const (
-	TypePING  = "PING"
-	TypeTCP   = "TCP"
-	TypeHTTP  = "HTTP"
-	TypeHTTPS = "HTTPS"
+	TypePING  Type = "PING"
+	TypeTCP   Type = "TCP"
+	TypeHTTP  Type = "HTTP"
+	TypeHTTPS Type = "HTTPS"
 )
 
 // CreateOptsBuilder allows extensions to add additional parameters to the
@@ -90,7 +92,7 @@ type CreateOpts struct {
 
 	// The type of probe, which is PING, TCP, HTTP, or HTTPS, that is
 	// sent by the load balancer to verify the member state.
-	Type string `json:"type" required:"true"`
+	Type Type `json:"type" required:"true"`
 
 	// The time, in seconds, between sending probes to members.
 	Delay int `json:"delay" required:"true"`
@@ -103,6 +105,8 @@ type CreateOpts struct {
 	// status to INACTIVE. Must be a number between 1 and 10.
 	MaxRetries int `json:"max_retries" required:"true"`
 
+	// Specifies the number of consecutive health checks when the health
+	// check result of a backend server changes from ONLINE to OFFLINE.
 	MaxRetriesDown int `json:"max_retries_down,omitempty"`
 
 	// URI path that will be accessed if Monitor type is HTTP or HTTPS.

--- a/openstack/elb/v3/monitors/requests.go
+++ b/openstack/elb/v3/monitors/requests.go
@@ -64,7 +64,7 @@ func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Page
 		url += query
 	}
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return MonitorPage{pagination.LinkedPageBase{PageResult: r}}
+		return MonitorPage{PageWithInfo: pagination.NewPageWithInfo(r)}
 	})
 }
 

--- a/openstack/elb/v3/monitors/requests.go
+++ b/openstack/elb/v3/monitors/requests.go
@@ -103,10 +103,7 @@ type CreateOpts struct {
 
 	// Number of permissible ping failures before changing the member's
 	// status to INACTIVE. Must be a number between 1 and 10.
-	MaxRetries int `json:"max_retries" required:"true"`
-
-	// Specifies the number of consecutive health checks when the health
-	// check result of a backend server changes from ONLINE to OFFLINE.
+	MaxRetries     int `json:"max_retries" required:"true"`
 	MaxRetriesDown int `json:"max_retries_down,omitempty"`
 
 	// URI path that will be accessed if Monitor type is HTTP or HTTPS.

--- a/openstack/elb/v3/monitors/requests.go
+++ b/openstack/elb/v3/monitors/requests.go
@@ -1,0 +1,250 @@
+package monitors
+
+import (
+	"fmt"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToMonitorListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the Monitor attributes you want to see returned. SortKey allows you to
+// sort by a particular Monitor attribute. SortDir sets the direction, and is
+// either `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	ID            string `q:"id"`
+	Name          string `q:"name"`
+	TenantID      string `q:"tenant_id"`
+	ProjectID     string `q:"project_id"`
+	PoolID        string `q:"pool_id"`
+	Type          string `q:"type"`
+	Delay         int    `q:"delay"`
+	Timeout       int    `q:"timeout"`
+	MaxRetries    int    `q:"max_retries"`
+	HTTPMethod    string `q:"http_method"`
+	URLPath       string `q:"url_path"`
+	ExpectedCodes string `q:"expected_codes"`
+	AdminStateUp  *bool  `q:"admin_state_up"`
+	Status        string `q:"status"`
+	Limit         int    `q:"limit"`
+	Marker        string `q:"marker"`
+	SortKey       string `q:"sort_key"`
+	SortDir       string `q:"sort_dir"`
+}
+
+// ToMonitorListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToMonitorListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), nil
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// health monitors. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+//
+// Default policy settings return only those health monitors that are owned by the
+// tenant who submits the request, unless an admin user submits the request.
+func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client)
+	if opts != nil {
+		query, err := opts.ToMonitorListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return MonitorPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Constants that represent approved monitoring types.
+const (
+	TypePING  = "PING"
+	TypeTCP   = "TCP"
+	TypeHTTP  = "HTTP"
+	TypeHTTPS = "HTTPS"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type CreateOptsBuilder interface {
+	ToMonitorCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts is the common options' struct used in this package's Create
+// operation.
+type CreateOpts struct {
+	// The Pool to Monitor.
+	PoolID string `json:"pool_id" required:"true"`
+
+	// The type of probe, which is PING, TCP, HTTP, or HTTPS, that is
+	// sent by the load balancer to verify the member state.
+	Type string `json:"type" required:"true"`
+
+	// The time, in seconds, between sending probes to members.
+	Delay int `json:"delay" required:"true"`
+
+	// Maximum number of seconds for a Monitor to wait for a ping reply
+	// before it times out. The value must be less than the delay value.
+	Timeout int `json:"timeout" required:"true"`
+
+	// Number of permissible ping failures before changing the member's
+	// status to INACTIVE. Must be a number between 1 and 10.
+	MaxRetries int `json:"max_retries" required:"true"`
+
+	MaxRetriesDown int `json:"max_retries_down,omitempty"`
+
+	// URI path that will be accessed if Monitor type is HTTP or HTTPS.
+	// Required for HTTP(S) types.
+	URLPath string `json:"url_path,omitempty"`
+
+	// Domain Name.
+	DomainName string `json:"domain_name,omitempty"`
+
+	// The HTTP method used for requests by the Monitor. If this attribute
+	// is not specified, it defaults to "GET".
+	HTTPMethod string `json:"http_method,omitempty"`
+
+	// Expected HTTP codes for a passing HTTP(S) Monitor. You can either specify
+	// a single status like "200", or a range like "200-202".
+	ExpectedCodes string `json:"expected_codes,omitempty"`
+
+	// ProjectID is the UUID of the project who owns the Monitor.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// The Name of the Monitor.
+	Name string `json:"name,omitempty"`
+
+	// The administrative state of the Monitor. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// The Port of the Monitor.
+	MonitorPort int `json:"monitor_port,omitempty"`
+}
+
+// ToMonitorCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToMonitorCreateMap() (map[string]interface{}, error) {
+	if opts.Type == TypeHTTP || opts.Type == TypeHTTPS {
+		if opts.URLPath == "" {
+			return nil, fmt.Errorf("`url_path` must be provided for HTTP and HTTPS")
+		}
+	}
+
+	b, err := golangsdk.BuildRequestBody(opts, "healthmonitor")
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// Create is an operation which provisions a new Health Monitor. There are
+// different types of Monitor you can provision: PING, TCP or HTTP(S). Below
+// are examples of how to create each one.
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToMonitorCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(rootURL(client), b, &r.Body, nil)
+	return
+}
+
+// Get retrieves a particular Health Monitor based on its unique ID.
+func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, id), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToMonitorUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts is the common options' struct used in this package's Update
+// operation.
+type UpdateOpts struct {
+	// The time, in seconds, between sending probes to members.
+	Delay int `json:"delay,omitempty"`
+
+	// Maximum number of seconds for a Monitor to wait for a ping reply
+	// before it times out. The value must be less than the delay value.
+	Timeout int `json:"timeout,omitempty"`
+
+	// Number of permissible ping failures before changing the member's
+	// status to INACTIVE. Must be a number between 1 and 10.
+	MaxRetries int `json:"max_retries,omitempty"`
+
+	MaxRetriesDown int `json:"max_retries_down,omitempty"`
+
+	// URI path that will be accessed if Monitor type is HTTP or HTTPS.
+	// Required for HTTP(S) types.
+	URLPath string `json:"url_path,omitempty"`
+
+	// Domain Name.
+	DomainName string `json:"domain_name,omitempty"`
+
+	// The HTTP method used for requests by the Monitor. If this attribute
+	// is not specified, it defaults to "GET". Required for HTTP(S) types.
+	HTTPMethod string `json:"http_method,omitempty"`
+
+	// Expected HTTP codes for a passing HTTP(S) Monitor. You can either specify
+	// a single status like "200", or a range like "200-202". Required for HTTP(S)
+	// types.
+	ExpectedCodes string `json:"expected_codes,omitempty"`
+
+	// The Name of the Monitor.
+	Name string `json:"name,omitempty"`
+
+	// The administrative state of the Monitor. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// The Port of the Monitor.
+	MonitorPort int `json:"monitor_port,omitempty"`
+
+	// The type of probe, which is PING, TCP, HTTP, or HTTPS, that is
+	// sent by the load balancer to verify the member state.
+	Type string `json:"type,omitempty"`
+}
+
+// ToMonitorUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToMonitorUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "healthmonitor")
+}
+
+// Update is an operation which modifies the attributes of the specified
+// Monitor.
+func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToMonitorUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Put(resourceURL(client, id), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	return
+}
+
+// Delete will permanently delete a particular Monitor based on its unique ID.
+func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, id), nil)
+	return
+}

--- a/openstack/elb/v3/monitors/results.go
+++ b/openstack/elb/v3/monitors/results.go
@@ -44,10 +44,7 @@ type Monitor struct {
 
 	// Number of allowed connection failures before changing the status of the
 	// member to INACTIVE. A valid value is from 1 to 10.
-	MaxRetries int `json:"max_retries"`
-
-	// Specifies the number of consecutive health checks when the health
-	// check result of a backend server changes from ONLINE to OFFLINE.
+	MaxRetries     int `json:"max_retries"`
 	MaxRetriesDown int `json:"max_retries_down"`
 
 	// The HTTP method that the monitor uses for requests.

--- a/openstack/elb/v3/monitors/results.go
+++ b/openstack/elb/v3/monitors/results.go
@@ -32,7 +32,7 @@ type Monitor struct {
 
 	// The type of probe sent by the load balancer to verify the member state,
 	// which is PING, TCP, HTTP, or HTTPS.
-	Type string `json:"type"`
+	Type Type `json:"type"`
 
 	// The time, in seconds, between sending probes to members.
 	Delay int `json:"delay"`
@@ -45,6 +45,10 @@ type Monitor struct {
 	// Number of allowed connection failures before changing the status of the
 	// member to INACTIVE. A valid value is from 1 to 10.
 	MaxRetries int `json:"max_retries"`
+
+	// Specifies the number of consecutive health checks when the health
+	// check result of a backend server changes from ONLINE to OFFLINE.
+	MaxRetriesDown int `json:"max_retries_down"`
 
 	// The HTTP method that the monitor uses for requests.
 	HTTPMethod string `json:"http_method"`

--- a/openstack/elb/v3/monitors/results.go
+++ b/openstack/elb/v3/monitors/results.go
@@ -71,14 +71,10 @@ type Monitor struct {
 	Status string `json:"status"`
 
 	// List of pools that are associated with the health monitor.
-	Pools []PoolID `json:"pools"`
-
-	// The provisioning status of the monitor.
-	// This value is ACTIVE, PENDING_* or ERROR.
-	ProvisioningStatus string `json:"provisioning_status"`
+	Pools []PoolRef `json:"pools"`
 }
 
-type PoolID struct {
+type PoolRef struct {
 	ID string `json:"id"`
 }
 

--- a/openstack/elb/v3/monitors/results.go
+++ b/openstack/elb/v3/monitors/results.go
@@ -1,0 +1,161 @@
+package monitors
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+)
+
+// Monitor represents a load balancer health monitor. A health monitor is used
+// to determine whether back-end members of the VIP's pool are usable
+// for processing a request. A pool can have several health monitors associated
+// with it. There are different types of health monitors supported:
+//
+// PING: used to ping the members using ICMP.
+// TCP: used to connect to the members using TCP.
+// HTTP: used to send an HTTP request to the member.
+// HTTPS: used to send a secure HTTP request to the member.
+//
+// When a pool has several monitors associated with it, each member of the pool
+// is monitored by all these monitors. If any monitor declares the member as
+// unhealthy, then the member status is changed to INACTIVE and the member
+// won't participate in its pool's load balancing. In other words, ALL monitors
+// must declare the member to be healthy for it to stay ACTIVE.
+type Monitor struct {
+	// The unique ID for the Monitor.
+	ID string `json:"id"`
+
+	// The Name of the Monitor.
+	Name string `json:"name"`
+
+	// TenantID is the owner of the Monitor.
+	TenantID string `json:"tenant_id"`
+
+	// The type of probe sent by the load balancer to verify the member state,
+	// which is PING, TCP, HTTP, or HTTPS.
+	Type string `json:"type"`
+
+	// The time, in seconds, between sending probes to members.
+	Delay int `json:"delay"`
+
+	// The maximum number of seconds for a monitor to wait for a connection to be
+	// established before it times out. This value must be less than the delay
+	// value.
+	Timeout int `json:"timeout"`
+
+	// Number of allowed connection failures before changing the status of the
+	// member to INACTIVE. A valid value is from 1 to 10.
+	MaxRetries int `json:"max_retries"`
+
+	// The HTTP method that the monitor uses for requests.
+	HTTPMethod string `json:"http_method"`
+
+	// The HTTP path of the request sent by the monitor to test the health of a
+	// member. Must be a string beginning with a forward slash (/).
+	URLPath string `json:"url_path"`
+
+	// Domain Name.
+	DomainName string `json:"domain_name"`
+
+	// Expected HTTP codes for a passing HTTP(S) monitor.
+	ExpectedCodes string `json:"expected_codes"`
+
+	// The administrative state of the health monitor, which is up (true) or
+	// down (false).
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// The Port of the Monitor.
+	MonitorPort int `json:"monitor_port"`
+
+	// The status of the health monitor. Indicates whether the health monitor is
+	// operational.
+	Status string `json:"status"`
+
+	// List of pools that are associated with the health monitor.
+	Pools []PoolID `json:"pools"`
+
+	// The provisioning status of the monitor.
+	// This value is ACTIVE, PENDING_* or ERROR.
+	ProvisioningStatus string `json:"provisioning_status"`
+}
+
+type PoolID struct {
+	ID string `json:"id"`
+}
+
+// MonitorPage is the page returned by a pager when traversing over a
+// collection of health monitors.
+type MonitorPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of monitors has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r MonitorPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []golangsdk.Link `json:"healthmonitors_links"`
+	}
+
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+
+	return golangsdk.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a MonitorPage struct is empty.
+func (r MonitorPage) IsEmpty() (bool, error) {
+	is, err := ExtractMonitors(r)
+	return len(is) == 0, err
+}
+
+// ExtractMonitors accepts a Page struct, specifically a MonitorPage struct,
+// and extracts the elements into a slice of Monitor structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractMonitors(r pagination.Page) ([]Monitor, error) {
+	var s []Monitor
+	err := (r.(MonitorPage)).ExtractIntoSlicePtr(&s, "healthmonitors")
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a monitor.
+func (r commonResult) Extract() (*Monitor, error) {
+	s := new(Monitor)
+	err := r.ExtractIntoStructPtr(s, "healthmonitor")
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Monitor.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Monitor.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Monitor.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the result succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/openstack/elb/v3/monitors/results.go
+++ b/openstack/elb/v3/monitors/results.go
@@ -81,23 +81,7 @@ type PoolRef struct {
 // MonitorPage is the page returned by a pager when traversing over a
 // collection of health monitors.
 type MonitorPage struct {
-	pagination.LinkedPageBase
-}
-
-// NextPageURL is invoked when a paginated collection of monitors has reached
-// the end of a page and the pager seeks to traverse over a new one. In order
-// to do this, it needs to construct the next page's URL.
-func (r MonitorPage) NextPageURL() (string, error) {
-	var s struct {
-		Links []golangsdk.Link `json:"healthmonitors_links"`
-	}
-
-	err := r.ExtractInto(&s)
-	if err != nil {
-		return "", err
-	}
-
-	return golangsdk.ExtractNextURL(s.Links)
+	pagination.PageWithInfo
 }
 
 // IsEmpty checks whether a MonitorPage struct is empty.

--- a/openstack/elb/v3/monitors/results.go
+++ b/openstack/elb/v3/monitors/results.go
@@ -126,7 +126,7 @@ type commonResult struct {
 	golangsdk.Result
 }
 
-// Extract is a function that accepts a result and extracts a monitor.
+// Extract is a function that accepts a result and extracts a Monitor.
 func (r commonResult) Extract() (*Monitor, error) {
 	s := new(Monitor)
 	err := r.ExtractIntoStructPtr(s, "healthmonitor")

--- a/openstack/elb/v3/monitors/urls.go
+++ b/openstack/elb/v3/monitors/urls.go
@@ -1,0 +1,15 @@
+package monitors
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+const (
+	resourcePath = "healthmonitors"
+)
+
+func rootURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL(resourcePath)
+}
+
+func resourceURL(client *golangsdk.ServiceClient, id string) string {
+	return client.ServiceURL(resourcePath, id)
+}


### PR DESCRIPTION
### What this PR does / why we need it
Implement Dedicated Load Balancer `monitors` v3 pkg

### Which issue this PR fixes
Refers to: #248

### Special notes for your reviewer
```
=== RUN   TestMonitorList
--- PASS: TestMonitorList (1.98s)
=== RUN   TestMonitorLifecycle
    helpers.go:18: Attempting to create ELBv3 LoadBalancer
    helpers.go:56: Created ELBv3 LoadBalancer: b3b3002e-506d-4360-88bc-8ff4d1479b9f
    helpers.go:149: Attempting to create ELBv3 Pool
    helpers.go:164: Created ELBv3 Pool: 6f1b842f-4290-4bf7-950c-7aa443e5331e
    monitors_test.go:38: Attempting to Create ELBv3 Monitor
    monitors_test.go:61: Created ELBv3 Monitor: 3b7b2aa5-5a98-4a14-b6e1-c8d857fc4280
    monitors_test.go:63: Attempting to Update ELBv3 Monitor
    monitors_test.go:72: Updated ELBv3 Monitor: 3b7b2aa5-5a98-4a14-b6e1-c8d857fc4280
    monitors_test.go:52: Attempting to Delete ELBv3 Monitor: 3b7b2aa5-5a98-4a14-b6e1-c8d857fc4280
    monitors_test.go:55: Deleted ELBv3 Monitor: 3b7b2aa5-5a98-4a14-b6e1-c8d857fc4280
    helpers.go:170: Attempting to delete ELBv3 Pool: 6f1b842f-4290-4bf7-950c-7aa443e5331e
    helpers.go:173: Deleted ELBv3 Pool: 6f1b842f-4290-4bf7-950c-7aa443e5331e
    helpers.go:62: Attempting to delete ELBv3 LoadBalancer: b3b3002e-506d-4360-88bc-8ff4d1479b9f
    helpers.go:65: Deleted ELBv3 LoadBalancer: b3b3002e-506d-4360-88bc-8ff4d1479b9f
--- PASS: TestMonitorLifecycle (10.17s)
PASS

Process finished with the exit code 0
```
