### PR TITLE
DMS/Topics: add topics functionality for DMS

### DIFF
--- a/openstack/dms/v1/topics/requests.go
+++ b/openstack/dms/v1/topics/requests.go
@@ -1,0 +1,63 @@
+package topics
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+type CreateOptsBuilder interface {
+	ToTopicCreateMap() (map[string]interface{}, error)
+}
+
+type DeleteOptsBuilder interface {
+	ToTopicDeleteMap() (map[string]interface{}, error)
+}
+
+type CreateOpts struct {
+	Name             string `json:"id" required:"true"`
+	Partition        int    `json:"partition,omitempty"`
+	Replication      int    `json:"replication,omitempty"`
+	SyncReplication  bool   `json:"sync_replication,omitempty"`
+	RetentionTime    int    `json:"retention_time,omitempty"`
+	SyncMessageFlush bool   `json:"sync_message_flush,omitempty"`
+}
+
+func (opts CreateOpts) ToTopicCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder, instanceId string) (r CreateResult) {
+	b, err := opts.ToTopicCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+func Get(client *golangsdk.ServiceClient, instanceId string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, instanceId), &r.Body, nil)
+	return
+}
+
+type DeleteOpts struct {
+	Topics []string `json:"topics" required:"true"`
+}
+
+func (opts DeleteOpts) ToTopicDeleteMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+func Delete(client *golangsdk.ServiceClient, opts DeleteOptsBuilder, instanceId string) (r DeleteResult) {
+	b, err := opts.ToTopicDeleteMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(deleteURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/dms/v1/topics/results.go
+++ b/openstack/dms/v1/topics/results.go
@@ -36,7 +36,7 @@ type Parameters struct {
 
 func (r CreateResult) Extract() (*TopicName, error) {
 	s := new(TopicName)
-	err := r.ExtractInto(s)
+	err := r.ExtractIntoStructPtr(s, "")
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (r CreateResult) Extract() (*TopicName, error) {
 
 func (r GetResult) Extract() (*Topic, error) {
 	s := new(Topic)
-	err := r.ExtractInto(s)
+	err := r.ExtractIntoStructPtr(s, "")
 	if err != nil {
 		return nil, err
 	}

--- a/openstack/dms/v1/topics/results.go
+++ b/openstack/dms/v1/topics/results.go
@@ -1,0 +1,67 @@
+package topics
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+type CreateResult struct {
+	golangsdk.Result
+}
+
+type GetResult struct {
+	golangsdk.Result
+}
+
+type DeleteResult struct {
+	golangsdk.Result
+}
+
+type TopicName struct {
+	Name string `json:"id"`
+}
+
+type Topic struct {
+	Size             int          `json:"size"`
+	RemainPartitions int          `json:"remain_partitions"`
+	MaxPartitions    int          `json:"max_partitions"`
+	Topics           []Parameters `json:"topics"`
+}
+
+type Parameters struct {
+	Name             string `json:"id"`
+	Partition        int    `json:"partition"`
+	Replication      int    `json:"replication"`
+	SyncReplication  string `json:"sync_replication"`
+	RetentionTime    int    `json:"retention_time"`
+	SyncMessageFlush string `json:"sync_message_flush"`
+}
+
+func (r CreateResult) Extract() (*TopicName, error) {
+	s := new(TopicName)
+	err := r.ExtractInto(s)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (r GetResult) Extract() (*Topic, error) {
+	s := new(Topic)
+	err := r.ExtractInto(s)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+type TopicDelete struct {
+	Name    string `json:"id"`
+	Success bool   `json:"success"`
+}
+
+func (r DeleteResult) Extract() ([]TopicDelete, error) {
+	var s []TopicDelete
+	err := r.ExtractIntoSlicePtr(&s, "topics")
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}

--- a/openstack/dms/v1/topics/urls.go
+++ b/openstack/dms/v1/topics/urls.go
@@ -1,0 +1,17 @@
+package topics
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+const resourcePath = "instances"
+
+func createURL(client *golangsdk.ServiceClient, instanceId string) string {
+	return client.ServiceURL(resourcePath, instanceId, "topics")
+}
+
+func getURL(client *golangsdk.ServiceClient, instanceId string) string {
+	return client.ServiceURL(resourcePath, instanceId, "topics")
+}
+
+func deleteURL(client *golangsdk.ServiceClient, instanceId string) string {
+	return client.ServiceURL(resourcePath, instanceId, "topics", "delete")
+}


### PR DESCRIPTION
### What this PR does / why we need it
This PR adds topics functionality for Kafka premium
### Which issue this PR fixes
Resolves: #366 

### Tests:
=== RUN   TestDmsList
--- PASS: TestDmsList (0.89s)
=== RUN   TestDmsLifeCycle
    instances_test.go:59: Attempting to create DMSv1 instance
    instances_test.go:96: DMSv1 instance successfully created: 90e5a591-aafb-4f59-a729-38919615028c
    instances_test.go:182: Attempting to create DMSv1 Topic
    instances_test.go:195: DMSv1 Topic successfully created: dms-topic-lqrx3lCT
    instances_test.go:201: Attempting to delete DMSv1 Topic
    instances_test.go:216: DMSv1 Topic successfully deleted
    instances_test.go:113: Attempting to update DMSv1 instance: 90e5a591-aafb-4f59-a729-38919615028c
    instances_test.go:123: DMSv1 instance updated successfully: 90e5a591-aafb-4f59-a729-38919615028c
    instances_test.go:102: Attempting to delete DMSv1 instance: 90e5a591-aafb-4f59-a729-38919615028c
    instances_test.go:109: DMSv1 instance deleted successfully: 90e5a591-aafb-4f59-a729-38919615028c
--- PASS: TestDmsLifeCycle (359.95s)
PASS

