### PR TITLE
[ELB] Fix `members` `CreateOpts` and `UpdateOpts`

### DIFF
--- a/openstack/elb/v3/members/requests.go
+++ b/openstack/elb/v3/members/requests.go
@@ -82,11 +82,14 @@ type CreateOpts struct {
 	// Only administrative users can specify a project UUID other than their own.
 	ProjectID string `json:"project_id,omitempty"`
 
-	// A positive integer value that indicates the relative portion of traffic
-	// that  this member should receive from the pool. For example, a member with
-	// a weight  of 10 receives five times as much traffic as a member with a
-	// weight of 2.
-	Weight int `json:"weight,omitempty"`
+	// Specifies the weight of the backend server.
+	//
+	// Requests are routed to backend servers in the same backend server group based on their weights.
+	//
+	// If the weight is 0, the backend server will not accept new requests.
+	//
+	// This parameter is invalid when lb_algorithm is set to SOURCE_IP for the backend server group that contains the backend server.
+	Weight *int `json:"weight,omitempty"`
 
 	// If you omit this parameter, LBaaS uses the vip_subnet_id parameter value
 	// for the subnet UUID.
@@ -131,13 +134,13 @@ type UpdateOptsBuilder interface {
 // operation.
 type UpdateOpts struct {
 	// Name of the Member.
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 
 	// A positive integer value that indicates the relative portion of traffic
 	// that this member should receive from the pool. For example, a member with
 	// a weight of 10 receives five times as much traffic as a member with a
 	// weight of 2.
-	Weight int `json:"weight,omitempty"`
+	Weight *int `json:"weight,omitempty"`
 
 	// The administrative state of the Pool. A valid value is true (UP)
 	// or false (DOWN).


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Fix schema of `...Opts` to match documentation

### Special notes for your reviewer
```
=== RUN   TestMemberLifecycle
    helpers.go:18: Attempting to create ELBv3 LoadBalancer
    helpers.go:56: Created ELBv3 LoadBalancer: bc02e1bd-867c-483c-8a33-984cac9f73d3
    helpers.go:149: Attempting to create ELBv3 Pool
    helpers.go:164: Created ELBv3 Pool: 70ea504e-095e-402e-b816-00a3894dffb7
    members_test.go:27: Attempting to create ELBv3 Member
    members_test.go:49: Created ELBv3 Member: 9f26a94a-438e-4482-9e69-e0c2e77288fe
    members_test.go:51: Attempting to update ELBv3 Member: 9f26a94a-438e-4482-9e69-e0c2e77288fe
    members_test.go:59: Updated ELBv3 Member: 9f26a94a-438e-4482-9e69-e0c2e77288fe
    members_test.go:40: Attempting to delete ELBv3 Member: 9f26a94a-438e-4482-9e69-e0c2e77288fe
    members_test.go:43: Deleted ELBv3 Member: 9f26a94a-438e-4482-9e69-e0c2e77288fe
    helpers.go:170: Attempting to delete ELBv3 Pool: 70ea504e-095e-402e-b816-00a3894dffb7
    helpers.go:173: Deleted ELBv3 Pool: 70ea504e-095e-402e-b816-00a3894dffb7
    helpers.go:62: Attempting to delete ELBv3 LoadBalancer: bc02e1bd-867c-483c-8a33-984cac9f73d3
    helpers.go:65: Deleted ELBv3 LoadBalancer: bc02e1bd-867c-483c-8a33-984cac9f73d3
--- PASS: TestMemberLifecycle (9.13s)
PASS

Process finished with the exit code 0

```