### PR TITLE
Implement `InfoPage` in `pagination` pkg

### DIFF
--- a/pagination/info.go
+++ b/pagination/info.go
@@ -1,0 +1,48 @@
+package pagination
+
+// PageWithInfo is a page with marker information inside `page_info`
+type PageWithInfo struct {
+	MarkerPageBase
+}
+
+type pageInfo struct {
+	PreviousMarker string `json:"previous_marker"`
+	NextMarker     string `json:"next_marker"`
+	CurrentCount   int    `json:"current_count"`
+}
+
+func (p PageWithInfo) LastMarker() (string, error) {
+	var info pageInfo
+	err := p.ExtractIntoStructPtr(&info, "page_info")
+	if err != nil {
+		return "", err
+	}
+	return info.NextMarker, nil
+}
+
+// NextPageURL generates the URL for the page of results after this one.
+func (p PageWithInfo) NextPageURL() (string, error) {
+	currentURL := p.URL
+
+	mark, err := p.Owner.LastMarker()
+	if err != nil {
+		return "", err
+	}
+	if mark == "" {
+		return "", nil
+	}
+
+	q := currentURL.Query()
+	q.Set("marker", mark)
+	currentURL.RawQuery = q.Encode()
+
+	return currentURL.String(), nil
+}
+
+func NewPageWithInfo(r PageResult) PageWithInfo {
+	p := PageWithInfo{MarkerPageBase: MarkerPageBase{
+		PageResult: r,
+	}}
+	p.Owner = &p
+	return p
+}

--- a/pagination/testing/info_test.go
+++ b/pagination/testing/info_test.go
@@ -1,0 +1,130 @@
+package testing
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+type InfoPageResult struct {
+	pagination.PageWithInfo
+}
+
+func (p InfoPageResult) IsEmpty() (bool, error) {
+	l, err := ExtractStructs(p)
+	if err != nil {
+		return false, err
+	}
+	return len(l) == 0, nil
+}
+
+type Struct struct {
+	ID string `json:"id"`
+}
+
+func ExtractStructs(p pagination.Page) ([]Struct, error) {
+	var structs []Struct
+	err := p.(InfoPageResult).ExtractIntoSlicePtr(&structs, "structs")
+	if err != nil {
+		return nil, err
+	}
+	return structs, nil
+}
+
+var expectedPolicies = []Struct{
+	{
+		ID: tools.RandomString("plc-", 20),
+	},
+	{
+		ID: tools.RandomString("plc-", 20),
+	},
+	{
+		ID: tools.RandomString("plc-", 20),
+	},
+	{
+		ID: tools.RandomString("plc-", 20),
+	},
+}
+
+func createInfoPager(t *testing.T) pagination.Pager {
+	th.SetupHTTP()
+
+	th.Mux.HandleFunc("/page", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		ms := r.Form["marker"]
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch {
+		case len(ms) == 0:
+			allJson, _ := json.MarshalIndent(expectedPolicies[:2], "", "  ")
+			response := fmt.Sprintf(`
+{
+  "page_info": {
+    "next_marker": "%s"
+  },
+  "structs": %s
+}
+`, expectedPolicies[2].ID, allJson)
+			_, _ = fmt.Fprint(w, response)
+		case len(ms) == 1 && ms[0] == expectedPolicies[2].ID:
+			allJson, _ := json.MarshalIndent(expectedPolicies[2:], "", "  ")
+			response := fmt.Sprintf(`
+{
+  "page_info": {
+  },
+  "structs": %s
+}
+`, allJson)
+			_, _ = fmt.Fprint(w, response)
+		default:
+			t.Errorf("Request with unexpected marker: [%v]", ms)
+		}
+	})
+
+	client := createClient()
+	return pagination.NewPager(client, th.Server.URL+"/page", func(r pagination.PageResult) pagination.Page {
+		return InfoPageResult{PageWithInfo: pagination.NewPageWithInfo(r)}
+	})
+}
+
+func TestInfoPageResult(t *testing.T) {
+	pager := createInfoPager(t)
+	defer th.TeardownHTTP()
+
+	callCount := 0
+	err := pager.EachPage(func(page pagination.Page) (bool, error) {
+		actual, err := ExtractStructs(page)
+		if err != nil {
+			return false, err
+		}
+		t.Logf("Handler invoked with %+v", actual)
+
+		switch callCount {
+		case 0:
+			th.AssertDeepEquals(t, actual, expectedPolicies[:2])
+		case 1:
+			th.AssertDeepEquals(t, actual, expectedPolicies[2:])
+		}
+
+		callCount += 1
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 2, callCount)
+}
+
+func TestInfoPageAll(t *testing.T) {
+	pager := createInfoPager(t)
+	defer th.TeardownHTTP()
+
+	page, err := pager.AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := ExtractStructs(page)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedPolicies, actual)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
The same `page_info` pagination is used at least in ELBv3 `policies` and `rules`
