### PR TITLE
[Refactor] Introduce extract functions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,7 @@
-issues:
-  exclude-rules:
-    # Exclude some staticcheck messages
-    - linters:
-        - staticcheck
-      text: "SA1008:"
+linters-settings:
+  staticcheck:
+    checks:
+      - all
+      # Exclude some staticcheck messages
+      - '-SA1008' # "content-length" is not canonical, avoid OBS headers warnings
+      - '-SA1019' # deprecations, used to avoid Extract... deprecation warnings

--- a/internal/extract/doc.go
+++ b/internal/extract/doc.go
@@ -1,0 +1,3 @@
+// Package extract contains functions for extracting JSON results into given structure or slice pointers.
+// Those are wrappers over `json.Marshall` and `json.Unmarshall` functions with additional validation built it
+package extract

--- a/internal/extract/json.go
+++ b/internal/extract/json.go
@@ -1,0 +1,153 @@
+package extract
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+)
+
+func intoPtr(body, to interface{}, label string) error {
+	if label == "" {
+		return Into(body, &to)
+	}
+
+	var m map[string]interface{}
+	err := Into(body, &m)
+	if err != nil {
+		return err
+	}
+
+	b, err := JsonMarshal(m[label])
+	if err != nil {
+		return err
+	}
+
+	toValue := reflect.ValueOf(to)
+	if toValue.Kind() == reflect.Ptr {
+		toValue = toValue.Elem()
+	}
+
+	switch toValue.Kind() {
+	case reflect.Slice:
+		typeOfV := toValue.Type().Elem()
+		if typeOfV.Kind() == reflect.Struct {
+			if typeOfV.NumField() > 0 && typeOfV.Field(0).Anonymous {
+				newSlice := reflect.MakeSlice(reflect.SliceOf(typeOfV), 0, 0)
+
+				for _, v := range m[label].([]interface{}) {
+					// For each iteration of the slice, we create a new struct.
+					// This is to work around a bug where elements of a slice
+					// are reused and not overwritten when the same copy of the
+					// struct is used:
+					//
+					// https://github.com/golang/go/issues/21092
+					// https://github.com/golang/go/issues/24155
+					// https://play.golang.org/p/NHo3ywlPZli
+					newType := reflect.New(typeOfV).Elem()
+
+					b, err := JsonMarshal(v)
+					if err != nil {
+						return err
+					}
+
+					// This is needed for structs with an UnmarshalJSON method.
+					// Technically this is just unmarshalling the response into
+					// a struct that is never used, but it's good enough to
+					// trigger the UnmarshalJSON method.
+					for i := 0; i < newType.NumField(); i++ {
+						s := newType.Field(i).Addr().Interface()
+
+						// Unmarshal is used rather than NewDecoder to also work
+						// around the above-mentioned bug.
+						err = json.Unmarshal(b, s)
+						if err != nil {
+							continue
+						}
+					}
+
+					newSlice = reflect.Append(newSlice, newType)
+				}
+
+				// "to" should now be properly modeled to receive the
+				// JSON response body and unmarshal into all the correct
+				// fields of the struct or composed extension struct
+				// at the end of this method.
+				toValue.Set(newSlice)
+			}
+		}
+	case reflect.Struct:
+		typeOfV := toValue.Type()
+		if typeOfV.NumField() > 0 && typeOfV.Field(0).Anonymous {
+			for i := 0; i < toValue.NumField(); i++ {
+				toField := toValue.Field(i)
+				if toField.Kind() == reflect.Struct {
+					s := toField.Addr().Interface()
+					err = json.NewDecoder(bytes.NewReader(b)).Decode(s)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	err = json.Unmarshal(b, &to)
+	return err
+}
+
+func JsonMarshal(t interface{}) ([]byte, error) {
+	buffer := &bytes.Buffer{}
+	enc := json.NewEncoder(buffer)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(t)
+	return buffer.Bytes(), err
+}
+
+func Into(body interface{}, to interface{}) error {
+	if reader, ok := body.(io.Reader); ok {
+		if readCloser, ok := reader.(io.Closer); ok {
+			defer readCloser.Close()
+		}
+		return json.NewDecoder(reader).Decode(to)
+	}
+
+	b, err := JsonMarshal(body)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(b, to)
+
+	return err
+}
+
+// IntoStructPtr will unmarshal the given body into the provided
+// interface{} (to).
+func IntoStructPtr(body, to interface{}, label string) error {
+	t := reflect.TypeOf(to)
+	if k := t.Kind(); k != reflect.Ptr {
+		return fmt.Errorf("expected pointer, got %v", k)
+	}
+	switch t.Elem().Kind() {
+	case reflect.Struct:
+		return intoPtr(body, to, label)
+	default:
+		return fmt.Errorf("expected pointer to struct, got: %v", t)
+	}
+}
+
+// IntoSlicePtr will unmarshal the provided body into the provided
+// interface{} (to).
+func IntoSlicePtr(body, to interface{}, label string) error {
+	t := reflect.TypeOf(to)
+	if k := t.Kind(); k != reflect.Ptr {
+		return fmt.Errorf("expected pointer, got %v", k)
+	}
+	switch t.Elem().Kind() {
+	case reflect.Slice:
+		return intoPtr(body, to, label)
+	default:
+		return fmt.Errorf("expected pointer to slice, got: %v", t)
+	}
+}

--- a/internal/extract/json_test.go
+++ b/internal/extract/json_test.go
@@ -1,0 +1,274 @@
+package extract
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// randomString duplicates here to avoid cyclic imports
+// TODO: this function should be moved to some other package later
+func randomString(prefix string, n int) string {
+	const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	var bytes = make([]byte, n)
+	_, _ = rand.Read(bytes)
+	for i, b := range bytes {
+		bytes[i] = alphanum[b%byte(len(alphanum))]
+	}
+	return prefix + string(bytes)
+}
+
+func TestInto(t *testing.T) {
+	key := "data_key"
+	value := randomString("v-", 20)
+
+	expected := map[string]string{key: value}
+
+	cases := map[string]interface{}{
+		"map": map[string]string{key: value},
+		"struct": struct {
+			DataKey string `json:"data_key"`
+		}{value},
+		"struct with other fields": struct {
+			DataKey  string `json:"data_key"`
+			DataKey2 string `json:"-"`
+		}{value, "difgljdfgn"},
+		"io.Reader": bytes.NewReader([]byte(fmt.Sprintf(`{ "data_key":  "%s"}`, value))),
+	}
+
+	for name, source := range cases {
+		source := source // avoid issues with parallel tests
+		expectedValue := expected[key]
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := make(map[string]string)
+			err := Into(source, &actual)
+
+			assert.NoError(t, err) // not exiting after one fail
+			assert.EqualValues(t, expectedValue, actual[key])
+		})
+	}
+}
+
+type TestDataType struct {
+	DataKey string `json:"data_key"`
+}
+
+type TestDataType2 struct {
+	TestDataType
+
+	SecondDataField string `json:"second_data_field"`
+}
+
+func readerFromString(src string) io.Reader {
+	return bytes.NewReader([]byte(src))
+}
+
+func TestIntoStructPtr(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+
+		actual := new(TestDataType)
+		value := randomString("v-", 20)
+
+		data := fmt.Sprintf(`
+		{
+			"data_key": "%s"
+		}
+		`, value)
+
+		err := IntoStructPtr(readerFromString(data), actual, "")
+		require.NoError(t, err)
+		require.Equal(t, value, actual.DataKey)
+	})
+
+	t.Run("with label", func(t *testing.T) {
+		t.Parallel()
+
+		actual := new(TestDataType)
+		value := randomString("v-", 20)
+
+		data := fmt.Sprintf(`
+		{
+			"internal": {
+				"data_key": "%s"
+			}
+		}
+		`, value)
+
+		err := IntoStructPtr(readerFromString(data), actual, "internal")
+		require.NoError(t, err)
+		require.Equal(t, value, actual.DataKey)
+	})
+
+	t.Run("with label and embed", func(t *testing.T) {
+		t.Parallel()
+
+		actual := new(TestDataType2)
+		value := randomString("v-", 20)
+
+		data := fmt.Sprintf(`
+		{
+			"internal": {
+				"data_key": "%s",
+				"second_data_field": "%[1]s-2"
+			}
+		}
+		`, value)
+
+		err := IntoStructPtr(readerFromString(data), actual, "internal")
+		require.NoError(t, err)
+		require.Equal(t, value, actual.DataKey)
+		require.Equal(t, value+"-2", actual.SecondDataField)
+	})
+
+	t.Run("with label (err)", func(t *testing.T) {
+		t.Parallel()
+
+		actual := new(TestDataType)
+		value := randomString("v-", 20)
+
+		data := fmt.Sprintf(`
+		{
+			"internal": {
+				"data_key": "%s"
+			}
+		}
+		`, value)
+
+		err := IntoStructPtr(readerFromString(data), actual, "")
+		require.NoError(t, err)
+		require.Equal(t, "", actual.DataKey)
+	})
+
+	t.Run("non pointer", func(t *testing.T) {
+		t.Parallel()
+
+		actual := TestDataType{}
+		value := randomString("v-", 20)
+
+		data := fmt.Sprintf(`
+		{
+			"data_key": "%s"
+		}
+		`, value)
+
+		err := IntoStructPtr(readerFromString(data), actual, "")
+		require.EqualError(t, err, "expected pointer, got struct")
+	})
+
+	t.Run("non struct", func(t *testing.T) {
+		t.Parallel()
+
+		actual := make(map[string]interface{})
+		value := randomString("v-", 20)
+
+		data := fmt.Sprintf(`
+		{
+			"data_key": "%s"
+		}
+		`, value)
+
+		err := IntoStructPtr(readerFromString(data), &actual, "")
+		require.EqualError(t, err, "expected pointer to struct, got: *map[string]interface {}")
+	})
+}
+
+func TestIntoSlicePtr(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+
+		actual := make([]TestDataType, 0)
+		value := randomString("v-", 20)
+
+		data := fmt.Sprintf(`
+		[{
+			"data_key": "%s"
+		}]
+		`, value)
+
+		err := IntoSlicePtr(readerFromString(data), &actual, "")
+		require.NoError(t, err)
+		require.Len(t, actual, 1)
+		require.Equal(t, value, actual[0].DataKey)
+	})
+
+	t.Run("with label", func(t *testing.T) {
+		t.Parallel()
+
+		actual := make([]TestDataType, 0)
+		value := randomString("v-", 20)
+
+		data := fmt.Sprintf(`
+		{
+			"data": [{ "data_key": "%s" }]
+		}
+		`, value)
+
+		err := IntoSlicePtr(readerFromString(data), &actual, "data")
+		require.NoError(t, err)
+		require.Len(t, actual, 1)
+		require.Equal(t, value, actual[0].DataKey)
+	})
+
+	t.Run("with label and embed", func(t *testing.T) {
+		t.Parallel()
+
+		actual := make([]TestDataType2, 0)
+		value := randomString("v-", 20)
+
+		data := fmt.Sprintf(`
+		{
+			"internal": [{
+				"data_key": "%s",
+				"second_data_field": "%[1]s"
+			}]
+		}
+		`, value)
+
+		err := IntoSlicePtr(readerFromString(data), &actual, "internal")
+		require.NoError(t, err)
+		require.Len(t, actual, 1)
+		require.Equal(t, value, actual[0].DataKey)
+		require.Equal(t, value, actual[0].SecondDataField)
+	})
+
+	t.Run("not pointer", func(t *testing.T) {
+		t.Parallel()
+
+		actual := make([]TestDataType, 0)
+		value := randomString("v-", 20)
+
+		data := fmt.Sprintf(`
+		[{
+			"data_key": "%s"
+		}]
+		`, value)
+
+		err := IntoSlicePtr(readerFromString(data), actual, "")
+		require.EqualError(t, err, "expected pointer, got slice")
+	})
+
+	t.Run("not slice", func(t *testing.T) {
+		t.Parallel()
+
+		actual := new(TestDataType)
+		value := randomString("v-", 20)
+
+		data := fmt.Sprintf(`
+		{
+			"data_key": "%s"
+		}
+		`, value)
+
+		err := IntoSlicePtr(readerFromString(data), actual, "")
+		require.EqualError(t, err, "expected pointer to slice, got: *extract.TestDataType")
+	})
+}

--- a/provider_client.go
+++ b/provider_client.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 )
 
 // DefaultUserAgent is the default User-Agent string set in the request header.
@@ -174,14 +176,6 @@ type RequestOpts struct {
 
 var applicationJSON = "application/json"
 
-func jsonMarshal(t interface{}) ([]byte, error) {
-	buffer := &bytes.Buffer{}
-	enc := json.NewEncoder(buffer)
-	enc.SetEscapeHTML(false)
-	err := enc.Encode(t)
-	return buffer.Bytes(), err
-}
-
 // Request performs an HTTP request using the ProviderClient's current HTTPClient. An authentication
 // header will automatically be provided.
 func (client *ProviderClient) Request(method, url string, options *RequestOpts) (*http.Response, error) {
@@ -195,7 +189,7 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 			panic("Please provide only one of JSONBody or RawBody to golangsdk.Request().")
 		}
 
-		rendered, err := jsonMarshal(options.JSONBody)
+		rendered, err := extract.JsonMarshal(options.JSONBody)
 		if err != nil {
 			return nil, err
 		}

--- a/results.go
+++ b/results.go
@@ -51,7 +51,7 @@ type JsonRDSInstanceField struct {
 	Status string `json:"status"`
 }
 
-func ExtractInto(body any, to any) error {
+func ExtractInto(body interface{}, to interface{}) error {
 	if reader, ok := body.(io.Reader); ok {
 		if readCloser, ok := reader.(io.Closer); ok {
 			defer readCloser.Close()
@@ -81,7 +81,7 @@ func (r Result) ExtractInto(to interface{}) error {
 	return ExtractInto(r.Body, to)
 }
 
-func extractIntoPtr(body, to any, label string) error {
+func extractIntoPtr(body, to interface{}, label string) error {
 	if label == "" {
 		return ExtractInto(body, &to)
 	}
@@ -170,22 +170,18 @@ func extractIntoPtr(body, to any, label string) error {
 	return err
 }
 
-func (r Result) extractIntoPtr(to interface{}, label string) error {
-	return extractIntoPtr(r.Body, to, label)
-}
-
 // ExtractIntoStructPtr will unmarshal the given body into the provided
 // interface{} (to).
-func ExtractIntoStructPtr(body, to any, label string) error {
+func ExtractIntoStructPtr(body, to interface{}, label string) error {
 	t := reflect.TypeOf(to)
 	if k := t.Kind(); k != reflect.Ptr {
-		return fmt.Errorf("Expected pointer, got %v", k)
+		return fmt.Errorf("expected pointer, got %v", k)
 	}
 	switch t.Elem().Kind() {
 	case reflect.Struct:
 		return extractIntoPtr(body, to, label)
 	default:
-		return fmt.Errorf("Expected pointer to struct, got: %v", t)
+		return fmt.Errorf("expected pointer to struct, got: %v", t)
 	}
 }
 
@@ -210,16 +206,16 @@ func (r Result) ExtractIntoStructPtr(to interface{}, label string) error {
 
 // ExtractIntoSlicePtr will unmarshal the provided body into the provided
 // interface{} (to).
-func ExtractIntoSlicePtr(body, to any, label string) error {
+func ExtractIntoSlicePtr(body, to interface{}, label string) error {
 	t := reflect.TypeOf(to)
 	if k := t.Kind(); k != reflect.Ptr {
-		return fmt.Errorf("Expected pointer, got %v", k)
+		return fmt.Errorf("expected pointer, got %v", k)
 	}
 	switch t.Elem().Kind() {
 	case reflect.Slice:
 		return extractIntoPtr(body, to, label)
 	default:
-		return fmt.Errorf("Expected pointer to slice, got: %v", t)
+		return fmt.Errorf("expected pointer to slice, got: %v", t)
 	}
 }
 
@@ -242,7 +238,7 @@ func (r Result) ExtractIntoSlicePtr(to interface{}, label string) error {
 	return ExtractIntoSlicePtr(r.Body, to, label)
 }
 
-func PrettyPrintJSON(body any) string {
+func PrettyPrintJSON(body interface{}) string {
 	pretty, err := json.MarshalIndent(body, "", "  ")
 	if err != nil {
 		panic(err.Error())

--- a/results.go
+++ b/results.go
@@ -25,7 +25,7 @@ further interpret the result's payload in a specific context. Extensions or
 providers can then provide additional extraction functions to pull out
 provider- or extension-specific information as well.
 
-: use plain functions of this package instead
+Deprecated: use plain functions of this package instead
 */
 type Result struct {
 	// Body is the payload of the HTTP response from the server. In most cases,
@@ -72,7 +72,7 @@ func ExtractInto(body interface{}, to interface{}) error {
 // the `Result.Body`. This would be useful for OpenStack providers that have
 // different fields in the response object than OpenStack proper.
 //
-// : use ExtractInto function instead
+// Deprecated: use ExtractInto function instead
 func (r Result) ExtractInto(to interface{}) error {
 	if r.Err != nil {
 		return r.Err
@@ -195,7 +195,7 @@ func ExtractIntoStructPtr(body, to interface{}, label string) error {
 // If provided, `label` will be filtered out of the response
 // body prior to `r` being unmarshalled into `to`.
 //
-// : use ExtractIntoStructPtr function instead
+// Deprecated: use ExtractIntoStructPtr function instead
 func (r Result) ExtractIntoStructPtr(to interface{}, label string) error {
 	if r.Err != nil {
 		return r.Err
@@ -229,7 +229,7 @@ func ExtractIntoSlicePtr(body, to interface{}, label string) error {
 // If provided, `label` will be filtered out of the response
 // body prior to `r` being unmarshalled into `to`.
 //
-// : use ExtractIntoSlicePtr function instead
+// Deprecated: use ExtractIntoSlicePtr function instead
 func (r Result) ExtractIntoSlicePtr(to interface{}, label string) error {
 	if r.Err != nil {
 		return r.Err
@@ -264,7 +264,7 @@ func (r Result) PrettyPrintJSON() string {
 // ExtractErr method
 // to cleanly pull it out.
 //
-// : use plain err return instead
+// Deprecated: use plain err return instead
 type ErrResult struct {
 	Result
 }

--- a/results.go
+++ b/results.go
@@ -25,7 +25,7 @@ further interpret the result's payload in a specific context. Extensions or
 providers can then provide additional extraction functions to pull out
 provider- or extension-specific information as well.
 
-Deprecated: use plain functions of this package instead
+: use plain functions of this package instead
 */
 type Result struct {
 	// Body is the payload of the HTTP response from the server. In most cases,
@@ -72,7 +72,7 @@ func ExtractInto(body interface{}, to interface{}) error {
 // the `Result.Body`. This would be useful for OpenStack providers that have
 // different fields in the response object than OpenStack proper.
 //
-// Deprecated: use ExtractInto function instead
+// : use ExtractInto function instead
 func (r Result) ExtractInto(to interface{}) error {
 	if r.Err != nil {
 		return r.Err
@@ -195,7 +195,7 @@ func ExtractIntoStructPtr(body, to interface{}, label string) error {
 // If provided, `label` will be filtered out of the response
 // body prior to `r` being unmarshalled into `to`.
 //
-// Deprecated: use ExtractIntoStructPtr function instead
+// : use ExtractIntoStructPtr function instead
 func (r Result) ExtractIntoStructPtr(to interface{}, label string) error {
 	if r.Err != nil {
 		return r.Err
@@ -229,7 +229,7 @@ func ExtractIntoSlicePtr(body, to interface{}, label string) error {
 // If provided, `label` will be filtered out of the response
 // body prior to `r` being unmarshalled into `to`.
 //
-// Deprecated: use ExtractIntoSlicePtr function instead
+// : use ExtractIntoSlicePtr function instead
 func (r Result) ExtractIntoSlicePtr(to interface{}, label string) error {
 	if r.Err != nil {
 		return r.Err
@@ -264,7 +264,7 @@ func (r Result) PrettyPrintJSON() string {
 // ExtractErr method
 // to cleanly pull it out.
 //
-// Deprecated: use plain err return instead
+// : use plain err return instead
 type ErrResult struct {
 	Result
 }

--- a/results.go
+++ b/results.go
@@ -25,7 +25,7 @@ further interpret the result's payload in a specific context. Extensions or
 providers can then provide additional extraction functions to pull out
 provider- or extension-specific information as well.
 
-Deprecated: use plain functions of this package instead
+Deprecated: use functions from internal/extract package instead
 */
 type Result struct {
 	// Body is the payload of the HTTP response from the server. In most cases,
@@ -55,7 +55,7 @@ type JsonRDSInstanceField struct {
 // the `Result.Body`. This would be useful for OpenStack providers that have
 // different fields in the response object than OpenStack proper.
 //
-// Deprecated: use ExtractInto function instead
+// Deprecated: use extract.Into function instead
 func (r Result) ExtractInto(to interface{}) error {
 	if r.Err != nil {
 		return r.Err
@@ -74,7 +74,7 @@ func (r Result) ExtractInto(to interface{}) error {
 // If provided, `label` will be filtered out of the response
 // body prior to `r` being unmarshalled into `to`.
 //
-// Deprecated: use ExtractIntoStructPtr function instead
+// Deprecated: use extract.IntoStructPtr function instead
 func (r Result) ExtractIntoStructPtr(to interface{}, label string) error {
 	if r.Err != nil {
 		return r.Err
@@ -93,7 +93,7 @@ func (r Result) ExtractIntoStructPtr(to interface{}, label string) error {
 // If provided, `label` will be filtered out of the response
 // body prior to `r` being unmarshalled into `to`.
 //
-// Deprecated: use ExtractIntoSlicePtr function instead
+// Deprecated: use extract.IntoSlicePtr function instead
 func (r Result) ExtractIntoSlicePtr(to interface{}, label string) error {
 	if r.Err != nil {
 		return r.Err

--- a/results.go
+++ b/results.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"reflect"
 	"strconv"
 	"time"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 )
 
 /*
@@ -51,23 +51,6 @@ type JsonRDSInstanceField struct {
 	Status string `json:"status"`
 }
 
-func ExtractInto(body interface{}, to interface{}) error {
-	if reader, ok := body.(io.Reader); ok {
-		if readCloser, ok := reader.(io.Closer); ok {
-			defer readCloser.Close()
-		}
-		return json.NewDecoder(reader).Decode(to)
-	}
-
-	b, err := jsonMarshal(body)
-	if err != nil {
-		return err
-	}
-	err = json.Unmarshal(b, to)
-
-	return err
-}
-
 // ExtractInto allows users to provide an object into which `Extract` will extract
 // the `Result.Body`. This would be useful for OpenStack providers that have
 // different fields in the response object than OpenStack proper.
@@ -78,111 +61,7 @@ func (r Result) ExtractInto(to interface{}) error {
 		return r.Err
 	}
 
-	return ExtractInto(r.Body, to)
-}
-
-func extractIntoPtr(body, to interface{}, label string) error {
-	if label == "" {
-		return ExtractInto(body, &to)
-	}
-
-	var m map[string]interface{}
-	err := ExtractInto(body, &m)
-	if err != nil {
-		return err
-	}
-
-	b, err := jsonMarshal(m[label])
-	if err != nil {
-		return err
-	}
-
-	toValue := reflect.ValueOf(to)
-	if toValue.Kind() == reflect.Ptr {
-		toValue = toValue.Elem()
-	}
-
-	switch toValue.Kind() {
-	case reflect.Slice:
-		typeOfV := toValue.Type().Elem()
-		if typeOfV.Kind() == reflect.Struct {
-			if typeOfV.NumField() > 0 && typeOfV.Field(0).Anonymous {
-				newSlice := reflect.MakeSlice(reflect.SliceOf(typeOfV), 0, 0)
-
-				for _, v := range m[label].([]interface{}) {
-					// For each iteration of the slice, we create a new struct.
-					// This is to work around a bug where elements of a slice
-					// are reused and not overwritten when the same copy of the
-					// struct is used:
-					//
-					// https://github.com/golang/go/issues/21092
-					// https://github.com/golang/go/issues/24155
-					// https://play.golang.org/p/NHo3ywlPZli
-					newType := reflect.New(typeOfV).Elem()
-
-					b, err := jsonMarshal(v)
-					if err != nil {
-						return err
-					}
-
-					// This is needed for structs with an UnmarshalJSON method.
-					// Technically this is just unmarshalling the response into
-					// a struct that is never used, but it's good enough to
-					// trigger the UnmarshalJSON method.
-					for i := 0; i < newType.NumField(); i++ {
-						s := newType.Field(i).Addr().Interface()
-
-						// Unmarshal is used rather than NewDecoder to also work
-						// around the above-mentioned bug.
-						err = json.Unmarshal(b, s)
-						if err != nil {
-							return err
-						}
-					}
-
-					newSlice = reflect.Append(newSlice, newType)
-				}
-
-				// "to" should now be properly modeled to receive the
-				// JSON response body and unmarshal into all the correct
-				// fields of the struct or composed extension struct
-				// at the end of this method.
-				toValue.Set(newSlice)
-			}
-		}
-	case reflect.Struct:
-		typeOfV := toValue.Type()
-		if typeOfV.NumField() > 0 && typeOfV.Field(0).Anonymous {
-			for i := 0; i < toValue.NumField(); i++ {
-				toField := toValue.Field(i)
-				if toField.Kind() == reflect.Struct {
-					s := toField.Addr().Interface()
-					err = json.NewDecoder(bytes.NewReader(b)).Decode(s)
-					if err != nil {
-						return err
-					}
-				}
-			}
-		}
-	}
-
-	err = json.Unmarshal(b, &to)
-	return err
-}
-
-// ExtractIntoStructPtr will unmarshal the given body into the provided
-// interface{} (to).
-func ExtractIntoStructPtr(body, to interface{}, label string) error {
-	t := reflect.TypeOf(to)
-	if k := t.Kind(); k != reflect.Ptr {
-		return fmt.Errorf("expected pointer, got %v", k)
-	}
-	switch t.Elem().Kind() {
-	case reflect.Struct:
-		return extractIntoPtr(body, to, label)
-	default:
-		return fmt.Errorf("expected pointer to struct, got: %v", t)
-	}
+	return extract.Into(r.Body, to)
 }
 
 // ExtractIntoStructPtr will unmarshal the Result (r) into the provided
@@ -201,22 +80,7 @@ func (r Result) ExtractIntoStructPtr(to interface{}, label string) error {
 		return r.Err
 	}
 
-	return ExtractIntoStructPtr(r.Body, to, label)
-}
-
-// ExtractIntoSlicePtr will unmarshal the provided body into the provided
-// interface{} (to).
-func ExtractIntoSlicePtr(body, to interface{}, label string) error {
-	t := reflect.TypeOf(to)
-	if k := t.Kind(); k != reflect.Ptr {
-		return fmt.Errorf("expected pointer, got %v", k)
-	}
-	switch t.Elem().Kind() {
-	case reflect.Slice:
-		return extractIntoPtr(body, to, label)
-	default:
-		return fmt.Errorf("expected pointer to slice, got: %v", t)
-	}
+	return extract.IntoStructPtr(r.Body, to, label)
 }
 
 // ExtractIntoSlicePtr will unmarshal the Result (r) into the provided
@@ -235,7 +99,7 @@ func (r Result) ExtractIntoSlicePtr(to interface{}, label string) error {
 		return r.Err
 	}
 
-	return ExtractIntoSlicePtr(r.Body, to, label)
+	return extract.IntoSlicePtr(r.Body, to, label)
 }
 
 func PrettyPrintJSON(body interface{}) string {
@@ -326,7 +190,7 @@ func (r HeaderResult) ExtractInto(to interface{}) error {
 		}
 	}
 
-	b, err := jsonMarshal(tmpHeaderMap)
+	b, err := extract.JsonMarshal(tmpHeaderMap)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Using extract functions allows to avoid using `Result`
structure and its derivatives

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->
Part of #389

### Special notes for your reviewer
This is what I was talking about in comments of #389 and in #381 and #384 discussions
Also, if unit tests are required, I will provide them later today