### PR TITLE
[RDS] return SlowLogPage for slowlog

### DIFF
--- a/openstack/rds/v3/instances/requests.go
+++ b/openstack/rds/v3/instances/requests.go
@@ -384,7 +384,7 @@ func ListSlowLog(client *golangsdk.ServiceClient, opts DbSlowLogBuilder, instanc
 	}
 
 	pageRdsList := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return ErrorLogPage{pagination.SinglePageBase(r)}
+		return SlowLogPage{pagination.SinglePageBase(r)}
 	})
 
 	rdsheader := map[string]string{"Content-Type": "application/json"}


### PR DESCRIPTION
Signed-off-by: Frank Kloeker <f.kloeker@telekom.de>

<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it

fix

```
panic: interface conversion: pagination.Page is instances.ErrorLogPage, not instances.SlowLogPage
```

### Which issue this PR fixes

I don't have an issue for that

### Special notes for your reviewer

thanks!