### PR TITLE
[ECS] Implement the possibility to encrypt `root_volume`

### DIFF
--- a/acceptance/openstack/common.go
+++ b/acceptance/openstack/common.go
@@ -150,6 +150,10 @@ func GetCloudServerCreateOpts(t *testing.T) cloudservers.CreateOpts {
 		},
 		RootVolume: cloudservers.RootVolume{
 			VolumeType: "SSD",
+			Metadata: map[string]interface{}{
+				"__system__encrypted": encryption,
+				"__system__cmkid":     kmsID,
+			},
 		},
 		DataVolumes: []cloudservers.DataVolume{
 			{

--- a/acceptance/openstack/swr/v2/organizations_test.go
+++ b/acceptance/openstack/swr/v2/organizations_test.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"testing"
 
@@ -11,11 +12,21 @@ import (
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
 
+func randomRepoName(prefix string, n int) string {
+	const alphanum = "0123456789abcdefghijklmnopqrstuvwxyz"
+	var bytes = make([]byte, n)
+	_, _ = rand.Read(bytes)
+	for i, b := range bytes {
+		bytes[i] = alphanum[b%byte(len(alphanum))]
+	}
+	return prefix + string(bytes)
+}
+
 func TestOrganizationWorkflow(t *testing.T) {
 	client, err := clients.NewSwrV2Client()
 	th.AssertNoErr(t, err)
 
-	name := "test-org"
+	name := randomRepoName("test-org", 6)
 	opts := organizations.CreateOpts{Namespace: name}
 	err = organizations.Create(client, opts).ExtractErr()
 	th.AssertNoErr(t, err)

--- a/openstack/ecs/v1/cloudservers/requests.go
+++ b/openstack/ecs/v1/cloudservers/requests.go
@@ -160,6 +160,8 @@ type RootVolume struct {
 	// Pay attention to this parameter if your ECS is SDI-compliant.
 	// If the value of this parameter is true, the created disk is of SCSI type.
 	PassThrough *bool `json:"hw:passthrough,omitempty"`
+
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
 type DataVolume struct {


### PR DESCRIPTION
### What this PR does / why we need it
Implement the possibility to encrypt `root_volume` in v1

### Which issue this PR fixes
Resolves: #310

### Special notes for your reviewer
```
=== RUN   TestCloudServerLifecycle
    common.go:175: Attempting to check ECSv1 createOpts
    cloudservers_test.go:21: CreateOpts are ok for creating a cloudServer
    common.go:181: Attempting to create ECSv1
    common.go:194: Created ECSv1 instance: 5ba42a3d-09e1-4324-a04b-a98f06932c8b
    common.go:200: Attempting to delete ECSv1: 5ba42a3d-09e1-4324-a04b-a98f06932c8b
    common.go:217: ECSv1 instance deleted: 5ba42a3d-09e1-4324-a04b-a98f06932c8b
--- PASS: TestCloudServerLifecycle (267.52s)
PASS

Process finished with the exit code 0
```