### PR TITLE
[ELB] Add `List` function to listeners v3

### DIFF
--- a/acceptance/openstack/elb/v3/listeners_test.go
+++ b/acceptance/openstack/elb/v3/listeners_test.go
@@ -65,4 +65,12 @@ func TestListenerLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, listenerName, newListener.Name)
 	th.AssertEquals(t, emptyDescription, newListener.Description)
+
+	listOpts := listeners.ListOpts{LoadBalancerID: []string{loadbalancerID}}
+	pages, err := listeners.List(client, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+	listenerSlice, err := listeners.ExtractListeners(pages)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(listenerSlice))
+	th.AssertDeepEquals(t, *newListener, listenerSlice[0])
 }

--- a/openstack/elb/v3/listeners/requests.go
+++ b/openstack/elb/v3/listeners/requests.go
@@ -3,6 +3,7 @@ package listeners
 import (
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
 
 // Protocol represents a listener protocol.
@@ -223,4 +224,52 @@ func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) 
 func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(resourceURL(client, id), nil)
 	return
+}
+
+type ListOptsBuilder interface {
+	ToListenerListQuery() (string, error)
+}
+
+type ListOpts struct {
+	Limit       int    `q:"limit"`
+	Marker      string `q:"marker"`
+	PageReverse bool   `q:"page_reverse"`
+
+	ProtocolPort            []int      `q:"protocol_port"`
+	Protocol                []Protocol `q:"protocol"`
+	Description             []string   `q:"description"`
+	DefaultTLSContainerRef  []string   `q:"default_tls_container_ref"`
+	ClientCATLSContainerRef []string   `q:"client_ca_tls_container_ref"`
+	DefaultPoolID           []string   `q:"default_pool_id"`
+	ID                      []string   `q:"id"`
+	Name                    []string   `q:"name"`
+	LoadBalancerID          []string   `q:"loadbalancer_id"`
+	TLSCiphersPolicy        []string   `q:"tls_ciphers_policy"`
+	MemberAddress           []string   `q:"member_address"`
+	MemberDeviceID          []string   `q:"member_device_id"`
+	MemberTimeout           []int      `q:"member_timeout"`
+	ClientTimeout           []int      `q:"client_timeout"`
+	KeepAliveTimeout        []int      `q:"keep_alive_timeout"`
+}
+
+func (opts ListOpts) ToListenerListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), nil
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := rootURL(client)
+	if opts != nil {
+		q, err := opts.ToListenerListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += q
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ListenerPage{PageWithInfo: pagination.NewPageWithInfo(r)}
+	})
 }

--- a/openstack/elb/v3/listeners/results.go
+++ b/openstack/elb/v3/listeners/results.go
@@ -4,6 +4,7 @@ import (
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/structs"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
 
 // Listener is the primary load balancing configuration object that specifies
@@ -127,4 +128,25 @@ type UpdateResult struct {
 // ExtractErr method to determine if the request succeeded or failed.
 type DeleteResult struct {
 	golangsdk.ErrResult
+}
+
+type ListenerPage struct {
+	pagination.PageWithInfo
+}
+
+func (p ListenerPage) IsEmpty() (bool, error) {
+	l, err := ExtractListeners(p)
+	if err != nil {
+		return false, err
+	}
+	return len(l) == 0, nil
+}
+
+func ExtractListeners(r pagination.Page) ([]Listener, error) {
+	var s []Listener
+	err := (r.(ListenerPage)).ExtractIntoSlicePtr(&s, "listeners")
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Missing `List` for listeners v3

Required for `opentelekomcloud_lb_listener_v3` data source.

### Special notes for your reviewer
```
=== RUN   TestListenerLifecycle
    helpers.go:18: Attempting to create ELBv3 LoadBalancer
    helpers.go:56: Created ELBv3 LoadBalancer: d91a462e-1227-43a6-bc23-460445296722
    helpers.go:69: Attempting to create ELBv3 certificate
    helpers.go:136: Created ELBv3 certificate: 481dd3edda384e5694357d6cf1ad00dc
    listeners_test.go:23: Attempting to create ELBv3 Listener
    listeners_test.go:51: Created ELBv3 Listener: 82687abf-ac59-493d-96fa-4230a6f3f9ac
    listeners_test.go:53: Attempting to update ELBv3 Listener: 82687abf-ac59-493d-96fa-4230a6f3f9ac
    listeners_test.go:62: Updated ELBv3 Listener: 82687abf-ac59-493d-96fa-4230a6f3f9ac
    listeners_test.go:43: Attempting to delete ELBv3 Listener: 82687abf-ac59-493d-96fa-4230a6f3f9ac
    listeners_test.go:46: Deleted ELBv3 Listener: 82687abf-ac59-493d-96fa-4230a6f3f9ac
    helpers.go:142: Attempting to delete ELBv3 certificate: 481dd3edda384e5694357d6cf1ad00dc
    helpers.go:145: Deleted ELBv3 certificate: 481dd3edda384e5694357d6cf1ad00dc
    helpers.go:62: Attempting to delete ELBv3 LoadBalancer: d91a462e-1227-43a6-bc23-460445296722
    helpers.go:65: Deleted ELBv3 LoadBalancer: d91a462e-1227-43a6-bc23-460445296722
--- PASS: TestListenerLifecycle (10.15s)
PASS

Process finished with the exit code 0

```
