### PR TITLE
Remove required tag for InitialNodeCount fields

### DIFF
--- a/openstack/cce/v3/nodepools/requests.go
+++ b/openstack/cce/v3/nodepools/requests.go
@@ -113,7 +113,7 @@ type CreateSpec struct {
 	// Node template
 	NodeTemplate nodes.Spec `json:"nodeTemplate" required:"true"`
 	// Initial number of expected nodes
-	InitialNodeCount int `json:"initialNodeCount" required:"true"`
+	InitialNodeCount int `json:"initialNodeCount"`
 	// Auto scaling parameters
 	Autoscaling AutoscalingSpec `json:"autoscaling,omitempty"`
 	// Node management parameters
@@ -185,7 +185,7 @@ type UpdateSpec struct {
 	// Node template
 	NodeTemplate UpdateNodeTemplate `json:"nodeTemplate,omitempty"`
 	// Initial number of expected nodes
-	InitialNodeCount int `json:"initialNodeCount" required:"true"`
+	InitialNodeCount int `json:"initialNodeCount"`
 	// Auto scaling parameters
 	Autoscaling AutoscalingSpec `json:"autoscaling,omitempty"`
 }


### PR DESCRIPTION
### What this PR does / why we need it
Enables scaling node pools to zero

### Special notes for your reviewer
InitialNodeCount can be zero (for scale-to-zero cases). Members with tag "required: true" are considered invalid when they have a zero value.