### PR TITLE
Use otc-golangci-lint

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -5,7 +5,7 @@
       functest_project_name: "eu-de_zuul_go"
     check:
       jobs:
-        - golangci-lint
+        - otc-golangci-lint
         - golang-make-vet
         - golang-make-test
     check-post:
@@ -13,7 +13,7 @@
         - golang-make-functional
     gate:
       jobs:
-        - golangci-lint
+        - otc-golangci-lint
         - golang-make-vet
         - golang-make-test
         - golang-make-functional

--- a/acceptance/openstack/swr/v2/domain_test.go
+++ b/acceptance/openstack/swr/v2/domain_test.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -15,12 +14,12 @@ func TestAccessDomainWorkflow(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	// setup deps
-	orgName := fmt.Sprintf("domaintest")
+	orgName := "domaintest"
 	dep := dependencies{t: t, client: client}
 	dep.createOrganization(orgName)
 	defer dep.deleteOrganization(orgName)
 
-	repoName := fmt.Sprintf("repodomain")
+	repoName := "repodomain"
 	dep.createRepository(orgName, repoName)
 	defer dep.deleteRepository(orgName, repoName)
 

--- a/openstack/obs/client.go
+++ b/openstack/obs/client.go
@@ -65,9 +65,7 @@ func (obsClient ObsClient) Refresh(ak, sk, securityToken string) {
 }
 
 func (obsClient ObsClient) Close() {
-	obsClient.httpClient = nil
 	obsClient.conf.transport.CloseIdleConnections()
-	obsClient.conf = nil
 	SyncLog()
 }
 

--- a/openstack/vpcep/v1/services/testing/requests_test.go
+++ b/openstack/vpcep/v1/services/testing/requests_test.go
@@ -114,7 +114,7 @@ func TestListRequest(t *testing.T) {
 
 	name := "test123"
 
-	th.Mux.HandleFunc(fmt.Sprintf("/vpc-endpoint-services"), func(w http.ResponseWriter, r *http.Request) {
+	th.Mux.HandleFunc("/vpc-endpoint-services", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestFormValues(t, r, map[string]string{"endpoint_service_name": name})


### PR DESCRIPTION
### What this PR does / why we need it
Use `otc-golangci-lint` against `golangci-lint`

