### PR TITLE
[DCS]: Float value fix

### DIFF
--- a/openstack/csbs/v1/backup/results.go
+++ b/openstack/csbs/v1/backup/results.go
@@ -54,7 +54,7 @@ type Backup struct {
 
 type ExtendInfo struct {
 	AutoTrigger          bool           `json:"auto_trigger"`
-	AverageSpeed         float64        `json:"average_speed"`
+	AverageSpeed         float32        `json:"average_speed"`
 	CopyFrom             string         `json:"copy_from"`
 	CopyStatus           string         `json:"copy_status"`
 	FailCode             FailCode       `json:"fail_code"`
@@ -67,7 +67,7 @@ type ExtendInfo struct {
 	ResourceName         string         `json:"resource_name"`
 	ResourceType         string         `json:"resource_type"`
 	Size                 int            `json:"size"`
-	SpaceSavingRatio     float64        `json:"space_saving_ratio"`
+	SpaceSavingRatio     float32        `json:"space_saving_ratio"`
 	VolumeBackups        []VolumeBackup `json:"volume_backups"`
 	FinishedAt           string         `json:"finished_at"`
 	TaskId               string         `json:"taskid"`
@@ -93,19 +93,19 @@ type FailCode struct {
 }
 
 type VolumeBackup struct {
-	AverageSpeed     int     `json:"average_speed"`
-	Bootable         bool    `json:"bootable"`
-	Id               string  `json:"id"`
-	ImageType        string  `json:"image_type"`
-	Incremental      bool    `json:"incremental"`
-	SnapshotID       string  `json:"snapshot_id"`
-	Name             string  `json:"name"`
-	Size             int     `json:"size"`
-	SourceVolumeId   string  `json:"source_volume_id"`
-	SourceVolumeSize int     `json:"source_volume_size"`
-	SpaceSavingRatio float64 `json:"space_saving_ratio"`
-	Status           string  `json:"status"`
-	SourceVolumeName string  `json:"source_volume_name"`
+	AverageSpeed     int    `json:"average_speed"`
+	Bootable         bool   `json:"bootable"`
+	Id               string `json:"id"`
+	ImageType        string `json:"image_type"`
+	Incremental      bool   `json:"incremental"`
+	SnapshotID       string `json:"snapshot_id"`
+	Name             string `json:"name"`
+	Size             int    `json:"size"`
+	SourceVolumeId   string `json:"source_volume_id"`
+	SourceVolumeSize int    `json:"source_volume_size"`
+	SpaceSavingRatio int    `json:"space_saving_ratio"`
+	Status           string `json:"status"`
+	SourceVolumeName string `json:"source_volume_name"`
 }
 
 func (r QueryResult) ExtractQueryResponse() ([]ResourceCapability, error) {

--- a/openstack/csbs/v1/backup/results.go
+++ b/openstack/csbs/v1/backup/results.go
@@ -54,7 +54,7 @@ type Backup struct {
 
 type ExtendInfo struct {
 	AutoTrigger          bool           `json:"auto_trigger"`
-	AverageSpeed         float32        `json:"average_speed"`
+	AverageSpeed         float64        `json:"average_speed"`
 	CopyFrom             string         `json:"copy_from"`
 	CopyStatus           string         `json:"copy_status"`
 	FailCode             FailCode       `json:"fail_code"`
@@ -67,7 +67,7 @@ type ExtendInfo struct {
 	ResourceName         string         `json:"resource_name"`
 	ResourceType         string         `json:"resource_type"`
 	Size                 int            `json:"size"`
-	SpaceSavingRatio     float32        `json:"space_saving_ratio"`
+	SpaceSavingRatio     float64        `json:"space_saving_ratio"`
 	VolumeBackups        []VolumeBackup `json:"volume_backups"`
 	FinishedAt           string         `json:"finished_at"`
 	TaskId               string         `json:"taskid"`
@@ -93,19 +93,19 @@ type FailCode struct {
 }
 
 type VolumeBackup struct {
-	AverageSpeed     int    `json:"average_speed"`
-	Bootable         bool   `json:"bootable"`
-	Id               string `json:"id"`
-	ImageType        string `json:"image_type"`
-	Incremental      bool   `json:"incremental"`
-	SnapshotID       string `json:"snapshot_id"`
-	Name             string `json:"name"`
-	Size             int    `json:"size"`
-	SourceVolumeId   string `json:"source_volume_id"`
-	SourceVolumeSize int    `json:"source_volume_size"`
-	SpaceSavingRatio int    `json:"space_saving_ratio"`
-	Status           string `json:"status"`
-	SourceVolumeName string `json:"source_volume_name"`
+	AverageSpeed     int     `json:"average_speed"`
+	Bootable         bool    `json:"bootable"`
+	Id               string  `json:"id"`
+	ImageType        string  `json:"image_type"`
+	Incremental      bool    `json:"incremental"`
+	SnapshotID       string  `json:"snapshot_id"`
+	Name             string  `json:"name"`
+	Size             int     `json:"size"`
+	SourceVolumeId   string  `json:"source_volume_id"`
+	SourceVolumeSize int     `json:"source_volume_size"`
+	SpaceSavingRatio float64 `json:"space_saving_ratio"`
+	Status           string  `json:"status"`
+	SourceVolumeName string  `json:"source_volume_name"`
 }
 
 func (r QueryResult) ExtractQueryResponse() ([]ResourceCapability, error) {

--- a/openstack/dcs/v1/instances/requests.go
+++ b/openstack/dcs/v1/instances/requests.go
@@ -40,7 +40,7 @@ type CreateOps struct {
 	// the value can be 0.125, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 24, 48, or 64.
 	// For a Redis Cluster DCS Redis 4.0 or 5.0 instance,
 	// the value can be 4, 8, 16, 24, 32, 48, 64, 96, 128, 192, 256, 384, 512, 768, or 1024.
-	Capacity float32 `json:"capacity" required:"true"`
+	Capacity float64 `json:"capacity" required:"true"`
 
 	// Indicate if no password visit cache instance is allowed.
 	NoPasswordAccess string `json:"no_password_access,omitempty"`

--- a/openstack/dcs/v1/instances/results.go
+++ b/openstack/dcs/v1/instances/results.go
@@ -36,7 +36,7 @@ type ListDcsResponse struct {
 type Instance struct {
 	Name                 string               `json:"name"`
 	Engine               string               `json:"engine"`
-	Capacity             float32              `json:"capacity"`
+	Capacity             float64              `json:"capacity"`
 	IP                   string               `json:"ip"`
 	Port                 int                  `json:"port"`
 	Status               string               `json:"status"`


### PR DESCRIPTION
### What this PR does / why we need it
This PR fixes float type (float64 is used in terraform).

### Acceptance tests
=== RUN   TestDcsConfigLifeCycle
    helpers.go:17: Attempting to create DCSv1 instance
    helpers.go:72: DCSv1 instance successfully created: 24298cd7-e6db-4a2a-94cf-b7afd4a5e3dd
    configs_test.go:27: Attempting to update DCSv1 configuration
    configs_test.go:30: Updated DCSv1 configuration
    helpers.go:81: Attempting to delete DCSv1 instance: 24298cd7-e6db-4a2a-94cf-b7afd4a5e3dd
    helpers.go:90: Deleted DCSv1 instance: 24298cd7-e6db-4a2a-94cf-b7afd4a5e3dd
--- PASS: TestDcsConfigLifeCycle (43.44s)
PASS

Process finished with the exit code 0
