### PR TITLE
[ELB] Enable ELBv3 acceptance tests in `eu-de` region

### DIFF
--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -6,7 +6,6 @@ package clients
 import (
 	"encoding/json"
 	"fmt"
-	"testing"
 
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack"
@@ -253,14 +252,10 @@ func NewElbV2Client() (*golangsdk.ServiceClient, error) {
 }
 
 // NewElbV3Client returns authenticated ELB v3 client
-func NewElbV3Client(t *testing.T) (*golangsdk.ServiceClient, error) {
+func NewElbV3Client() (*golangsdk.ServiceClient, error) {
 	cc, err := CloudAndClient()
 	if err != nil {
 		return nil, err
-	}
-
-	if cc.RegionName == "eu-de" {
-		t.Skip("ELBv3 is not working on `eu-de` yet")
 	}
 
 	return openstack.NewELBV3(cc.ProviderClient, golangsdk.EndpointOpts{

--- a/acceptance/openstack/elb/v3/certificates_test.go
+++ b/acceptance/openstack/elb/v3/certificates_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCertificateList(t *testing.T) {
-	client, err := clients.NewElbV3Client(t)
+	client, err := clients.NewElbV3Client()
 	th.AssertNoErr(t, err)
 
 	listOpts := certificates.ListOpts{}
@@ -26,7 +26,7 @@ func TestCertificateList(t *testing.T) {
 }
 
 func TestCertificateLifecycle(t *testing.T) {
-	client, err := clients.NewElbV3Client(t)
+	client, err := clients.NewElbV3Client()
 	th.AssertNoErr(t, err)
 
 	certificateID := createCertificate(t, client)

--- a/acceptance/openstack/elb/v3/flavors_test.go
+++ b/acceptance/openstack/elb/v3/flavors_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestFlavorsList(t *testing.T) {
-	client, err := clients.NewElbV3Client(t)
+	client, err := clients.NewElbV3Client()
 	th.AssertNoErr(t, err)
 
 	listOpts := flavors.ListOpts{}

--- a/acceptance/openstack/elb/v3/listeners_test.go
+++ b/acceptance/openstack/elb/v3/listeners_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestListenerLifecycle(t *testing.T) {
-	client, err := clients.NewElbV3Client(t)
+	client, err := clients.NewElbV3Client()
 	th.AssertNoErr(t, err)
 
 	loadbalancerID := createLoadBalancer(t, client)

--- a/acceptance/openstack/elb/v3/loadbalancers_test.go
+++ b/acceptance/openstack/elb/v3/loadbalancers_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestLoadBalancerList(t *testing.T) {
-	client, err := clients.NewElbV3Client(t)
+	client, err := clients.NewElbV3Client()
 	th.AssertNoErr(t, err)
 
 	listOpts := loadbalancers.ListOpts{}
@@ -26,7 +26,7 @@ func TestLoadBalancerList(t *testing.T) {
 }
 
 func TestLoadBalancerLifecycle(t *testing.T) {
-	client, err := clients.NewElbV3Client(t)
+	client, err := clients.NewElbV3Client()
 	th.AssertNoErr(t, err)
 
 	loadbalancerID := createLoadBalancer(t, client)

--- a/acceptance/openstack/elb/v3/members_test.go
+++ b/acceptance/openstack/elb/v3/members_test.go
@@ -15,7 +15,7 @@ func iInt(v int) *int {
 }
 
 func TestMemberLifecycle(t *testing.T) {
-	client, err := clients.NewElbV3Client(t)
+	client, err := clients.NewElbV3Client()
 	th.AssertNoErr(t, err)
 
 	loadbalancerID := createLoadBalancer(t, client)

--- a/acceptance/openstack/elb/v3/monitors_test.go
+++ b/acceptance/openstack/elb/v3/monitors_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMonitorList(t *testing.T) {
-	client, err := clients.NewElbV3Client(t)
+	client, err := clients.NewElbV3Client()
 	th.AssertNoErr(t, err)
 
 	listOpts := monitors.ListOpts{}
@@ -26,7 +26,7 @@ func TestMonitorList(t *testing.T) {
 }
 
 func TestMonitorLifecycle(t *testing.T) {
-	client, err := clients.NewElbV3Client(t)
+	client, err := clients.NewElbV3Client()
 	th.AssertNoErr(t, err)
 
 	loadbalancerID := createLoadBalancer(t, client)

--- a/acceptance/openstack/elb/v3/policies_test.go
+++ b/acceptance/openstack/elb/v3/policies_test.go
@@ -12,7 +12,7 @@ import (
 func TestPolicyWorkflow(t *testing.T) {
 	t.Parallel()
 
-	client, err := clients.NewElbV3Client(t)
+	client, err := clients.NewElbV3Client()
 	th.AssertNoErr(t, err)
 
 	lbID := createLoadBalancer(t, client)

--- a/acceptance/openstack/elb/v3/pools_test.go
+++ b/acceptance/openstack/elb/v3/pools_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestPoolList(t *testing.T) {
-	client, err := clients.NewElbV3Client(t)
+	client, err := clients.NewElbV3Client()
 	th.AssertNoErr(t, err)
 
 	listOpts := pools.ListOpts{}
@@ -26,7 +26,7 @@ func TestPoolList(t *testing.T) {
 }
 
 func TestPoolLifecycle(t *testing.T) {
-	client, err := clients.NewElbV3Client(t)
+	client, err := clients.NewElbV3Client()
 	th.AssertNoErr(t, err)
 
 	loadbalancerID := createLoadBalancer(t, client)

--- a/acceptance/openstack/elb/v3/rules_test.go
+++ b/acceptance/openstack/elb/v3/rules_test.go
@@ -14,7 +14,7 @@ import (
 func TestRuleWorkflow(t *testing.T) {
 	t.Parallel()
 
-	client, err := clients.NewElbV3Client(t)
+	client, err := clients.NewElbV3Client()
 	th.AssertNoErr(t, err)
 
 	lbID := createLoadBalancer(t, client)


### PR DESCRIPTION
### What this PR does / why we need it
Now we can enable acceptance tests in `eu-de` region since it's available.

### Which issue this PR fixes
Resolves: #336

### Special notes for your reviewer

```
=== RUN   TestCertificateList
--- PASS: TestCertificateList (0.94s)
=== RUN   TestCertificateLifecycle
--- PASS: TestCertificateLifecycle (2.65s)
=== RUN   TestFlavorsList
--- PASS: TestFlavorsList (1.56s)
=== RUN   TestListenerLifecycle
--- PASS: TestListenerLifecycle (6.92s)
=== RUN   TestLoadBalancerList
--- PASS: TestLoadBalancerList (1.25s)
=== RUN   TestLoadBalancerLifecycle
--- PASS: TestLoadBalancerLifecycle (3.94s)
=== RUN   TestMemberLifecycle
--- PASS: TestMemberLifecycle (6.61s)
=== RUN   TestMonitorList
--- PASS: TestMonitorList (1.24s)
=== RUN   TestMonitorLifecycle
--- PASS: TestMonitorLifecycle (5.48s)
=== RUN   TestPolicyWorkflow
=== PAUSE TestPolicyWorkflow
=== CONT  TestPolicyWorkflow
=== CONT  TestPolicyWorkflow
--- PASS: TestPolicyWorkflow (8.40s)
=== RUN   TestPoolList
--- PASS: TestPoolList (1.14s)
=== RUN   TestPoolLifecycle
--- PASS: TestPoolLifecycle (4.78s)
=== RUN   TestRuleWorkflow
=== PAUSE TestRuleWorkflow
=== CONT  TestRuleWorkflow
--- PASS: TestRuleWorkflow (8.66s)
PASS
ok  	github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack/elb/v3	45.382s

Process finished with the exit code 0
```