### PR TITLE
[ELB] Allow update pool v3 name to empty string

### DIFF
--- a/acceptance/openstack/elb/v3/pools_test.go
+++ b/acceptance/openstack/elb/v3/pools_test.go
@@ -39,7 +39,7 @@ func TestPoolLifecycle(t *testing.T) {
 	poolName := tools.RandomString("update-pool-", 3)
 	emptyDescription := ""
 	updateOpts := pools.UpdateOpts{
-		Name:        poolName,
+		Name:        &poolName,
 		Description: &emptyDescription,
 		LBMethod:    "ROUND_ROBIN",
 	}
@@ -49,7 +49,7 @@ func TestPoolLifecycle(t *testing.T) {
 
 	newPool, err := pools.Get(client, poolID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, updateOpts.Name, newPool.Name)
+	th.AssertEquals(t, *updateOpts.Name, newPool.Name)
 	th.AssertEquals(t, emptyDescription, newPool.Description)
 	th.AssertEquals(t, updateOpts.LBMethod, newPool.LBMethod)
 }

--- a/openstack/elb/v3/pools/requests.go
+++ b/openstack/elb/v3/pools/requests.go
@@ -161,7 +161,7 @@ type UpdateOptsBuilder interface {
 // operation.
 type UpdateOpts struct {
 	// Name of the pool.
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// Human-readable description for the pool.
 	Description *string `json:"description,omitempty"`
@@ -171,14 +171,15 @@ type UpdateOpts struct {
 	// and LBMethodSourceIp as valid values for this attribute.
 	LBMethod string `json:"lb_algorithm,omitempty"`
 
-	// Persistence is the session persistence of the pool.
-	// Omit this field to prevent session persistence.
+	// Specifies whether to enable sticky sessions.
 	Persistence *SessionPersistence `json:"session_persistence,omitempty"`
 
-	// The administrative state of the Pool. A valid value is true (UP)
-	// or false (DOWN).
+	// The administrative state of the Pool. The value can only be updated to true.
+	// This parameter is unsupported. Please do not use it.
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 
+	// Specifies whether to enable slow start.
+	// This parameter is unsupported. Please do not use it.
 	SlowStart *SlowStart `json:"slow_start,omitempty"`
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Make `Name` field of `UpdateOpts` a string pointer

Minor `UpdateOpts` documentation update


### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->
Fix #289 

### Special notes for your reviewer
```
=== RUN   TestPoolList
    tools.go:72: {
          "lb_algorithm": "ROUND_ROBIN",
          "protocol": "HTTP",
          "description": "",
          "listeners": [],
          "members": [],
          "healthmonitor_id": "ea82b468-4cee-448f-8b2f-b5c12045470c",
          "admin_state_up": true,
          "name": "server_group-df2b",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "id": "0d3a7bfd-a883-4b8f-9411-72a83d9817ac",
          "loadbalancers": [
            {
              "id": "f6ef85fd-2424-4625-b68d-c099b2f8f5eb"
            }
          ],
          "session_persistence": {
            "type": ""
          },
          "ip_version": "v4",
          "slow_start": {
            "enable": false,
            "duration": 30
          }
        }
    tools.go:72: {
          "lb_algorithm": "ROUND_ROBIN",
          "protocol": "HTTP",
          "description": "",
          "listeners": [
            {
              "id": "1394dd64-3561-4939-8c6e-cb75d1229d1b"
            }
          ],
          "members": [
            {
              "id": "512c69ce-9cc3-4fa1-83cb-c28db5d07809"
            }
          ],
          "healthmonitor_id": "",
          "admin_state_up": true,
          "name": "server_group-e450",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "id": "59818e53-9d4d-402c-a555-e19098545b32",
          "loadbalancers": [
            {
              "id": "f6ef85fd-2424-4625-b68d-c099b2f8f5eb"
            }
          ],
          "session_persistence": {
            "type": ""
          },
          "ip_version": "v4",
          "slow_start": {
            "enable": false,
            "duration": 30
          }
        }
    tools.go:72: {
          "lb_algorithm": "ROUND_ROBIN",
          "protocol": "HTTP",
          "description": "",
          "listeners": [
            {
              "id": "1394dd64-3561-4939-8c6e-cb75d1229d1b"
            }
          ],
          "members": [],
          "healthmonitor_id": "8426938b-9159-44b9-8817-d63bf3831f9d",
          "admin_state_up": true,
          "name": "server_group-e52c",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "id": "59f84a63-2555-4e66-b863-0fda1d6ee8aa",
          "loadbalancers": [
            {
              "id": "f6ef85fd-2424-4625-b68d-c099b2f8f5eb"
            }
          ],
          "session_persistence": {
            "type": ""
          },
          "ip_version": "v4",
          "slow_start": {
            "enable": false,
            "duration": 30
          }
        }
    tools.go:72: {
          "lb_algorithm": "ROUND_ROBIN",
          "protocol": "HTTP",
          "description": "",
          "listeners": [
            {
              "id": "1394dd64-3561-4939-8c6e-cb75d1229d1b"
            }
          ],
          "members": [],
          "healthmonitor_id": "0a024881-3246-4f0c-b264-361f42113aa9",
          "admin_state_up": true,
          "name": "server_group-fe81",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "id": "9cbaa44f-6b15-457a-a461-c3610ea34ad0",
          "loadbalancers": [
            {
              "id": "f6ef85fd-2424-4625-b68d-c099b2f8f5eb"
            }
          ],
          "session_persistence": {
            "type": ""
          },
          "ip_version": "v4",
          "slow_start": {
            "enable": false,
            "duration": 30
          }
        }
    tools.go:72: {
          "lb_algorithm": "ROUND_ROBIN",
          "protocol": "HTTP",
          "description": "trololo",
          "listeners": [
            {
              "id": "ec00b5f0-15c1-46e9-9923-d228e6805d74"
            }
          ],
          "members": [],
          "healthmonitor_id": "e60faebc-624d-4146-9657-83e423433434",
          "admin_state_up": true,
          "name": "my_pool",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "id": "cc080727-2754-4d7c-9ed4-3ab34ace43f5",
          "loadbalancers": [
            {
              "id": "f6ef85fd-2424-4625-b68d-c099b2f8f5eb"
            }
          ],
          "session_persistence": {
            "type": ""
          },
          "ip_version": "v4",
          "slow_start": {
            "enable": false,
            "duration": 30
          }
        }
    tools.go:72: {
          "lb_algorithm": "QUIC_CID",
          "protocol": "QUIC",
          "description": "",
          "listeners": [],
          "members": [],
          "healthmonitor_id": "",
          "admin_state_up": true,
          "name": "",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "id": "f82172f6-e6ae-409c-a4e1-857a0cb133b5",
          "loadbalancers": [
            {
              "id": "5d60db94-6d3a-4602-8524-97e5b7737d72"
            }
          ],
          "session_persistence": {
            "type": "SOURCE_IP",
            "persistence_timeout": 1
          },
          "ip_version": "dualstack",
          "slow_start": {
            "enable": null,
            "duration": 0
          }
        }
--- PASS: TestPoolList (1.11s)
=== RUN   TestPoolLifecycle
    helpers.go:18: Attempting to create ELBv3 LoadBalancer
    helpers.go:56: Created ELBv3 LoadBalancer: 4468b746-8cac-4e59-8fde-bec01f4e4718
    helpers.go:149: Attempting to create ELBv3 Pool
    helpers.go:164: Created ELBv3 Pool: e54cf905-9bc9-4b18-b13c-4d239d768cd8
    pools_test.go:38: Attempting to update ELBv3 Pool: e54cf905-9bc9-4b18-b13c-4d239d768cd8
    pools_test.go:48: Updated ELBv3 Pool: e54cf905-9bc9-4b18-b13c-4d239d768cd8
    helpers.go:170: Attempting to delete ELBv3 Pool: e54cf905-9bc9-4b18-b13c-4d239d768cd8
    helpers.go:173: Deleted ELBv3 Pool: e54cf905-9bc9-4b18-b13c-4d239d768cd8
    helpers.go:62: Attempting to delete ELBv3 LoadBalancer: 4468b746-8cac-4e59-8fde-bec01f4e4718
    helpers.go:65: Deleted ELBv3 LoadBalancer: 4468b746-8cac-4e59-8fde-bec01f4e4718
--- PASS: TestPoolLifecycle (8.43s)
PASS

Process finished with the exit code 0
```
