### PR TITLE
[LB] Update `CreateOpts` in `listeners` v3 pkg

### DIFF
--- a/acceptance/openstack/elb/v3/listeners_test.go
+++ b/acceptance/openstack/elb/v3/listeners_test.go
@@ -55,7 +55,7 @@ func TestListenerLifecycle(t *testing.T) {
 	emptyDescription := ""
 	updateOpts := listeners.UpdateOpts{
 		Description: &emptyDescription,
-		Name:        listenerName,
+		Name:        &listenerName,
 	}
 	_, err = listeners.Update(client, listener.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -63,6 +63,6 @@ func TestListenerLifecycle(t *testing.T) {
 
 	newListener, err := listeners.Get(client, listener.ID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, updateOpts.Name, newListener.Name)
+	th.AssertEquals(t, listenerName, newListener.Name)
 	th.AssertEquals(t, emptyDescription, newListener.Description)
 }

--- a/openstack/elb/v3/listeners/requests.go
+++ b/openstack/elb/v3/listeners/requests.go
@@ -37,7 +37,7 @@ type CreateOpts struct {
 	// A reference to a Barbican container of TLS secrets.
 	DefaultTlsContainerRef string `json:"default_tls_container_ref,omitempty"`
 
-	// Human-readable description for the Listener.
+	// Provides supplementary information about the Listener.
 	Description string `json:"description,omitempty"`
 
 	// whether to use HTTP2.
@@ -46,7 +46,7 @@ type CreateOpts struct {
 	// The load balancer on which to provision this listener.
 	LoadbalancerID string `json:"loadbalancer_id" required:"true"`
 
-	// Human-readable name for the Listener. Does not have to be unique.
+	// Specifies the Listener name.
 	Name string `json:"name,omitempty"`
 
 	// ProjectID is only required if the caller has an admin role and wants
@@ -160,13 +160,13 @@ type UpdateOpts struct {
 	// A reference to a container of TLS secrets.
 	DefaultTlsContainerRef *string `json:"default_tls_container_ref,omitempty"`
 
-	// Human-readable description for the Listener.
+	// Provides supplementary information about the Listener.
 	Description *string `json:"description,omitempty"`
 
 	// whether to use HTTP2.
 	Http2Enable *bool `json:"http2_enable,omitempty"`
 
-	// Human-readable name for the Listener. Does not have to be unique.
+	// Specifies the Listener name.
 	Name *string `json:"name,omitempty"`
 
 	// A list of references to TLS secrets.

--- a/openstack/elb/v3/listeners/requests.go
+++ b/openstack/elb/v3/listeners/requests.go
@@ -72,13 +72,13 @@ type CreateOpts struct {
 	EnableMemberRetry *bool `json:"enable_member_retry,omitempty"`
 
 	// The keepalive timeout of the Listener.
-	KeepAliveTimeout *int `json:"keepalive_timeout,omitempty"`
+	KeepAliveTimeout int `json:"keepalive_timeout,omitempty"`
 
 	// The client timeout of the Listener.
-	ClientTimeout *int `json:"client_timeout,omitempty"`
+	ClientTimeout int `json:"client_timeout,omitempty"`
 
 	// The member timeout of the Listener.
-	MemberTimeout *int `json:"member_timeout,omitempty"`
+	MemberTimeout int `json:"member_timeout,omitempty"`
 
 	// The IpGroup of the Listener.
 	IpGroup *IpGroup `json:"ipgroup,omitempty"`
@@ -167,7 +167,7 @@ type UpdateOpts struct {
 	Http2Enable *bool `json:"http2_enable,omitempty"`
 
 	// Human-readable name for the Listener. Does not have to be unique.
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// A list of references to TLS secrets.
 	SniContainerRefs *[]string `json:"sni_container_refs,omitempty"`
@@ -179,13 +179,13 @@ type UpdateOpts struct {
 	EnableMemberRetry *bool `json:"enable_member_retry,omitempty"`
 
 	// The keepalive timeout of the Listener.
-	KeepAliveTimeout *int `json:"keepalive_timeout,omitempty"`
+	KeepAliveTimeout int `json:"keepalive_timeout,omitempty"`
 
 	// The client timeout of the Listener.
-	ClientTimeout *int `json:"client_timeout,omitempty"`
+	ClientTimeout int `json:"client_timeout,omitempty"`
 
 	// The member timeout of the Listener.
-	MemberTimeout *int `json:"member_timeout,omitempty"`
+	MemberTimeout int `json:"member_timeout,omitempty"`
 
 	// The IpGroup of the Listener.
 	IpGroup *IpGroupUpdate `json:"ipgroup,omitempty"`

--- a/openstack/elb/v3/listeners/results.go
+++ b/openstack/elb/v3/listeners/results.go
@@ -35,7 +35,7 @@ type Listener struct {
 	// A reference to a Barbican container of TLS secrets.
 	DefaultTlsContainerRef string `json:"default_tls_container_ref"`
 
-	// Human-readable description for the Listener.
+	// Provides supplementary information about the Listener.
 	Description string `json:"description"`
 
 	// whether to use HTTP2.
@@ -44,7 +44,7 @@ type Listener struct {
 	// A list of load balancer IDs.
 	Loadbalancers []structs.ResourceRef `json:"loadbalancers"`
 
-	// Human-readable name for the Listener. Does not have to be unique.
+	// Specifies the Listener Name.
 	Name string `json:"name"`
 
 	// Specifies the ProjectID where the listener is used.


### PR DESCRIPTION
### What this PR does / why we need it
Update `CreateOpts` in `listeners` v3 pkg

### Special notes for your reviewer

```
=== RUN   TestListenerLifecycle
    helpers.go:18: Attempting to create ELBv3 LoadBalancer
    helpers.go:56: Created ELBv3 LoadBalancer: 95c63318-e9df-4ce8-a72a-c0330e1f14c3
    helpers.go:69: Attempting to create ELBv3 certificate
    helpers.go:136: Created ELBv3 certificate: 38f210613d51447b9723ac6834a4725f
    listeners_test.go:23: Attempting to create ELBv3 Listener
    listeners_test.go:51: Created ELBv3 Listener: 2437d4db-5f90-480d-8e2d-fef6c9982bae
    listeners_test.go:53: Attempting to update ELBv3 Listener: 2437d4db-5f90-480d-8e2d-fef6c9982bae
    listeners_test.go:62: Updated ELBv3 Listener: 2437d4db-5f90-480d-8e2d-fef6c9982bae
    listeners_test.go:43: Attempting to delete ELBv3 Listener: 2437d4db-5f90-480d-8e2d-fef6c9982bae
    listeners_test.go:46: Deleted ELBv3 Listener: 2437d4db-5f90-480d-8e2d-fef6c9982bae
    helpers.go:142: Attempting to delete ELBv3 certificate: 38f210613d51447b9723ac6834a4725f
    helpers.go:145: Deleted ELBv3 certificate: 38f210613d51447b9723ac6834a4725f
    helpers.go:62: Attempting to delete ELBv3 LoadBalancer: 95c63318-e9df-4ce8-a72a-c0330e1f14c3
    helpers.go:65: Deleted ELBv3 LoadBalancer: 95c63318-e9df-4ce8-a72a-c0330e1f14c3
--- PASS: TestListenerLifecycle (10.50s)
PASS

Process finished with the exit code 0
```