### PR TITLE
[ELB] Use `PageWithInfo` in `v3` resources

### DIFF
--- a/openstack/elb/v3/flavors/requests.go
+++ b/openstack/elb/v3/flavors/requests.go
@@ -44,7 +44,7 @@ func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Page
 		url += queryString
 	}
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return FlavorPage{pagination.LinkedPageBase{PageResult: r}}
+		return FlavorPage{PageWithInfo: pagination.NewPageWithInfo(r)}
 	})
 }
 

--- a/openstack/elb/v3/flavors/results.go
+++ b/openstack/elb/v3/flavors/results.go
@@ -48,7 +48,7 @@ type FlavorInfo struct {
 // FlavorPage is the page returned by a pager when traversing over a
 // collection of flavor.
 type FlavorPage struct {
-	pagination.LinkedPageBase
+	pagination.PageWithInfo
 }
 
 // IsEmpty checks whether a FlavorsPage struct is empty.

--- a/openstack/elb/v3/loadbalancers/requests.go
+++ b/openstack/elb/v3/loadbalancers/requests.go
@@ -47,9 +47,7 @@ func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Page
 		url += query
 	}
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		p := LoadbalancerPage{pagination.MarkerPageBase{PageResult: r}}
-		p.MarkerPageBase.Owner = p
-		return p
+		return LoadbalancerPage{PageWithInfo: pagination.NewPageWithInfo(r)}
 	})
 }
 

--- a/openstack/elb/v3/loadbalancers/results.go
+++ b/openstack/elb/v3/loadbalancers/results.go
@@ -175,18 +175,7 @@ func (r GetStatusesResult) Extract() (*StatusTree, error) {
 // LoadbalancerPage is the page returned by a pager when traversing over a
 // collection of loadbalancer.
 type LoadbalancerPage struct {
-	pagination.MarkerPageBase
-}
-
-func (r LoadbalancerPage) LastMarker() (string, error) {
-	results, err := ExtractLoadbalancers(r)
-	if err != nil {
-		return "", err
-	}
-	if len(results) == 0 {
-		return "", nil
-	}
-	return results[len(results)-1].ID, nil
+	pagination.PageWithInfo
 }
 
 // IsEmpty checks whether a FlavorsPage struct is empty.

--- a/openstack/elb/v3/members/requests.go
+++ b/openstack/elb/v3/members/requests.go
@@ -56,9 +56,7 @@ func List(client *golangsdk.ServiceClient, poolID string, opts ListOptsBuilder) 
 		url += query
 	}
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		p := MemberPage{pagination.MarkerPageBase{PageResult: r}}
-		p.MarkerPageBase.Owner = p
-		return p
+		return MemberPage{PageWithInfo: pagination.NewPageWithInfo(r)}
 	})
 }
 

--- a/openstack/elb/v3/members/results.go
+++ b/openstack/elb/v3/members/results.go
@@ -43,18 +43,15 @@ type Member struct {
 // MemberPage is the page returned by a pager when traversing over a
 // collection of Members in a Pool.
 type MemberPage struct {
-	pagination.MarkerPageBase
+	pagination.PageWithInfo
 }
 
-func (r MemberPage) LastMarker() (string, error) {
-	results, err := ExtractMembers(r)
+func (p MemberPage) IsEmpty() (bool, error) {
+	l, err := ExtractMembers(p)
 	if err != nil {
-		return "", err
+		return false, err
 	}
-	if len(results) == 0 {
-		return "", nil
-	}
-	return results[len(results)-1].ID, nil
+	return len(l) == 0, nil
 }
 
 // ExtractMembers accepts a Page struct, specifically a MemberPage struct,

--- a/openstack/elb/v3/policies/requests.go
+++ b/openstack/elb/v3/policies/requests.go
@@ -133,9 +133,7 @@ func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Page
 	}
 
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		p := PolicyPage{MarkerPageBase: pagination.MarkerPageBase{PageResult: r}}
-		p.Owner = &p
-		return p
+		return PolicyPage{PageWithInfo: pagination.NewPageWithInfo(r)}
 	})
 }
 

--- a/openstack/elb/v3/policies/results.go
+++ b/openstack/elb/v3/policies/results.go
@@ -52,42 +52,8 @@ type DeleteResult struct {
 	golangsdk.ErrResult
 }
 
-type PageInfo struct {
-	PreviousMarker string `json:"previous_marker"`
-	NextMarker     string `json:"next_marker"`
-	CurrentCount   int    `json:"current_count"`
-}
-
 type PolicyPage struct {
-	pagination.MarkerPageBase
-}
-
-func (p PolicyPage) LastMarker() (string, error) {
-	var info PageInfo
-	err := p.ExtractIntoStructPtr(&info, "page_info")
-	if err != nil {
-		return "", err
-	}
-	return info.NextMarker, nil
-}
-
-// NextPageURL generates the URL for the page of results after this one.
-func (p PolicyPage) NextPageURL() (string, error) {
-	currentURL := p.URL
-
-	mark, err := p.Owner.LastMarker()
-	if err != nil {
-		return "", err
-	}
-	if mark == "" {
-		return "", nil
-	}
-
-	q := currentURL.Query()
-	q.Set("marker", mark)
-	currentURL.RawQuery = q.Encode()
-
-	return currentURL.String(), nil
+	pagination.PageWithInfo
 }
 
 func (p PolicyPage) IsEmpty() (bool, error) {

--- a/openstack/elb/v3/pools/requests.go
+++ b/openstack/elb/v3/pools/requests.go
@@ -56,9 +56,7 @@ func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Page
 		url += query
 	}
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		p := PoolPage{pagination.MarkerPageBase{PageResult: r}}
-		p.MarkerPageBase.Owner = p
-		return p
+		return PoolPage{PageWithInfo: pagination.NewPageWithInfo(r)}
 	})
 }
 

--- a/openstack/elb/v3/pools/results.go
+++ b/openstack/elb/v3/pools/results.go
@@ -71,18 +71,7 @@ type Pool struct {
 // PoolPage is the page returned by a pager when traversing over a
 // collection of pools.
 type PoolPage struct {
-	pagination.MarkerPageBase
-}
-
-func (r PoolPage) LastMarker() (string, error) {
-	results, err := ExtractPools(r)
-	if err != nil {
-		return "", err
-	}
-	if len(results) == 0 {
-		return "", nil
-	}
-	return results[len(results)-1].ID, nil
+	pagination.PageWithInfo
 }
 
 // IsEmpty checks whether a PoolPage struct is empty.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Use `pagination.PageWithInfo` as a base for `PolicyPage`

### Special notes for your reviewer
```
=== RUN   TestCertificateList
    tools.go:72: {
          "id": "9f5dc5a582594e5c8114fce0c6d42604",
          "name": "cert-8603",
          "description": "",
          "type": "server",
          "domain": "www.voronezh.dada.ru",
          "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIICXQIBAAKBgQDFPN9ojPndxSC4E1pqWQVKGHCFlXAAGBOxbGfSzXqzsoyacotu\neqMqXQbxrPSQFATeVmhZPNVEMdvcAMjYsV/mymtAwVqVA6q/OFdX/b3UHO+b/VqL\no3J5SrM86Veqnjzwu4oCSabuEDiN+tga1syQmEG4OFM6NSmAYSxcZdE6LwIDAQAB\nAoGBAJvLzJCyIsCJcKHWL6onbSUtDtyFwPViD1QrVAtQYabF14g8CGUZG/9fgheu\nTXPtTDcvu7cZdUArvgYW3I9F9IBb2lmF3a44xfiAKdDhzr4DK/vQhvHPuuTeZA41\nr2zp8Cu+Bp40pSxmoAOK3B0/peZAka01Ju7c7ZChDWrxleHZAkEA/6dcaWHotfGS\neW5YLbSms3f0m0GH38nRl7oxyCW6yMIDkFHURVMBKW1OhrcuGo8u0nTMi5IH9gRg\n5bH8XcujlQJBAMWBQgzCHyoSeryD3TFieXIFzgDBw6Ve5hyMjUtjvgdVKoxRPvpO\nkclc39QHP6Dm2wrXXHEej+9RILxBZCVQNbMCQQC42i+Ut0nHvPuXN/UkXzomDHde\nh1ySsOAO4H+8Y6OSI87l3HUrByCQ7stX1z3L0HofjHqV9Koy9emGTFLZEzSdAkB7\nEi6cUKKmztkYe3rr+RcATEmwAw3tEJOHmrW5ErApVZKr2TzLMQZ7WZpIPzQRCYnY\n2ZZLDuZWFFG3vW+wKKktAkAaQ5GNzbwkRLpXF1FZFuNF7erxypzstbUmU/31b7tS\ni5LmxTGKL/xRYtZEHjya4Ikkkgt40q1MrUsgIYbFYMf2\n-----END RSA PRIVATE KEY-----",
          "certificate": "-----BEGIN CERTIFICATE-----\nMIIDIjCCAougAwIBAgIJALV96mEtVF4EMA0GCSqGSIb3DQEBBQUAMGoxCzAJBgNV\nBAYTAnh4MQswCQYDVQQIEwJ4eDELMAkGA1UEBxMCeHgxCzAJBgNVBAoTAnh4MQsw\nCQYDVQQLEwJ4eDELMAkGA1UEAxMCeHgxGjAYBgkqhkiG9w0BCQEWC3h4eEAxNjMu\nY29tMB4XDTE3MTExMzAyMjYxM1oXDTIwMTExMjAyMjYxM1owajELMAkGA1UEBhMC\neHgxCzAJBgNVBAgTAnh4MQswCQYDVQQHEwJ4eDELMAkGA1UEChMCeHgxCzAJBgNV\nBAsTAnh4MQswCQYDVQQDEwJ4eDEaMBgGCSqGSIb3DQEJARYLeHh4QDE2My5jb20w\ngZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMU832iM+d3FILgTWmpZBUoYcIWV\ncAAYE7FsZ9LNerOyjJpyi256oypdBvGs9JAUBN5WaFk81UQx29wAyNixX+bKa0DB\nWpUDqr84V1f9vdQc75v9WoujcnlKszzpV6qePPC7igJJpu4QOI362BrWzJCYQbg4\nUzo1KYBhLFxl0TovAgMBAAGjgc8wgcwwHQYDVR0OBBYEFMbTvDyvE2KsRy9zPq/J\nWOjovG+WMIGcBgNVHSMEgZQwgZGAFMbTvDyvE2KsRy9zPq/JWOjovG+WoW6kbDBq\nMQswCQYDVQQGEwJ4eDELMAkGA1UECBMCeHgxCzAJBgNVBAcTAnh4MQswCQYDVQQK\nEwJ4eDELMAkGA1UECxMCeHgxCzAJBgNVBAMTAnh4MRowGAYJKoZIhvcNAQkBFgt4\neHhAMTYzLmNvbYIJALV96mEtVF4EMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEF\nBQADgYEAASkC/1iwiALa2RU3YCxqZFEEsZZvQxikrDkDbFeoa6Tk49Fnb1f7FCW6\nPTtY3HPWl5ygsMsSy0Fi3xp3jmuIwzJhcQ3tcK5gC99HWp6Kw37RL8WoB8GWFU0Q\n4tHLOjBIxkZROPRhH+zMIrqUexv6fsb3NWKhnlfh1Mj5wQE4Ldo=\n-----END CERTIFICATE-----",
          "create_time": "",
          "update_time": "",
          "expire_time": "2020-11-12T02:26:13Z"
        }
    tools.go:72: {
          "id": "2f05dcefa717404cafc72e239ee70955",
          "name": "cert-638d",
          "description": "wfdsfsffaf",
          "type": "client",
          "domain": "",
          "private_key": "",
          "certificate": "-----BEGIN CERTIFICATE-----\nMIIDIjCCAougAwIBAgIJALV96mEtVF4EMA0GCSqGSIb3DQEBBQUAMGoxCzAJBgNV\nBAYTAnh4MQswCQYDVQQIEwJ4eDELMAkGA1UEBxMCeHgxCzAJBgNVBAoTAnh4MQsw\nCQYDVQQLEwJ4eDELMAkGA1UEAxMCeHgxGjAYBgkqhkiG9w0BCQEWC3h4eEAxNjMu\nY29tMB4XDTE3MTExMzAyMjYxM1oXDTIwMTExMjAyMjYxM1owajELMAkGA1UEBhMC\neHgxCzAJBgNVBAgTAnh4MQswCQYDVQQHEwJ4eDELMAkGA1UEChMCeHgxCzAJBgNV\nBAsTAnh4MQswCQYDVQQDEwJ4eDEaMBgGCSqGSIb3DQEJARYLeHh4QDE2My5jb20w\ngZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMU832iM+d3FILgTWmpZBUoYcIWV\ncAAYE7FsZ9LNerOyjJpyi256oypdBvGs9JAUBN5WaFk81UQx29wAyNixX+bKa0DB\nWpUDqr84V1f9vdQc75v9WoujcnlKszzpV6qePPC7igJJpu4QOI362BrWzJCYQbg4\nUzo1KYBhLFxl0TovAgMBAAGjgc8wgcwwHQYDVR0OBBYEFMbTvDyvE2KsRy9zPq/J\nWOjovG+WMIGcBgNVHSMEgZQwgZGAFMbTvDyvE2KsRy9zPq/JWOjovG+WoW6kbDBq\nMQswCQYDVQQGEwJ4eDELMAkGA1UECBMCeHgxCzAJBgNVBAcTAnh4MQswCQYDVQQK\nEwJ4eDELMAkGA1UECxMCeHgxCzAJBgNVBAMTAnh4MRowGAYJKoZIhvcNAQkBFgt4\neHhAMTYzLmNvbYIJALV96mEtVF4EMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEF\nBQADgYEAASkC/1iwiALa2RU3YCxqZFEEsZZvQxikrDkDbFeoa6Tk49Fnb1f7FCW6\nPTtY3HPWl5ygsMsSy0Fi3xp3jmuIwzJhcQ3tcK5gC99HWp6Kw37RL8WoB8GWFU0Q\n4tHLOjBIxkZROPRhH+zMIrqUexv6fsb3NWKhnlfh1Mj5wQE4Ldo=\n-----END CERTIFICATE-----",
          "create_time": "",
          "update_time": "",
          "expire_time": "2020-11-12T02:26:13Z"
        }
    tools.go:72: {
          "id": "8df67be9955d4a69a33f70eb6e0be23d",
          "name": "cert-b3ab",
          "description": "",
          "type": "server",
          "domain": "",
          "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIICXQIBAAKBgQDFPN9ojPndxSC4E1pqWQVKGHCFlXAAGBOxbGfSzXqzsoyacotu\neqMqXQbxrPSQFATeVmhZPNVEMdvcAMjYsV/mymtAwVqVA6q/OFdX/b3UHO+b/VqL\no3J5SrM86Veqnjzwu4oCSabuEDiN+tga1syQmEG4OFM6NSmAYSxcZdE6LwIDAQAB\nAoGBAJvLzJCyIsCJcKHWL6onbSUtDtyFwPViD1QrVAtQYabF14g8CGUZG/9fgheu\nTXPtTDcvu7cZdUArvgYW3I9F9IBb2lmF3a44xfiAKdDhzr4DK/vQhvHPuuTeZA41\nr2zp8Cu+Bp40pSxmoAOK3B0/peZAka01Ju7c7ZChDWrxleHZAkEA/6dcaWHotfGS\neW5YLbSms3f0m0GH38nRl7oxyCW6yMIDkFHURVMBKW1OhrcuGo8u0nTMi5IH9gRg\n5bH8XcujlQJBAMWBQgzCHyoSeryD3TFieXIFzgDBw6Ve5hyMjUtjvgdVKoxRPvpO\nkclc39QHP6Dm2wrXXHEej+9RILxBZCVQNbMCQQC42i+Ut0nHvPuXN/UkXzomDHde\nh1ySsOAO4H+8Y6OSI87l3HUrByCQ7stX1z3L0HofjHqV9Koy9emGTFLZEzSdAkB7\nEi6cUKKmztkYe3rr+RcATEmwAw3tEJOHmrW5ErApVZKr2TzLMQZ7WZpIPzQRCYnY\n2ZZLDuZWFFG3vW+wKKktAkAaQ5GNzbwkRLpXF1FZFuNF7erxypzstbUmU/31b7tS\ni5LmxTGKL/xRYtZEHjya4Ikkkgt40q1MrUsgIYbFYMf2\n-----END RSA PRIVATE KEY-----",
          "certificate": "-----BEGIN CERTIFICATE-----\nMIIDIjCCAougAwIBAgIJALV96mEtVF4EMA0GCSqGSIb3DQEBBQUAMGoxCzAJBgNV\nBAYTAnh4MQswCQYDVQQIEwJ4eDELMAkGA1UEBxMCeHgxCzAJBgNVBAoTAnh4MQsw\nCQYDVQQLEwJ4eDELMAkGA1UEAxMCeHgxGjAYBgkqhkiG9w0BCQEWC3h4eEAxNjMu\nY29tMB4XDTE3MTExMzAyMjYxM1oXDTIwMTExMjAyMjYxM1owajELMAkGA1UEBhMC\neHgxCzAJBgNVBAgTAnh4MQswCQYDVQQHEwJ4eDELMAkGA1UEChMCeHgxCzAJBgNV\nBAsTAnh4MQswCQYDVQQDEwJ4eDEaMBgGCSqGSIb3DQEJARYLeHh4QDE2My5jb20w\ngZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMU832iM+d3FILgTWmpZBUoYcIWV\ncAAYE7FsZ9LNerOyjJpyi256oypdBvGs9JAUBN5WaFk81UQx29wAyNixX+bKa0DB\nWpUDqr84V1f9vdQc75v9WoujcnlKszzpV6qePPC7igJJpu4QOI362BrWzJCYQbg4\nUzo1KYBhLFxl0TovAgMBAAGjgc8wgcwwHQYDVR0OBBYEFMbTvDyvE2KsRy9zPq/J\nWOjovG+WMIGcBgNVHSMEgZQwgZGAFMbTvDyvE2KsRy9zPq/JWOjovG+WoW6kbDBq\nMQswCQYDVQQGEwJ4eDELMAkGA1UECBMCeHgxCzAJBgNVBAcTAnh4MQswCQYDVQQK\nEwJ4eDELMAkGA1UECxMCeHgxCzAJBgNVBAMTAnh4MRowGAYJKoZIhvcNAQkBFgt4\neHhAMTYzLmNvbYIJALV96mEtVF4EMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEF\nBQADgYEAASkC/1iwiALa2RU3YCxqZFEEsZZvQxikrDkDbFeoa6Tk49Fnb1f7FCW6\nPTtY3HPWl5ygsMsSy0Fi3xp3jmuIwzJhcQ3tcK5gC99HWp6Kw37RL8WoB8GWFU0Q\n4tHLOjBIxkZROPRhH+zMIrqUexv6fsb3NWKhnlfh1Mj5wQE4Ldo=\n-----END CERTIFICATE-----",
          "create_time": "",
          "update_time": "",
          "expire_time": "2020-11-12T02:26:13Z"
        }
    tools.go:72: {
          "id": "ab8c99c24c954b4bbe171a58f6fda2d5",
          "name": "client-cert",
          "description": "",
          "type": "client",
          "domain": "",
          "private_key": "",
          "certificate": "-----BEGIN CERTIFICATE-----\nMIIDIjCCAougAwIBAgIJALV96mEtVF4EMA0GCSqGSIb3DQEBBQUAMGoxCzAJBgNV\nBAYTAnh4MQswCQYDVQQIEwJ4eDELMAkGA1UEBxMCeHgxCzAJBgNVBAoTAnh4MQsw\nCQYDVQQLEwJ4eDELMAkGA1UEAxMCeHgxGjAYBgkqhkiG9w0BCQEWC3h4eEAxNjMu\nY29tMB4XDTE3MTExMzAyMjYxM1oXDTIwMTExMjAyMjYxM1owajELMAkGA1UEBhMC\neHgxCzAJBgNVBAgTAnh4MQswCQYDVQQHEwJ4eDELMAkGA1UEChMCeHgxCzAJBgNV\nBAsTAnh4MQswCQYDVQQDEwJ4eDEaMBgGCSqGSIb3DQEJARYLeHh4QDE2My5jb20w\ngZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMU832iM+d3FILgTWmpZBUoYcIWV\ncAAYE7FsZ9LNerOyjJpyi256oypdBvGs9JAUBN5WaFk81UQx29wAyNixX+bKa0DB\nWpUDqr84V1f9vdQc75v9WoujcnlKszzpV6qePPC7igJJpu4QOI362BrWzJCYQbg4\nUzo1KYBhLFxl0TovAgMBAAGjgc8wgcwwHQYDVR0OBBYEFMbTvDyvE2KsRy9zPq/J\nWOjovG+WMIGcBgNVHSMEgZQwgZGAFMbTvDyvE2KsRy9zPq/JWOjovG+WoW6kbDBq\nMQswCQYDVQQGEwJ4eDELMAkGA1UECBMCeHgxCzAJBgNVBAcTAnh4MQswCQYDVQQK\nEwJ4eDELMAkGA1UECxMCeHgxCzAJBgNVBAMTAnh4MRowGAYJKoZIhvcNAQkBFgt4\neHhAMTYzLmNvbYIJALV96mEtVF4EMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEF\nBQADgYEAASkC/1iwiALa2RU3YCxqZFEEsZZvQxikrDkDbFeoa6Tk49Fnb1f7FCW6\nPTtY3HPWl5ygsMsSy0Fi3xp3jmuIwzJhcQ3tcK5gC99HWp6Kw37RL8WoB8GWFU0Q\n4tHLOjBIxkZROPRhH+zMIrqUexv6fsb3NWKhnlfh1Mj5wQE4Ldo=\n-----END CERTIFICATE-----",
          "create_time": "",
          "update_time": "",
          "expire_time": "2020-11-12T02:26:13Z"
        }
    tools.go:72: {
          "id": "0489270e098448998511c0c4ff6aef1e",
          "name": "server-cert",
          "description": "",
          "type": "server",
          "domain": "",
          "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIICXQIBAAKBgQDFPN9ojPndxSC4E1pqWQVKGHCFlXAAGBOxbGfSzXqzsoyacotu\neqMqXQbxrPSQFATeVmhZPNVEMdvcAMjYsV/mymtAwVqVA6q/OFdX/b3UHO+b/VqL\no3J5SrM86Veqnjzwu4oCSabuEDiN+tga1syQmEG4OFM6NSmAYSxcZdE6LwIDAQAB\nAoGBAJvLzJCyIsCJcKHWL6onbSUtDtyFwPViD1QrVAtQYabF14g8CGUZG/9fgheu\nTXPtTDcvu7cZdUArvgYW3I9F9IBb2lmF3a44xfiAKdDhzr4DK/vQhvHPuuTeZA41\nr2zp8Cu+Bp40pSxmoAOK3B0/peZAka01Ju7c7ZChDWrxleHZAkEA/6dcaWHotfGS\neW5YLbSms3f0m0GH38nRl7oxyCW6yMIDkFHURVMBKW1OhrcuGo8u0nTMi5IH9gRg\n5bH8XcujlQJBAMWBQgzCHyoSeryD3TFieXIFzgDBw6Ve5hyMjUtjvgdVKoxRPvpO\nkclc39QHP6Dm2wrXXHEej+9RILxBZCVQNbMCQQC42i+Ut0nHvPuXN/UkXzomDHde\nh1ySsOAO4H+8Y6OSI87l3HUrByCQ7stX1z3L0HofjHqV9Koy9emGTFLZEzSdAkB7\nEi6cUKKmztkYe3rr+RcATEmwAw3tEJOHmrW5ErApVZKr2TzLMQZ7WZpIPzQRCYnY\n2ZZLDuZWFFG3vW+wKKktAkAaQ5GNzbwkRLpXF1FZFuNF7erxypzstbUmU/31b7tS\ni5LmxTGKL/xRYtZEHjya4Ikkkgt40q1MrUsgIYbFYMf2\n-----END RSA PRIVATE KEY-----",
          "certificate": "-----BEGIN CERTIFICATE-----\nMIIDIjCCAougAwIBAgIJALV96mEtVF4EMA0GCSqGSIb3DQEBBQUAMGoxCzAJBgNV\nBAYTAnh4MQswCQYDVQQIEwJ4eDELMAkGA1UEBxMCeHgxCzAJBgNVBAoTAnh4MQsw\nCQYDVQQLEwJ4eDELMAkGA1UEAxMCeHgxGjAYBgkqhkiG9w0BCQEWC3h4eEAxNjMu\nY29tMB4XDTE3MTExMzAyMjYxM1oXDTIwMTExMjAyMjYxM1owajELMAkGA1UEBhMC\neHgxCzAJBgNVBAgTAnh4MQswCQYDVQQHEwJ4eDELMAkGA1UEChMCeHgxCzAJBgNV\nBAsTAnh4MQswCQYDVQQDEwJ4eDEaMBgGCSqGSIb3DQEJARYLeHh4QDE2My5jb20w\ngZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMU832iM+d3FILgTWmpZBUoYcIWV\ncAAYE7FsZ9LNerOyjJpyi256oypdBvGs9JAUBN5WaFk81UQx29wAyNixX+bKa0DB\nWpUDqr84V1f9vdQc75v9WoujcnlKszzpV6qePPC7igJJpu4QOI362BrWzJCYQbg4\nUzo1KYBhLFxl0TovAgMBAAGjgc8wgcwwHQYDVR0OBBYEFMbTvDyvE2KsRy9zPq/J\nWOjovG+WMIGcBgNVHSMEgZQwgZGAFMbTvDyvE2KsRy9zPq/JWOjovG+WoW6kbDBq\nMQswCQYDVQQGEwJ4eDELMAkGA1UECBMCeHgxCzAJBgNVBAcTAnh4MQswCQYDVQQK\nEwJ4eDELMAkGA1UECxMCeHgxCzAJBgNVBAMTAnh4MRowGAYJKoZIhvcNAQkBFgt4\neHhAMTYzLmNvbYIJALV96mEtVF4EMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEF\nBQADgYEAASkC/1iwiALa2RU3YCxqZFEEsZZvQxikrDkDbFeoa6Tk49Fnb1f7FCW6\nPTtY3HPWl5ygsMsSy0Fi3xp3jmuIwzJhcQ3tcK5gC99HWp6Kw37RL8WoB8GWFU0Q\n4tHLOjBIxkZROPRhH+zMIrqUexv6fsb3NWKhnlfh1Mj5wQE4Ldo=\n-----END CERTIFICATE-----",
          "create_time": "",
          "update_time": "",
          "expire_time": "2020-11-12T02:26:13Z"
        }
--- PASS: TestCertificateList (0.85s)
=== RUN   TestCertificateLifecycle
    helpers.go:69: Attempting to create ELBv3 certificate
    helpers.go:136: Created ELBv3 certificate: f7c0a0dfe3e44a05aa3a9b7060280807
    certificates_test.go:35: Attempting to update ELBv3 certificate: f7c0a0dfe3e44a05aa3a9b7060280807
    certificates_test.go:45: Updated ELBv3 certificate: f7c0a0dfe3e44a05aa3a9b7060280807
    helpers.go:142: Attempting to delete ELBv3 certificate: f7c0a0dfe3e44a05aa3a9b7060280807
    helpers.go:145: Deleted ELBv3 certificate: f7c0a0dfe3e44a05aa3a9b7060280807
--- PASS: TestCertificateLifecycle (2.89s)
=== RUN   TestFlavorsList
--- PASS: TestFlavorsList (1.04s)
=== RUN   TestListenerLifecycle
    helpers.go:18: Attempting to create ELBv3 LoadBalancer
    helpers.go:56: Created ELBv3 LoadBalancer: 88e26bc7-2af7-42d5-9efa-07260d7d664e
    helpers.go:69: Attempting to create ELBv3 certificate
    helpers.go:136: Created ELBv3 certificate: 4dd4dcf64c534fd68f4acb7cdc2418b5
    listeners_test.go:23: Attempting to create ELBv3 Listener
    listeners_test.go:51: Created ELBv3 Listener: 7f9cd2ca-91f2-4b5f-a87d-6edd8f9bab76
    listeners_test.go:53: Attempting to update ELBv3 Listener: 7f9cd2ca-91f2-4b5f-a87d-6edd8f9bab76
    listeners_test.go:62: Updated ELBv3 Listener: 7f9cd2ca-91f2-4b5f-a87d-6edd8f9bab76
    listeners_test.go:43: Attempting to delete ELBv3 Listener: 7f9cd2ca-91f2-4b5f-a87d-6edd8f9bab76
    listeners_test.go:46: Deleted ELBv3 Listener: 7f9cd2ca-91f2-4b5f-a87d-6edd8f9bab76
    helpers.go:142: Attempting to delete ELBv3 certificate: 4dd4dcf64c534fd68f4acb7cdc2418b5
    helpers.go:145: Deleted ELBv3 certificate: 4dd4dcf64c534fd68f4acb7cdc2418b5
    helpers.go:62: Attempting to delete ELBv3 LoadBalancer: 88e26bc7-2af7-42d5-9efa-07260d7d664e
    helpers.go:65: Deleted ELBv3 LoadBalancer: 88e26bc7-2af7-42d5-9efa-07260d7d664e
--- PASS: TestListenerLifecycle (8.11s)
=== RUN   TestLoadBalancerList
    tools.go:72: {
          "id": "f6ef85fd-2424-4625-b68d-c099b2f8f5eb",
          "description": "ttt",
          "provisioning_status": "ACTIVE",
          "admin_state_up": true,
          "provider": "vlb",
          "pools": [
            {
              "id": "59818e53-9d4d-402c-a555-e19098545b32"
            },
            {
              "id": "cc080727-2754-4d7c-9ed4-3ab34ace43f5"
            },
            {
              "id": "59f84a63-2555-4e66-b863-0fda1d6ee8aa"
            },
            {
              "id": "0d3a7bfd-a883-4b8f-9411-72a83d9817ac"
            },
            {
              "id": "9cbaa44f-6b15-457a-a461-c3610ea34ad0"
            }
          ],
          "listeners": [
            {
              "id": "1394dd64-3561-4939-8c6e-cb75d1229d1b"
            },
            {
              "id": "49b43e0b-bb56-4519-9f4e-38f7f6361170"
            },
            {
              "id": "ec00b5f0-15c1-46e9-9923-d228e6805d74"
            }
          ],
          "operating_status": "ONLINE",
          "vip_address": "192.168.0.49",
          "vip_subnet_cidr_id": "34cbf900-68e1-47ce-854c-f3b98248bab9",
          "name": "lb-to-die",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "vip_port_id": "c4ecf845-77b0-4247-842c-a1e04a26280d",
          "tags": [
            {
              "key": "key",
              "value": "vali"
            },
            {
              "key": "key1",
              "value": ""
            },
            {
              "key": "key2",
              "value": "value2"
            },
            {
              "key": "white",
              "value": "white"
            }
          ],
          "guaranteed": true,
          "vpc_id": "a4f39382-0777-4ad5-b2eb-4dee3b636633",
          "eips": [],
          "ipv6_vip_address": "",
          "ipv6_vip_virsubnet_id": "",
          "ipv6_vip_port_id": "",
          "availability_zone_list": [
            "eu-nl-01"
          ],
          "l4_flavor_id": "",
          "l4_scale_flavor_id": "",
          "l7_flavor_id": "",
          "l7_scale_flavor_id": "",
          "publicips": [],
          "elb_virsubnet_ids": [
            "07488dd8-45b8-42ff-bec6-d3f3b8daaaf3"
          ],
          "elb_virsubnet_type": "ipv4",
          "ip_target_enable": false,
          "frozen_scene": "",
          "ipv6_bandwidth": {
            "id": ""
          },
          "created_at": "2021-09-21T14:20:26Z",
          "updated_at": "2021-10-20T13:32:38Z"
        }
--- PASS: TestLoadBalancerList (0.92s)
=== RUN   TestLoadBalancerLifecycle
    helpers.go:18: Attempting to create ELBv3 LoadBalancer
    helpers.go:56: Created ELBv3 LoadBalancer: 6e8a1971-df4a-419a-977c-a016623e31c8
    loadbalancers_test.go:35: Attempting to update ELBv3 LoadBalancer: 6e8a1971-df4a-419a-977c-a016623e31c8
    loadbalancers_test.go:45: Updated ELBv3 LoadBalancer: 6e8a1971-df4a-419a-977c-a016623e31c8
    helpers.go:62: Attempting to delete ELBv3 LoadBalancer: 6e8a1971-df4a-419a-977c-a016623e31c8
    helpers.go:65: Deleted ELBv3 LoadBalancer: 6e8a1971-df4a-419a-977c-a016623e31c8
--- PASS: TestLoadBalancerLifecycle (6.35s)
=== RUN   TestMemberLifecycle
    helpers.go:18: Attempting to create ELBv3 LoadBalancer
    helpers.go:56: Created ELBv3 LoadBalancer: 8181b9e4-86bd-4eaa-a8e5-e11b7d38863e
    common.go:138: One of OS_VPC_ID, OS_NETWORK_ID or OS_AVAILABILITY_ZONE env vars is missing but ECSv1 test requires
    helpers.go:62: Attempting to delete ELBv3 LoadBalancer: 8181b9e4-86bd-4eaa-a8e5-e11b7d38863e
    helpers.go:65: Deleted ELBv3 LoadBalancer: 8181b9e4-86bd-4eaa-a8e5-e11b7d38863e
--- SKIP: TestMemberLifecycle (22.34s)

Test ignored.
=== RUN   TestPolicyWorkflow
=== PAUSE TestPolicyWorkflow
=== CONT  TestPolicyWorkflow
    helpers.go:18: Attempting to create ELBv3 LoadBalancer
    helpers.go:56: Created ELBv3 LoadBalancer: 645cff15-3ac9-4c79-a638-f1fdda682352
    helpers.go:149: Attempting to create ELBv3 Pool
    helpers.go:164: Created ELBv3 Pool: 0c866ba5-9f41-42cf-b84c-bee533b1cc6e
    policies_test.go:37: Created L7 Policy
    policies_test.go:65: Updated l7 Policy
    policies_test.go:42: Deleted L7 Policy
    helpers.go:170: Attempting to delete ELBv3 Pool: 0c866ba5-9f41-42cf-b84c-bee533b1cc6e
    helpers.go:173: Deleted ELBv3 Pool: 0c866ba5-9f41-42cf-b84c-bee533b1cc6e
    helpers.go:62: Attempting to delete ELBv3 LoadBalancer: 645cff15-3ac9-4c79-a638-f1fdda682352
    helpers.go:65: Deleted ELBv3 LoadBalancer: 645cff15-3ac9-4c79-a638-f1fdda682352
--- PASS: TestPolicyWorkflow (8.74s)
=== RUN   TestPoolList
    tools.go:72: {
          "lb_algorithm": "ROUND_ROBIN",
          "protocol": "HTTP",
          "description": "",
          "listeners": [],
          "members": [],
          "healthmonitor_id": "ea82b468-4cee-448f-8b2f-b5c12045470c",
          "admin_state_up": true,
          "name": "server_group-df2b",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "id": "0d3a7bfd-a883-4b8f-9411-72a83d9817ac",
          "loadbalancers": [
            {
              "id": "f6ef85fd-2424-4625-b68d-c099b2f8f5eb"
            }
          ],
          "session_persistence": {
            "type": ""
          },
          "ip_version": "v4",
          "slow_start": {
            "enable": false,
            "duration": 30
          }
        }
    tools.go:72: {
          "lb_algorithm": "ROUND_ROBIN",
          "protocol": "HTTP",
          "description": "",
          "listeners": [
            {
              "id": "1394dd64-3561-4939-8c6e-cb75d1229d1b"
            }
          ],
          "members": [
            {
              "id": "512c69ce-9cc3-4fa1-83cb-c28db5d07809"
            }
          ],
          "healthmonitor_id": "",
          "admin_state_up": true,
          "name": "server_group-e450",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "id": "59818e53-9d4d-402c-a555-e19098545b32",
          "loadbalancers": [
            {
              "id": "f6ef85fd-2424-4625-b68d-c099b2f8f5eb"
            }
          ],
          "session_persistence": {
            "type": ""
          },
          "ip_version": "v4",
          "slow_start": {
            "enable": false,
            "duration": 30
          }
        }
    tools.go:72: {
          "lb_algorithm": "ROUND_ROBIN",
          "protocol": "HTTP",
          "description": "",
          "listeners": [
            {
              "id": "1394dd64-3561-4939-8c6e-cb75d1229d1b"
            }
          ],
          "members": [],
          "healthmonitor_id": "8426938b-9159-44b9-8817-d63bf3831f9d",
          "admin_state_up": true,
          "name": "server_group-e52c",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "id": "59f84a63-2555-4e66-b863-0fda1d6ee8aa",
          "loadbalancers": [
            {
              "id": "f6ef85fd-2424-4625-b68d-c099b2f8f5eb"
            }
          ],
          "session_persistence": {
            "type": ""
          },
          "ip_version": "v4",
          "slow_start": {
            "enable": false,
            "duration": 30
          }
        }
    tools.go:72: {
          "lb_algorithm": "ROUND_ROBIN",
          "protocol": "HTTP",
          "description": "",
          "listeners": [
            {
              "id": "1394dd64-3561-4939-8c6e-cb75d1229d1b"
            }
          ],
          "members": [],
          "healthmonitor_id": "0a024881-3246-4f0c-b264-361f42113aa9",
          "admin_state_up": true,
          "name": "server_group-fe81",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "id": "9cbaa44f-6b15-457a-a461-c3610ea34ad0",
          "loadbalancers": [
            {
              "id": "f6ef85fd-2424-4625-b68d-c099b2f8f5eb"
            }
          ],
          "session_persistence": {
            "type": ""
          },
          "ip_version": "v4",
          "slow_start": {
            "enable": false,
            "duration": 30
          }
        }
    tools.go:72: {
          "lb_algorithm": "ROUND_ROBIN",
          "protocol": "HTTP",
          "description": "trololo",
          "listeners": [
            {
              "id": "ec00b5f0-15c1-46e9-9923-d228e6805d74"
            }
          ],
          "members": [],
          "healthmonitor_id": "e60faebc-624d-4146-9657-83e423433434",
          "admin_state_up": true,
          "name": "my_pool",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "id": "cc080727-2754-4d7c-9ed4-3ab34ace43f5",
          "loadbalancers": [
            {
              "id": "f6ef85fd-2424-4625-b68d-c099b2f8f5eb"
            }
          ],
          "session_persistence": {
            "type": ""
          },
          "ip_version": "v4",
          "slow_start": {
            "enable": false,
            "duration": 30
          }
        }
--- PASS: TestPoolList (1.50s)
=== RUN   TestPoolLifecycle
    helpers.go:18: Attempting to create ELBv3 LoadBalancer
    helpers.go:56: Created ELBv3 LoadBalancer: 2cf07908-4b2f-4025-b00b-60d31cf6f40a
    helpers.go:149: Attempting to create ELBv3 Pool
    helpers.go:164: Created ELBv3 Pool: ee5f22fe-46c2-428c-a5ab-67c9f2b82699
    pools_test.go:38: Attempting to update ELBv3 Pool: ee5f22fe-46c2-428c-a5ab-67c9f2b82699
    pools_test.go:48: Updated ELBv3 Pool: ee5f22fe-46c2-428c-a5ab-67c9f2b82699
    helpers.go:170: Attempting to delete ELBv3 Pool: ee5f22fe-46c2-428c-a5ab-67c9f2b82699
    helpers.go:173: Deleted ELBv3 Pool: ee5f22fe-46c2-428c-a5ab-67c9f2b82699
    helpers.go:62: Attempting to delete ELBv3 LoadBalancer: 2cf07908-4b2f-4025-b00b-60d31cf6f40a
    helpers.go:65: Deleted ELBv3 LoadBalancer: 2cf07908-4b2f-4025-b00b-60d31cf6f40a
--- PASS: TestPoolLifecycle (6.71s)
PASS
ok  	github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack/elb/v3	59.450s

Process finished with the exit code 0
```