### PR TITLE
[CES] add missing SuppressDuration for alarm rule conditions

### DIFF
--- a/openstack/cloudeyeservice/alarmrule/requests.go
+++ b/openstack/cloudeyeservice/alarmrule/requests.go
@@ -23,6 +23,7 @@ type MetricOpts struct {
 
 type ConditionOpts struct {
 	Period             int    `json:"period" required:"true"`
+	SuppressDuration   int    `json:"suppress_duration"`
 	Filter             string `json:"filter" required:"true"`
 	ComparisonOperator string `json:"comparison_operator" required:"true"`
 	// The Value ranges from 0 to MAX_VALUE

--- a/openstack/cloudeyeservice/alarmrule/requests.go
+++ b/openstack/cloudeyeservice/alarmrule/requests.go
@@ -23,7 +23,7 @@ type MetricOpts struct {
 
 type ConditionOpts struct {
 	Period             int    `json:"period" required:"true"`
-	SuppressDuration   int    `json:"suppress_duration"`
+	SuppressDuration   int    `json:"suppress_duration,omitempty"`
 	Filter             string `json:"filter" required:"true"`
 	ComparisonOperator string `json:"comparison_operator" required:"true"`
 	// The Value ranges from 0 to MAX_VALUE

--- a/openstack/cloudeyeservice/alarmrule/results.go
+++ b/openstack/cloudeyeservice/alarmrule/results.go
@@ -32,6 +32,7 @@ type MetricInfo struct {
 
 type ConditionInfo struct {
 	Period             int    `json:"period"`
+	SuppressDuration   int    `json:"suppress_duration,omitempty"`
 	Filter             string `json:"filter"`
 	ComparisonOperator string `json:"comparison_operator"`
 	Value              int    `json:"value"`


### PR DESCRIPTION
Signed-off-by: Frank Kloeker <f.kloeker@telekom.de>

<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it

Alarm Rule condition in CES allows SuppressDuration for repeating the alarm after specific timespan.
Default is once, no repeat of the alarm.

### Which issue this PR fixes
Resolves: #349 

### Special notes for your reviewer
Depends-On: https://github.com/opentelekomcloud/gophertelekomcloud/pull/351