### PR TITLE
[SFS] Update client creation

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -545,13 +545,7 @@ func NewSharedFileSystemV2(client *golangsdk.ProviderClient, eo golangsdk.Endpoi
 
 // NewSharedFileSystemTurboV1 creates a ServiceClient that may be used to access the v2 shared file system turbo service.
 func NewSharedFileSystemTurboV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
-	sc, err := initClientOpts(client, eo, "sfsturbo")
-	if err != nil {
-		return nil, err
-	}
-	sc.Endpoint = sc.Endpoint + "v1/"
-	sc.ResourceBase = sc.Endpoint + client.ProjectID + "/"
-	return sc, err
+	return initClientOpts(client, eo, "sfsturbo")
 }
 
 // NewOrchestrationV1 creates a ServiceClient that may be used to access the v1


### PR DESCRIPTION
### What this PR does / why we need it
Update SFS-turbo client creation

### Which issue this PR fixes
Fixes: #279 

### Special notes for your reviewer
```
=== RUN   TestSFSTurboList
--- PASS: TestSFSTurboList (2.40s)
=== RUN   TestSFSTurboLifecycle
    common.go:64: Security group ab023d56-2744-4e17-87eb-082f5a475da3 was created
    helpers.go:15: Attempting to create SFSTurboV1
    helpers.go:39: Waiting for SFS Turbo dff872c3-b784-49ab-a227-51854f528b82 to be active
    helpers.go:46: Created SFS turbo: dff872c3-b784-49ab-a227-51854f528b82
    helpers.go:64: Attempting to expand SFS Turbo: dff872c3-b784-49ab-a227-51854f528b82
    helpers.go:81: Expanded SFS turbo: dff872c3-b784-49ab-a227-51854f528b82
    helpers.go:87: Attempting to change SG SFS Turbo: dff872c3-b784-49ab-a227-51854f528b82
    helpers.go:104: Change SG SFS turbo: dff872c3-b784-49ab-a227-51854f528b82
    helpers.go:52: Attempting to delete SFS Turbo: dff872c3-b784-49ab-a227-51854f528b82
    helpers.go:60: Deleted SFS Turbo: dff872c3-b784-49ab-a227-51854f528b82
    common.go:75: Security group ab023d56-2744-4e17-87eb-082f5a475da3 was deleted
--- PASS: TestSFSTurboLifecycle (532.25s)
PASS

Process finished with the exit code 0
```