### PR TITLE
[ELB] Pool v3: tweak structure fields

### DIFF
--- a/openstack/elb/v3/pools/requests.go
+++ b/openstack/elb/v3/pools/requests.go
@@ -122,7 +122,7 @@ type SessionPersistence struct {
 
 type SlowStart struct {
 	// Specifies whether to Enable slow start.
-	Enable *bool `json:"enable" required:"true"`
+	Enable bool `json:"enable" required:"true"`
 
 	// Specifies the slow start Duration, in seconds.
 	Duration int `json:"duration" required:"true"`

--- a/openstack/elb/v3/pools/results.go
+++ b/openstack/elb/v3/pools/results.go
@@ -47,11 +47,11 @@ type Pool struct {
 
 	// Indicates whether connections in the same session will be processed by the
 	// same Pool member or not.
-	Persistence SessionPersistence `json:"session_persistence"`
+	Persistence *SessionPersistence `json:"session_persistence"`
 
 	IpVersion string `json:"ip_version"`
 
-	SlowStart SlowStart `json:"slow_start"`
+	SlowStart *SlowStart `json:"slow_start"`
 }
 
 // PoolPage is the page returned by a pager when traversing over a


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Make `SessionPersistence` and `SlowStart` pointers in `Pool` structure

Make  `SlowStart.Enable` a bool instead of a bool pointer

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer

```
=== RUN   TestPoolList
    tools.go:72: {
          "lb_algorithm": "ROUND_ROBIN",
          "protocol": "HTTP",
          "description": "",
          "listeners": [],
          "members": [],
          "healthmonitor_id": "ea82b468-4cee-448f-8b2f-b5c12045470c",
          "admin_state_up": true,
          "name": "server_group-df2b",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "id": "0d3a7bfd-a883-4b8f-9411-72a83d9817ac",
          "loadbalancers": [
            {
              "id": "f6ef85fd-2424-4625-b68d-c099b2f8f5eb"
            }
          ],
          "session_persistence": null,
          "ip_version": "v4",
          "slow_start": {
            "enable": false,
            "duration": 30
          }
        }
    tools.go:72: {
          "lb_algorithm": "ROUND_ROBIN",
          "protocol": "HTTP",
          "description": "",
          "listeners": [
            {
              "id": "1394dd64-3561-4939-8c6e-cb75d1229d1b"
            }
          ],
          "members": [
            {
              "id": "512c69ce-9cc3-4fa1-83cb-c28db5d07809"
            }
          ],
          "healthmonitor_id": "",
          "admin_state_up": true,
          "name": "server_group-e450",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "id": "59818e53-9d4d-402c-a555-e19098545b32",
          "loadbalancers": [
            {
              "id": "f6ef85fd-2424-4625-b68d-c099b2f8f5eb"
            }
          ],
          "session_persistence": null,
          "ip_version": "v4",
          "slow_start": {
            "enable": false,
            "duration": 30
          }
        }
    tools.go:72: {
          "lb_algorithm": "ROUND_ROBIN",
          "protocol": "HTTP",
          "description": "",
          "listeners": [
            {
              "id": "1394dd64-3561-4939-8c6e-cb75d1229d1b"
            }
          ],
          "members": [],
          "healthmonitor_id": "8426938b-9159-44b9-8817-d63bf3831f9d",
          "admin_state_up": true,
          "name": "server_group-e52c",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "id": "59f84a63-2555-4e66-b863-0fda1d6ee8aa",
          "loadbalancers": [
            {
              "id": "f6ef85fd-2424-4625-b68d-c099b2f8f5eb"
            }
          ],
          "session_persistence": null,
          "ip_version": "v4",
          "slow_start": {
            "enable": false,
            "duration": 30
          }
        }
    tools.go:72: {
          "lb_algorithm": "ROUND_ROBIN",
          "protocol": "HTTP",
          "description": "",
          "listeners": [
            {
              "id": "1394dd64-3561-4939-8c6e-cb75d1229d1b"
            }
          ],
          "members": [],
          "healthmonitor_id": "0a024881-3246-4f0c-b264-361f42113aa9",
          "admin_state_up": true,
          "name": "server_group-fe81",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "id": "9cbaa44f-6b15-457a-a461-c3610ea34ad0",
          "loadbalancers": [
            {
              "id": "f6ef85fd-2424-4625-b68d-c099b2f8f5eb"
            }
          ],
          "session_persistence": null,
          "ip_version": "v4",
          "slow_start": {
            "enable": false,
            "duration": 30
          }
        }
    tools.go:72: {
          "lb_algorithm": "ROUND_ROBIN",
          "protocol": "HTTP",
          "description": "trololo",
          "listeners": [
            {
              "id": "ec00b5f0-15c1-46e9-9923-d228e6805d74"
            }
          ],
          "members": [],
          "healthmonitor_id": "e60faebc-624d-4146-9657-83e423433434",
          "admin_state_up": true,
          "name": "my_pool",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "id": "cc080727-2754-4d7c-9ed4-3ab34ace43f5",
          "loadbalancers": [
            {
              "id": "f6ef85fd-2424-4625-b68d-c099b2f8f5eb"
            }
          ],
          "session_persistence": null,
          "ip_version": "v4",
          "slow_start": {
            "enable": false,
            "duration": 30
          }
        }
    tools.go:72: {
          "lb_algorithm": "QUIC_CID",
          "protocol": "QUIC",
          "description": "",
          "listeners": [],
          "members": [],
          "healthmonitor_id": "",
          "admin_state_up": true,
          "name": "",
          "project_id": "c742c92afd8d46b1b3083d004afffd70",
          "id": "f82172f6-e6ae-409c-a4e1-857a0cb133b5",
          "loadbalancers": [
            {
              "id": "5d60db94-6d3a-4602-8524-97e5b7737d72"
            }
          ],
          "session_persistence": {
            "type": "SOURCE_IP",
            "persistence_timeout": 1
          },
          "ip_version": "dualstack",
          "slow_start": null
        }
--- PASS: TestPoolList (0.97s)
=== RUN   TestPoolLifecycle
    helpers.go:18: Attempting to create ELBv3 LoadBalancer
    helpers.go:56: Created ELBv3 LoadBalancer: 3b18ab2c-d308-40bb-8d57-a9297c331b4d
    helpers.go:149: Attempting to create ELBv3 Pool
    helpers.go:164: Created ELBv3 Pool: 5ec7e372-7e7d-4805-9cc7-0bd9e9e0bb2f
    pools_test.go:38: Attempting to update ELBv3 Pool: 5ec7e372-7e7d-4805-9cc7-0bd9e9e0bb2f
    pools_test.go:48: Updated ELBv3 Pool: 5ec7e372-7e7d-4805-9cc7-0bd9e9e0bb2f
    helpers.go:170: Attempting to delete ELBv3 Pool: 5ec7e372-7e7d-4805-9cc7-0bd9e9e0bb2f
    helpers.go:173: Deleted ELBv3 Pool: 5ec7e372-7e7d-4805-9cc7-0bd9e9e0bb2f
    helpers.go:62: Attempting to delete ELBv3 LoadBalancer: 3b18ab2c-d308-40bb-8d57-a9297c331b4d
    helpers.go:65: Deleted ELBv3 LoadBalancer: 3b18ab2c-d308-40bb-8d57-a9297c331b4d
--- PASS: TestPoolLifecycle (7.37s)
PASS

Process finished with the exit code 0

```
