### PR TITLE
[KMS] Fix init client in `eu-nl` region

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -793,8 +793,7 @@ func NewRDSV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*gol
 
 // NewKMSV1 creates a ServiceClient that may be used to access the KMS service.
 func NewKMSV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
-	sc, err := initClientOpts(client, eo, "kms")
-	return sc, err
+	return initClientOpts(client, eo, "kmsv1")
 }
 
 // NewSMNV2 creates a ServiceClient that may be used to access the SMN service.

--- a/openstack/kms/v1/grants/results.go
+++ b/openstack/kms/v1/grants/results.go
@@ -32,7 +32,10 @@ type CreateResult struct {
 func (r CreateResult) Extract() (*CreateGrant, error) {
 	s := new(CreateGrant)
 	err := r.ExtractInto(s)
-	return s, err
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 type DeleteResult struct {
@@ -46,5 +49,8 @@ type ListResult struct {
 func (r ListResult) Extract() (*ListGrant, error) {
 	s := new(ListGrant)
 	err := r.ExtractInto(&s)
-	return s, err
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/openstack/kms/v1/grants/urls.go
+++ b/openstack/kms/v1/grants/urls.go
@@ -7,13 +7,13 @@ const (
 )
 
 func createURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "create-grant")
+	return c.ServiceURL(resourcePath, "create-grant")
 }
 
 func deleteURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "revoke-grant")
+	return c.ServiceURL(resourcePath, "revoke-grant")
 }
 
 func listURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "list-grants")
+	return c.ServiceURL(resourcePath, "list-grants")
 }

--- a/openstack/kms/v1/keys/requests.go
+++ b/openstack/kms/v1/keys/requests.go
@@ -270,27 +270,3 @@ func ListAllKeys(client *golangsdk.ServiceClient, opts ListOptsBuilder) (r ListR
 	})
 	return
 }
-
-// func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) (r GetResult) {
-//	//url := listURL(client)
-//	//if opts != nil {
-//	//	query, err := opts.ToKeyListQuery()
-//	//	if err != nil {
-//	//		return pagination.Pager{Err: err}
-//	//	}
-//	//	url += query
-//	//}
-//	b, err := opts.ToKeyListQuery()
-//	if err != nil {
-//		r.Err = err
-//		return
-//	}
-//	_, r.Err = client.Post(listURL(client), b, &r.Body, &golangsdk.RequestOpts{
-//		OkCodes: []int{200},
-//	})
-//	return
-//
-//	//return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-//	//	return KeyPage{pagination.LinkedPageBase{PageResult: r}}
-//	//})
-// }

--- a/openstack/kms/v1/keys/results.go
+++ b/openstack/kms/v1/keys/results.go
@@ -108,19 +108,28 @@ type ListResult struct {
 func (r commonResult) ExtractListKey() (*ListKey, error) {
 	var s *ListKey
 	err := r.ExtractInto(&s)
-	return s, err
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 func (r commonResult) Extract() (*Key, error) {
 	var s *Key
 	err := r.ExtractInto(&s)
-	return s, err
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 func (r commonResult) ExtractKeyInfo() (*Key, error) {
 	var s Key
 	err := r.ExtractKeyInfoInto(&s)
-	return &s, err
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
 }
 
 func (r commonResult) ExtractKeyInfoInto(v interface{}) error {
@@ -130,13 +139,19 @@ func (r commonResult) ExtractKeyInfoInto(v interface{}) error {
 func (r commonResult) ExtractDataKey() (*DataKey, error) {
 	var s *DataKey
 	err := r.ExtractInto(&s)
-	return s, err
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 func (r commonResult) ExtractEncryptDEK() (*EncryptDEK, error) {
 	var s *EncryptDEK
 	err := r.ExtractInto(&s)
-	return s, err
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 type KeyPage struct {
@@ -153,5 +168,8 @@ func ExtractKeys(r pagination.Page) ([]Key, error) {
 		Keys []Key `json:"keys"`
 	}
 	err := (r.(KeyPage)).ExtractInto(&s)
-	return s.Keys, err
+	if err != nil {
+		return nil, err
+	}
+	return s.Keys, nil
 }

--- a/openstack/kms/v1/keys/urls.go
+++ b/openstack/kms/v1/keys/urls.go
@@ -7,41 +7,41 @@ const (
 )
 
 func getURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "describe-key")
+	return c.ServiceURL(resourcePath, "describe-key")
 }
 
 func createURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "create-key")
+	return c.ServiceURL(resourcePath, "create-key")
 }
 
 func deleteURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "schedule-key-deletion")
+	return c.ServiceURL(resourcePath, "schedule-key-deletion")
 }
 
 func updateAliasURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "update-key-alias")
+	return c.ServiceURL(resourcePath, "update-key-alias")
 }
 
 func updateDesURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "update-key-description")
+	return c.ServiceURL(resourcePath, "update-key-description")
 }
 
 func dataEncryptURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "create-datakey")
+	return c.ServiceURL(resourcePath, "create-datakey")
 }
 
 func encryptDEKURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "encrypt-datakey")
+	return c.ServiceURL(resourcePath, "encrypt-datakey")
 }
 
 func enableKeyURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "enable-key")
+	return c.ServiceURL(resourcePath, "enable-key")
 }
 
 func disableKeyURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "disable-key")
+	return c.ServiceURL(resourcePath, "disable-key")
 }
 
 func listURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL(c.ProjectID, resourcePath, "list-keys")
+	return c.ServiceURL(resourcePath, "list-keys")
 }


### PR DESCRIPTION
### What this PR does / why we need it
* Fix init client in `eu-nl` region
* Get rid of `c.ProjectID` in `kms` pkg

### Which issue this PR fixes
Refers to: https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1591

### Special notes for your reviewer
```
=== RUN   TestKmsGrantsLifecycle
--- PASS: TestKmsGrantsLifecycle (2.46s)
PASS


Process finished with the exit code 0
```