### PR TITLE
[WAF] Fix invalid structures in rules

### DIFF
--- a/acceptance/openstack/waf/v1/datamasking_rules_test.go
+++ b/acceptance/openstack/waf/v1/datamasking_rules_test.go
@@ -1,0 +1,42 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	rules "github.com/opentelekomcloud/gophertelekomcloud/openstack/waf/v1/datamasking_rules"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestDatamaskingRuleWorkflow(t *testing.T) {
+	client, err := clients.NewWafV1Client()
+	th.AssertNoErr(t, err)
+
+	pID := prepareAndRemovePolicy(t, client)
+	opts := rules.CreateOpts{
+		Path:     "/*",
+		Category: "params",
+		Index:    "name",
+	}
+	r, err := rules.Create(client, pID, opts).Extract()
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		th.AssertNoErr(t, rules.Delete(client, pID, r.Id).ExtractErr())
+	})
+
+	th.AssertEquals(t, opts.Path, r.Path)
+	th.AssertEquals(t, pID, r.PolicyID)
+
+	uOpts := rules.UpdateOpts{
+		Path:     "/test/*",
+		Category: opts.Category,
+		Index:    opts.Index,
+	}
+	_, err = rules.Update(client, pID, r.Id, uOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	r, err = rules.Get(client, pID, r.Id).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, pID, r.PolicyID)
+	th.AssertEquals(t, uOpts.Path, r.Path)
+}

--- a/acceptance/openstack/waf/v1/webtamper_rules_test.go
+++ b/acceptance/openstack/waf/v1/webtamper_rules_test.go
@@ -1,0 +1,28 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	rules "github.com/opentelekomcloud/gophertelekomcloud/openstack/waf/v1/webtamperprotection_rules"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestWebTamperRuleWorkflow(t *testing.T) {
+	client, err := clients.NewWafV1Client()
+	th.AssertNoErr(t, err)
+
+	pID := prepareAndRemovePolicy(t, client)
+	opts := rules.CreateOpts{
+		Hostname: "example.com",
+		Path:     "/*",
+	}
+	r, err := rules.Create(client, pID, opts).Extract()
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		th.AssertNoErr(t, rules.Delete(client, pID, r.Id).ExtractErr())
+	})
+
+	th.AssertEquals(t, r.Path, opts.Path)
+	th.AssertEquals(t, r.PolicyID, pID)
+}

--- a/openstack/waf/v1/datamasking_rules/requests.go
+++ b/openstack/waf/v1/datamasking_rules/requests.go
@@ -13,7 +13,7 @@ type CreateOptsBuilder interface {
 
 // CreateOpts contains all the values needed to create a new datamasking rule.
 type CreateOpts struct {
-	Url      string `json:"url" required:"true"`
+	Path     string `json:"path" required:"true"`
 	Category string `json:"category" required:"true"`
 	Index    string `json:"index" required:"true"`
 }
@@ -43,7 +43,7 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts contains all the values needed to update a datamasking rule.
 type UpdateOpts struct {
-	Url      string `json:"url" required:"true"`
+	Path     string `json:"path" required:"true"`
 	Category string `json:"category" required:"true"`
 	Index    string `json:"index" required:"true"`
 }

--- a/openstack/waf/v1/datamasking_rules/results.go
+++ b/openstack/waf/v1/datamasking_rules/results.go
@@ -8,13 +8,13 @@ type DataMasking struct {
 	// DataMasking Rule ID
 	Id string `json:"id"`
 	// DataMaksing Rule URL
-	Url string `json:"url"`
+	Path string `json:"path"`
 	// Masked Field
 	Category string `json:"category"`
 	// Masked Subfield
 	Index string `json:"index"`
 	// Policy ID
-	PolicyID string `json:"policyid"`
+	PolicyID string `json:"policy_id"`
 }
 
 type commonResult struct {

--- a/openstack/waf/v1/falsealarmmasking_rules/requests.go
+++ b/openstack/waf/v1/falsealarmmasking_rules/requests.go
@@ -13,8 +13,8 @@ type CreateOptsBuilder interface {
 
 // CreateOpts contains all the values needed to create a new falsealarmmasking rule.
 type CreateOpts struct {
-	Url  string `json:"url" required:"true"`
-	Rule string `json:"rule" required:"true"`
+	Path    string `json:"path" required:"true"`
+	EventID string `json:"rule" required:"true"`
 }
 
 // ToAlarmMaskingCreateMap builds a create request body from CreateOpts.

--- a/openstack/waf/v1/falsealarmmasking_rules/results.go
+++ b/openstack/waf/v1/falsealarmmasking_rules/results.go
@@ -16,11 +16,13 @@ type AlarmMasking struct {
 	// False Alarm Masking Rule ID
 	Id string `json:"id"`
 	// False Alarm Maksing Rule URL
-	Url string `json:"url"`
+	Path string `json:"path"`
 	// Rule ID
-	Rule string `json:"rule"`
+	Rule      string `json:"rule"`
+	EventID   string `json:"event_id"`
+	EventType string `json:"event_type"`
 	// Policy ID
-	PolicyID string `json:"policyid"`
+	PolicyID string `json:"policy_id"`
 }
 
 type commonResult struct {

--- a/openstack/waf/v1/webtamperprotection_rules/requests.go
+++ b/openstack/waf/v1/webtamperprotection_rules/requests.go
@@ -14,7 +14,7 @@ type CreateOptsBuilder interface {
 // CreateOpts contains all the values needed to create a new web tamper protection rule.
 type CreateOpts struct {
 	Hostname string `json:"hostname" required:"true"`
-	Url      string `json:"url" required:"true"`
+	Path     string `json:"path" required:"true"`
 }
 
 // ToWebTamperCreateMap builds a create request body from CreateOpts.

--- a/openstack/waf/v1/webtamperprotection_rules/results.go
+++ b/openstack/waf/v1/webtamperprotection_rules/results.go
@@ -6,9 +6,9 @@ import (
 
 type WebTamper struct {
 	Id       string `json:"id"`
-	PolicyID string `json:"policyid"`
+	PolicyID string `json:"policy_id"`
 	Hostname string `json:"hostname"`
-	Url      string `json:"url"`
+	Path     string `json:"path"`
 }
 
 type commonResult struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Fix structure of DataMasking, FalseAlarmMasking, WebTamperProtection rules

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->
Required for https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/1662

### Special notes for your reviewer
This breaks backward compatibility of rules, as structure fields names are changed too