### PR TITLE
[RDS] add PointInTime Recovery

### DIFF
--- a/openstack/rds/v3/backups/requests.go
+++ b/openstack/rds/v3/backups/requests.go
@@ -176,8 +176,8 @@ type RestorePITROpts struct {
 }
 
 type Source struct {
-	InstanceID  string `json:"instance_id" required:"true"`
 	BackupID    string `json:"backup_id" required:"false"`
+	InstanceID  string `json:"instance_id" required:"true"`
 	RestoreTime int64  `json:"restore_time" required:"false"`
 	Type        string `json:"type" required:"true"`
 }

--- a/openstack/rds/v3/backups/requests.go
+++ b/openstack/rds/v3/backups/requests.go
@@ -177,7 +177,8 @@ type RestorePITROpts struct {
 
 type Source struct {
 	InstanceID   string `json:"instance_id" required:"true"`
-	RestoreTime  int64  `json:"restore_time" required:"true"`
+	BackupID     string `json:"backup_id" required:"false"`
+	RestoreTime  int64  `json:"restore_time" required:"false"`
 	Type         string `json:"type" required:"true"`
 }
 

--- a/openstack/rds/v3/backups/requests.go
+++ b/openstack/rds/v3/backups/requests.go
@@ -171,8 +171,8 @@ type RestoreToNewOpts struct {
 }
 
 type RestorePITROpts struct {
-	Source *Source `json:"source"`
-	Target *Target `json:"target"`
+	Source Source `json:"source"`
+	Target Target `json:"target"`
 }
 
 type Source struct {
@@ -190,14 +190,14 @@ type RestoreToNewOptsBuilder interface {
 }
 
 type RestorePITROptsBuilder interface {
-	ToBackupRestoreMap() (map[string]interface{}, error)
+	ToPITRRestoreMap() (map[string]interface{}, error)
 }
 
 func (opts RestoreToNewOpts) ToBackupRestoreMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "")
 }
 
-func (opts RestorePITROpts) ToBackupRestoreMap() (map[string]interface{}, error) {
+func (opts RestorePITROpts) ToPITRRestoreMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "")
 }
 
@@ -214,7 +214,7 @@ func RestoreToNew(c *golangsdk.ServiceClient, opts RestoreToNewOptsBuilder) (r R
 }
 
 func RestorePITR(c *golangsdk.ServiceClient, opts RestorePITROptsBuilder) (r RestoreResult) {
-	b, err := opts.ToBackupRestoreMap()
+	b, err := opts.ToPITRRestoreMap()
 	if err != nil {
 		r.Err = err
 		return

--- a/openstack/rds/v3/backups/requests.go
+++ b/openstack/rds/v3/backups/requests.go
@@ -176,10 +176,10 @@ type RestorePITROpts struct {
 }
 
 type Source struct {
-	InstanceID   string `json:"instance_id" required:"true"`
-	BackupID     string `json:"backup_id" required:"false"`
-	RestoreTime  int64  `json:"restore_time" required:"false"`
-	Type         string `json:"type" required:"true"`
+	InstanceID  string `json:"instance_id" required:"true"`
+	BackupID    string `json:"backup_id" required:"false"`
+	RestoreTime int64  `json:"restore_time" required:"false"`
+	Type        string `json:"type" required:"true"`
 }
 
 type Target struct {

--- a/openstack/rds/v3/backups/requests.go
+++ b/openstack/rds/v3/backups/requests.go
@@ -170,11 +170,34 @@ type RestoreToNewOpts struct {
 	RestorePoint     RestorePoint              `json:"restore_point" required:"true"`
 }
 
+type RestorePITROpts struct {
+	Source *Source `json:"source"`
+	Target *Target `json:"target"`
+}
+
+type Source struct {
+	InstanceId   string `json:"instance_id" required:"true"`
+	RestoreTime  int64  `json:"restore_time" required:"true"`
+	Type         string `json:"type" required:"true"`
+}
+
+type Target struct {
+	InstanceId string `json:"instance_id" required:"true"`
+}
+
 type RestoreToNewOptsBuilder interface {
 	ToBackupRestoreMap() (map[string]interface{}, error)
 }
 
+type RestorePITROptsBuilder interface {
+	ToBackupRestoreMap() (map[string]interface{}, error)
+}
+
 func (opts RestoreToNewOpts) ToBackupRestoreMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+func (opts RestorePITROpts) ToBackupRestoreMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "")
 }
 
@@ -185,6 +208,18 @@ func RestoreToNew(c *golangsdk.ServiceClient, opts RestoreToNewOptsBuilder) (r R
 		return
 	}
 	_, r.Err = c.Post(instances.CreateURL(c), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	return
+}
+
+func RestorePITR(c *golangsdk.ServiceClient, opts RestorePITROptsBuilder) (r RestoreResult) {
+	b, err := opts.ToBackupRestoreMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(instances.CreateURL(c) + "/recovery", b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{200, 201, 202},
 	})
 	return

--- a/openstack/rds/v3/backups/requests.go
+++ b/openstack/rds/v3/backups/requests.go
@@ -176,13 +176,13 @@ type RestorePITROpts struct {
 }
 
 type Source struct {
-	InstanceId   string `json:"instance_id" required:"true"`
+	InstanceID   string `json:"instance_id" required:"true"`
 	RestoreTime  int64  `json:"restore_time" required:"true"`
 	Type         string `json:"type" required:"true"`
 }
 
 type Target struct {
-	InstanceId string `json:"instance_id" required:"true"`
+	InstanceID string `json:"instance_id" required:"true"`
 }
 
 type RestoreToNewOptsBuilder interface {
@@ -219,7 +219,7 @@ func RestorePITR(c *golangsdk.ServiceClient, opts RestorePITROptsBuilder) (r Res
 		r.Err = err
 		return
 	}
-	_, r.Err = c.Post(instances.CreateURL(c) + "/recovery", b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = c.Post(restoreURL(c), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{200, 201, 202},
 	})
 	return

--- a/openstack/rds/v3/backups/testing/requests_test.go
+++ b/openstack/rds/v3/backups/testing/requests_test.go
@@ -46,13 +46,15 @@ const expectedRequest = `
 const expectedPITRRequest = `
 {
   "source": {
+    "backup_id": "",
     "instance_id": "d8e6ca5a624745bcb546a227aa3ae1cfin01",
-    "type": "timestamp",
-    "restore_time": 1532001446987
+    "restore_time": 1532001446987,
+    "type": "timestamp"
   },
   "target": {
     "instance_id": "d8e6ca5a624745bcb546a227aa3ae1cfin01"
   }
+}
 `
 
 const expectedResponse = `
@@ -124,12 +126,12 @@ func exampleRestoreOpts() backups.RestoreToNewOpts {
 
 func exampleRestorePITROpts() backups.RestorePITROpts {
 	return backups.RestorePITROpts{
-		Source: {
+		Source: backups.Source{
 			InstanceID:  "d8e6ca5a624745bcb546a227aa3ae1cfin01",
 			RestoreTime: 1532001446987,
 			Type:        "timestamp",
 		},
-		Target: {
+		Target: backups.Target{
 			InstanceID: "d8e6ca5a624745bcb546a227aa3ae1cfin01",
 		},
 	}
@@ -147,7 +149,7 @@ func TestRestoreRequestBodyPITR(t *testing.T) {
 	opts := exampleRestorePITROpts()
 	result, err := opts.ToPITRRestoreMap()
 	th.AssertNoErr(t, err)
-	th.AssertJSONEquals(t, expectedRequest, result)
+	th.AssertJSONEquals(t, expectedPITRRequest, result)
 }
 
 func TestRestoreRequest(t *testing.T) {

--- a/openstack/rds/v3/backups/urls.go
+++ b/openstack/rds/v3/backups/urls.go
@@ -13,3 +13,7 @@ func backupURL(c *golangsdk.ServiceClient, id string) string {
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL("instances", id, "backups/policy")
 }
+
+func restoreURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("instances", "recovery")
+}


### PR DESCRIPTION
Signed-off-by: Frank Kloeker <f.kloeker@telekom.de>

<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it

At the moment Backup Restore to New Instances are supported. This PR extends the restore methods with Point In Time Recovery (PITR) to the same instance,

Ref: https://docs.otc.t-systems.com/api/rds/rds_09_0009.html

