### PR TITLE
[RDS] Fix backup fields

### DIFF
--- a/acceptance/openstack/rds/v3/backups_test.go
+++ b/acceptance/openstack/rds/v3/backups_test.go
@@ -37,4 +37,11 @@ func TestBackupWorkflow(t *testing.T) {
 	err = backups.WaitForBackup(client, rds.Id, b.ID, backups.StatusCompleted)
 	th.AssertNoErr(t, err)
 	t.Log("Backup creation complete")
+
+	pages, err := backups.List(client, backups.ListOpts{InstanceID: b.InstanceID, BackupID: b.ID}).AllPages()
+	th.AssertNoErr(t, err)
+	backupList, err := backups.ExtractBackups(pages)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(backupList))
+	tools.PrintResource(t, backupList[0])
 }

--- a/openstack/rds/v3/backups/results.go
+++ b/openstack/rds/v3/backups/results.go
@@ -22,16 +22,16 @@ const (
 )
 
 type Backup struct {
-	ID          string              `json:"id"`
-	InstanceID  string              `json:"instance_id"`
-	Name        string              `json:"name"`
-	Description string              `json:"description"`
-	Type        string              `json:"type"`
-	Databases   []BackupDatabase    `json:"databases"`
-	BeginTime   string              `json:"begin_time"`
-	EndTime     string              `json:"end_time"`
-	Datastore   instances.Datastore `json:"datastore"`
-	Status      BackupStatus        `json:"status"`
+	ID         string              `json:"id"`
+	InstanceID string              `json:"instance_id"`
+	Name       string              `json:"name"`
+	Type       string              `json:"type"`
+	Size       int                 `json:"size"`
+	Databases  []BackupDatabase    `json:"databases"`
+	BeginTime  string              `json:"begin_time"`
+	EndTime    string              `json:"end_time"`
+	Datastore  instances.Datastore `json:"datastore"`
+	Status     BackupStatus        `json:"status"`
 }
 
 type CreateResult struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
`Backup` response schema is not up to date with documentation:
https://docs.otc.t-systems.com/api/rds/rds_09_0005.html

`Description` field removed

`Size` field added

### Special notes for your reviewer
```
=== RUN   TestBackupWorkflow
    helpers.go:16: Attempting to create RDSv3
    helpers.go:62: Created RDSv3: 3b86ee0c35bd44b18121942dc79d8ec4in03
    backups_test.go:30: Backup creation started
    backups_test.go:39: Backup creation complete
    tools.go:72: {
          "id": "083fedb479164dc2b3dc4f7013fdb0a8br03",
          "instance_id": "3b86ee0c35bd44b18121942dc79d8ec4in03",
          "name": "rds-backup-xtv5I",
          "type": "manual",
          "size": 5142,
          "databases": null,
          "begin_time": "2022-02-04T14:10:02+0000",
          "end_time": "2022-02-04T14:12:12+0000",
          "datastore": {
            "type": "PostgreSQL",
            "version": "11"
          },
          "status": "COMPLETED"
        }
    backups_test.go:34: Backup deleted
    helpers.go:68: Attempting to delete RDSv3: 3b86ee0c35bd44b18121942dc79d8ec4in03
    helpers.go:73: RDSv3 instance deleted: 3b86ee0c35bd44b18121942dc79d8ec4in03
--- PASS: TestBackupWorkflow (437.64s)
PASS

Process finished with the exit code 0
```