### PR TITLE
[WAF] Fix invalid CC protection rules fields

### DIFF
--- a/acceptance/openstack/waf/v1/ccattackprotection_rules_test.go
+++ b/acceptance/openstack/waf/v1/ccattackprotection_rules_test.go
@@ -1,0 +1,54 @@
+package v1
+
+import (
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	rules "github.com/opentelekomcloud/gophertelekomcloud/openstack/waf/v1/ccattackprotection_rules"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/waf/v1/policies"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestCCAttackProtectionRuleWorkflow(t *testing.T) {
+	client, err := clients.NewWafV1Client()
+	th.AssertNoErr(t, err)
+
+	pID := prepareAndRemovePolicy(t, client)
+	opts := rules.CreateOpts{
+		Path:        "/admin*",
+		LimitNum:    golangsdk.IntToPointer(2),
+		LimitPeriod: golangsdk.IntToPointer(30),
+		LockTime:    golangsdk.IntToPointer(1200),
+		TagType:     "cookie",
+		TagIndex:    "sessionid",
+		TagCondition: rules.TagCondition{
+			Category: "Referer",
+			Contents: []string{"http://www.example.com/path"},
+		},
+		Action: rules.Action{
+			Category: "block",
+			Detail: rules.Detail{
+				Response: rules.Response{
+					ContentType: "application/json",
+					Content:     `{"error":"forbidden"}`,
+				},
+			},
+		},
+	}
+	r, err := rules.Create(client, pID, opts).Extract()
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		th.AssertNoErr(t, rules.Delete(client, pID, r.Id).ExtractErr())
+	})
+
+	th.AssertEquals(t, r.PolicyID, pID)
+}
+
+func prepareAndRemovePolicy(t *testing.T, client *golangsdk.ServiceClient) string {
+	p := preparePolicy(t, client)
+	t.Cleanup(func() {
+		th.AssertNoErr(t, policies.Delete(client, p.Id).ExtractErr())
+	})
+	return p.Id
+}

--- a/openstack/waf/v1/ccattackprotection_rules/requests.go
+++ b/openstack/waf/v1/ccattackprotection_rules/requests.go
@@ -13,7 +13,7 @@ type CreateOptsBuilder interface {
 
 // CreateOpts contains all the values needed to create a new cc attack protection rule.
 type CreateOpts struct {
-	Url          string       `json:"url" required:"true"`
+	Path         string       `json:"path" required:"true"`
 	LimitNum     *int         `json:"limit_num" required:"true"`
 	LimitPeriod  *int         `json:"limit_period" required:"true"`
 	LockTime     *int         `json:"lock_time,omitempty"`

--- a/openstack/waf/v1/ccattackprotection_rules/results.go
+++ b/openstack/waf/v1/ccattackprotection_rules/results.go
@@ -6,8 +6,8 @@ import (
 
 type CcAttack struct {
 	Id           string       `json:"id"`
-	PolicyID     string       `json:"policyid"`
-	Url          string       `json:"url"`
+	PolicyID     string       `json:"policy_id"`
+	Path         string       `json:"path"`
 	LimitNum     int          `json:"limit_num"`
 	LimitPeriod  int          `json:"limit_period"`
 	LockTime     int          `json:"lock_time"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Rename `url` JSON field to `path`

Rename `policyid` JSON field to `policy_id`

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->
Fix #334

### Acceptance Results

```
=== RUN   TestCCAttackProtectionRuleWorkflow
--- PASS: TestCCAttackProtectionRuleWorkflow (2.38s)
PASS

Process finished with the exit code 0
```
