### PR TITLE
[ELB] Fix `monitors` v3 structures

### DIFF
--- a/acceptance/openstack/elb/v3/monitors_test.go
+++ b/acceptance/openstack/elb/v3/monitors_test.go
@@ -38,13 +38,14 @@ func TestMonitorLifecycle(t *testing.T) {
 	t.Logf("Attempting to Create ELBv3 Monitor")
 	monitorName := tools.RandomString("create-monitor-", 3)
 	createOpts := monitors.CreateOpts{
-		PoolID:     poolID,
-		Type:       monitors.TypeHTTP,
-		Delay:      1,
-		Timeout:    30,
-		MaxRetries: 3,
-		URLPath:    "/",
-		Name:       monitorName,
+		PoolID:        poolID,
+		Type:          monitors.TypeHTTP,
+		Delay:         1,
+		Timeout:       30,
+		MaxRetries:    3,
+		HTTPMethod:    "OPTIONS",
+		ExpectedCodes: "200-299",
+		Name:          monitorName,
 	}
 	monitor, err := monitors.Create(client, createOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -63,10 +64,11 @@ func TestMonitorLifecycle(t *testing.T) {
 	t.Logf("Attempting to Update ELBv3 Monitor")
 	monitorName = tools.RandomString("update-monitor-", 3)
 	updateOpts := monitors.UpdateOpts{
-		Delay:      3,
-		Timeout:    35,
-		MaxRetries: 5,
-		Name:       monitorName,
+		Delay:          3,
+		Timeout:        35,
+		MaxRetries:     5,
+		MaxRetriesDown: 3,
+		Name:           monitorName,
 	}
 	_, err = monitors.Update(client, monitor.ID, updateOpts).Extract()
 	th.AssertNoErr(t, err)
@@ -78,4 +80,5 @@ func TestMonitorLifecycle(t *testing.T) {
 	th.AssertEquals(t, updateOpts.Timeout, newMonitor.Timeout)
 	th.AssertEquals(t, updateOpts.Delay, newMonitor.Delay)
 	th.AssertEquals(t, updateOpts.MaxRetries, newMonitor.MaxRetries)
+	th.AssertEquals(t, createOpts.HTTPMethod, newMonitor.HTTPMethod)
 }

--- a/openstack/elb/v3/monitors/requests.go
+++ b/openstack/elb/v3/monitors/requests.go
@@ -1,8 +1,6 @@
 package monitors
 
 import (
-	"fmt"
-
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
@@ -90,27 +88,32 @@ type CreateOpts struct {
 	// The Pool to Monitor.
 	PoolID string `json:"pool_id" required:"true"`
 
-	// The type of probe, which is PING, TCP, HTTP, or HTTPS, that is
-	// sent by the load balancer to verify the member state.
+	// Specifies the health check protocol.
+	//
+	// The value can be TCP, UDP_CONNECT, HTTP, HTTPS, or PING.
 	Type Type `json:"type" required:"true"`
 
 	// The time, in seconds, between sending probes to members.
 	Delay int `json:"delay" required:"true"`
 
-	// Maximum number of seconds for a Monitor to wait for a ping reply
-	// before it times out. The value must be less than the delay value.
+	// Specifies the maximum time required for waiting for a response from the health check, in seconds.
+	// It is recommended that you set the value less than that of parameter delay.
 	Timeout int `json:"timeout" required:"true"`
 
-	// Number of permissible ping failures before changing the member's
-	// status to INACTIVE. Must be a number between 1 and 10.
-	MaxRetries     int `json:"max_retries" required:"true"`
+	// Specifies the number of consecutive health checks when the health check result of a backend server changes
+	// from OFFLINE to ONLINE. The value ranges from 1 to 10.
+	MaxRetries int `json:"max_retries" required:"true"`
+
+	// Specifies the number of consecutive health checks when the health check result of a backend server changes
+	// from ONLINE to OFFLINE.
 	MaxRetriesDown int `json:"max_retries_down,omitempty"`
 
-	// URI path that will be accessed if Monitor type is HTTP or HTTPS.
-	// Required for HTTP(S) types.
+	// Specifies the HTTP request path for the health check.
+	// The value must start with a slash (/), and the default value is /. This parameter is available only when type is set to HTTP.
 	URLPath string `json:"url_path,omitempty"`
 
-	// Domain Name.
+	// Specifies the domain name that HTTP requests are sent to during the health check.
+	// This parameter is available only when type is set to HTTP.
 	DomainName string `json:"domain_name,omitempty"`
 
 	// The HTTP method used for requests by the Monitor. If this attribute
@@ -138,12 +141,6 @@ type CreateOpts struct {
 
 // ToMonitorCreateMap builds a request body from CreateOpts.
 func (opts CreateOpts) ToMonitorCreateMap() (map[string]interface{}, error) {
-	if opts.Type == TypeHTTP || opts.Type == TypeHTTPS {
-		if opts.URLPath == "" {
-			return nil, fmt.Errorf("`url_path` must be provided for HTTP and HTTPS")
-		}
-	}
-
 	b, err := golangsdk.BuildRequestBody(opts, "healthmonitor")
 	if err != nil {
 		return nil, err

--- a/openstack/elb/v3/monitors/results.go
+++ b/openstack/elb/v3/monitors/results.go
@@ -28,8 +28,8 @@ type Monitor struct {
 	// The Name of the Monitor.
 	Name string `json:"name"`
 
-	// TenantID is the owner of the Monitor.
-	TenantID string `json:"tenant_id"`
+	// Specifies the project ID.
+	ProjectID string `json:"project_id"`
 
 	// The type of probe sent by the load balancer to verify the member state,
 	// which is PING, TCP, HTTP, or HTTPS.
@@ -43,9 +43,12 @@ type Monitor struct {
 	// value.
 	Timeout int `json:"timeout"`
 
-	// Number of allowed connection failures before changing the status of the
-	// member to INACTIVE. A valid value is from 1 to 10.
-	MaxRetries     int `json:"max_retries"`
+	// Specifies the number of consecutive health checks when the health check result of a backend server changes
+	// from OFFLINE to ONLINE.
+	MaxRetries int `json:"max_retries"`
+
+	// Specifies the number of consecutive health checks when the health check result of a backend server changes
+	// from ONLINE to OFFLINE.
 	MaxRetriesDown int `json:"max_retries_down"`
 
 	// The HTTP method that the monitor uses for requests.
@@ -67,10 +70,6 @@ type Monitor struct {
 
 	// The Port of the Monitor.
 	MonitorPort int `json:"monitor_port"`
-
-	// The status of the health monitor. Indicates whether the health monitor is
-	// operational.
-	Status string `json:"status"`
 
 	// List of pools that are associated with the health monitor.
 	Pools []structs.ResourceRef `json:"pools"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Make `monitor` structs match documentation

Make `monitor` structs match actual behaviour

Improve `monitor` documentation

### Special notes for your reviewer
```
=== RUN   TestMonitorList
    tools.go:72: {
          "id": "0a024881-3246-4f0c-b264-361f42113aa9",
          "name": "",
          "project_id": "...",
          "type": "HTTP",
          "delay": 5,
          "timeout": 3,
          "max_retries": 3,
          "max_retries_down": 3,
          "http_method": "GET",
          "url_path": "/",
          "domain_name": "",
          "expected_codes": "200",
          "admin_state_up": true,
          "monitor_port": 0,
          "pools": [
            {
              "id": "9cbaa44f-6b15-457a-a461-c3610ea34ad0"
            }
          ]
        }
    tools.go:72: {
          "id": "8426938b-9159-44b9-8817-d63bf3831f9d",
          "name": "",
          "project_id": "...",
          "type": "HTTP",
          "delay": 5,
          "timeout": 3,
          "max_retries": 3,
          "max_retries_down": 3,
          "http_method": "GET",
          "url_path": "/",
          "domain_name": "",
          "expected_codes": "200",
          "admin_state_up": false,
          "monitor_port": 0,
          "pools": [
            {
              "id": "59f84a63-2555-4e66-b863-0fda1d6ee8aa"
            }
          ]
        }
    tools.go:72: {
          "id": "e60faebc-624d-4146-9657-83e423433434",
          "name": "",
          "project_id": "...",
          "type": "HTTP",
          "delay": 5,
          "timeout": 3,
          "max_retries": 3,
          "max_retries_down": 3,
          "http_method": "GET",
          "url_path": "/",
          "domain_name": "",
          "expected_codes": "200",
          "admin_state_up": false,
          "monitor_port": 0,
          "pools": [
            {
              "id": "cc080727-2754-4d7c-9ed4-3ab34ace43f5"
            }
          ]
        }
    tools.go:72: {
          "id": "ea82b468-4cee-448f-8b2f-b5c12045470c",
          "name": "",
          "project_id": "...",
          "type": "HTTP",
          "delay": 5,
          "timeout": 3,
          "max_retries": 3,
          "max_retries_down": 3,
          "http_method": "GET",
          "url_path": "/",
          "domain_name": "",
          "expected_codes": "200",
          "admin_state_up": true,
          "monitor_port": 0,
          "pools": [
            {
              "id": "0d3a7bfd-a883-4b8f-9411-72a83d9817ac"
            }
          ]
        }
--- PASS: TestMonitorList (1.05s)
=== RUN   TestMonitorLifecycle
    helpers.go:18: Attempting to create ELBv3 LoadBalancer
    helpers.go:56: Created ELBv3 LoadBalancer: 4b032cfe-7374-4fbd-aa65-f27e974efd37
    helpers.go:149: Attempting to create ELBv3 Pool
    helpers.go:164: Created ELBv3 Pool: bd7d9d57-1393-4b82-84e0-4f273694694e
    monitors_test.go:38: Attempting to Create ELBv3 Monitor
    monitors_test.go:62: Created ELBv3 Monitor: b6b067ac-8f7e-4b06-b106-e878ff668964
    monitors_test.go:64: Attempting to Update ELBv3 Monitor
    monitors_test.go:75: Updated ELBv3 Monitor: b6b067ac-8f7e-4b06-b106-e878ff668964
    monitors_test.go:53: Attempting to Delete ELBv3 Monitor: b6b067ac-8f7e-4b06-b106-e878ff668964
    monitors_test.go:56: Deleted ELBv3 Monitor: b6b067ac-8f7e-4b06-b106-e878ff668964
    helpers.go:170: Attempting to delete ELBv3 Pool: bd7d9d57-1393-4b82-84e0-4f273694694e
    helpers.go:173: Deleted ELBv3 Pool: bd7d9d57-1393-4b82-84e0-4f273694694e
    helpers.go:62: Attempting to delete ELBv3 LoadBalancer: 4b032cfe-7374-4fbd-aa65-f27e974efd37
    helpers.go:65: Deleted ELBv3 LoadBalancer: 4b032cfe-7374-4fbd-aa65-f27e974efd37
--- PASS: TestMonitorLifecycle (8.18s)
PASS

Process finished with the exit code 0

```