### PR TITLE
[Enhancement] Restrict internal response body types

### DIFF
--- a/internal/extract/doc.go
+++ b/internal/extract/doc.go
@@ -1,3 +1,3 @@
 // Package extract contains functions for extracting JSON results into given structure or slice pointers.
-// Those are wrappers over `json.Marshall` and `json.Unmarshall` functions with additional validation built it
+// Those are wrappers over `json.Marshal` and `json.Unmarshal` functions with additional validation built it
 package extract

--- a/openstack/blockstorage/extensions/quotasets/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/quotasets/testing/fixtures.go
@@ -36,41 +36,41 @@ var getExpectedQuotaSet = quotasets.QuotaSet{
 
 var getUsageExpectedJSONBody = `
 {
-	"quota_set" : {
-		"id": "555544443333222211110000ffffeeee",
-		"volumes" : {
-			"in_use": 15,
-			"limit": 16,
-			"reserved": 17
-		},
-		"snapshots" : {
-			"in_use": 18,
-			"limit": 19,
-			"reserved": 20
-		},
-		"gigabytes" : {
-			"in_use": 21,
-			"limit": 22,
-			"reserved": 23
-		},
-		"per_volume_gigabytes" : {
-			"in_use": 24,
-			"limit": 25,
-			"reserved": 26
-		},
-		"backups" : {
-			"in_use": 27,
-			"limit": 28,
-			"reserved": 29
-		},
-		"backup_gigabytes" : {
-			"in_use": 30,
-			"limit": 31,
-			"reserved": 32
-		}
-		}
-	}
-}`
+  "quota_set": {
+    "id": "555544443333222211110000ffffeeee",
+    "volumes": {
+      "in_use": 15,
+      "limit": 16,
+      "reserved": 17
+    },
+    "snapshots": {
+      "in_use": 18,
+      "limit": 19,
+      "reserved": 20
+    },
+    "gigabytes": {
+      "in_use": 21,
+      "limit": 22,
+      "reserved": 23
+    },
+    "per_volume_gigabytes": {
+      "in_use": 24,
+      "limit": 25,
+      "reserved": 26
+    },
+    "backups": {
+      "in_use": 27,
+      "limit": 28,
+      "reserved": 29
+    },
+    "backup_gigabytes": {
+      "in_use": 30,
+      "limit": 31,
+      "reserved": 32
+    }
+  }
+}
+`
 
 var getUsageExpectedQuotaSet = quotasets.QuotaUsageSet{
 	ID:                 FirstTenantID,

--- a/openstack/blockstorage/v1/snapshots/results.go
+++ b/openstack/blockstorage/v1/snapshots/results.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/metadata"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
 
@@ -109,11 +110,7 @@ type UpdateMetadataResult struct {
 
 // ExtractMetadata returns the metadata from a response from snapshots.UpdateMetadata.
 func (r UpdateMetadataResult) ExtractMetadata() (map[string]interface{}, error) {
-	if r.Err != nil {
-		return nil, r.Err
-	}
-	m := r.Body.(map[string]interface{})["metadata"]
-	return m.(map[string]interface{}), nil
+	return metadata.Extract(r.BodyReader())
 }
 
 type commonResult struct {

--- a/openstack/blockstorage/v2/snapshots/results.go
+++ b/openstack/blockstorage/v2/snapshots/results.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/metadata"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
 
@@ -99,11 +100,7 @@ type UpdateMetadataResult struct {
 
 // ExtractMetadata returns the metadata from a response from snapshots.UpdateMetadata.
 func (r UpdateMetadataResult) ExtractMetadata() (map[string]interface{}, error) {
-	if r.Err != nil {
-		return nil, r.Err
-	}
-	m := r.Body.(map[string]interface{})["metadata"]
-	return m.(map[string]interface{}), nil
+	return metadata.Extract(r.BodyReader())
 }
 
 type commonResult struct {

--- a/openstack/blockstorage/v3/snapshots/results.go
+++ b/openstack/blockstorage/v3/snapshots/results.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/metadata"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
 
@@ -111,11 +112,7 @@ type UpdateMetadataResult struct {
 
 // ExtractMetadata returns the metadata from a response from snapshots.UpdateMetadata.
 func (r UpdateMetadataResult) ExtractMetadata() (map[string]interface{}, error) {
-	if r.Err != nil {
-		return nil, r.Err
-	}
-	m := r.Body.(map[string]interface{})["metadata"]
-	return m.(map[string]interface{}), nil
+	return metadata.Extract(r.BodyReader())
 }
 
 type commonResult struct {

--- a/openstack/bms/v2/flavors/results.go
+++ b/openstack/bms/v2/flavors/results.go
@@ -88,7 +88,7 @@ func (page FlavorPage) IsEmpty() (bool, error) {
 // next page of results.
 func (page FlavorPage) NextPageURL() (string, error) {
 	var res []golangsdk.Link
-	err := extract.IntoSlicePtr(page.Result.Body, &res, "flavors_links")
+	err := extract.IntoSlicePtr(page.Result.BodyReader(), &res, "flavors_links")
 	if err != nil {
 		return "", err
 	}
@@ -99,6 +99,6 @@ func (page FlavorPage) NextPageURL() (string, error) {
 // from the List operation.
 func ExtractFlavors(r pagination.Page) ([]Flavor, error) {
 	var res []Flavor
-	err := extract.IntoSlicePtr(r.(FlavorPage).Result.Body, &res, "flavors")
+	err := extract.IntoSlicePtr(r.(FlavorPage).Result.BodyReader(), &res, "flavors")
 	return res, err
 }

--- a/openstack/bms/v2/keypairs/results.go
+++ b/openstack/bms/v2/keypairs/results.go
@@ -33,7 +33,7 @@ func ExtractKeyPairs(r pagination.Page) ([]KeyPair, error) {
 		KeyPair KeyPair `json:"keypair"`
 	}
 
-	err := extract.IntoSlicePtr(r.(KeyPairPage).Result.Body, &res, "keypairs")
+	err := extract.IntoSlicePtr(r.(KeyPairPage).Result.BodyReader(), &res, "keypairs")
 	results := make([]KeyPair, len(res))
 
 	for i, pair := range res {

--- a/openstack/bms/v2/nics/results.go
+++ b/openstack/bms/v2/nics/results.go
@@ -36,7 +36,7 @@ type NicPage struct {
 func (r NicPage) NextPageURL() (string, error) {
 	var res []golangsdk.Link
 
-	err := extract.IntoSlicePtr(r.Body, &res, "interfaceAttachments_links")
+	err := extract.IntoSlicePtr(r.BodyReader(), &res, "interfaceAttachments_links")
 	if err != nil {
 		return "", err
 	}
@@ -55,6 +55,6 @@ func (r NicPage) IsEmpty() (bool, error) {
 // a generic collection is mapped into a relevant slice.
 func ExtractNics(r pagination.Page) ([]Nic, error) {
 	var res []Nic
-	err := extract.IntoSlicePtr(r.(NicPage).Body, &res, "interfaceAttachments")
+	err := extract.IntoSlicePtr(r.(NicPage).BodyReader(), &res, "interfaceAttachments")
 	return res, err
 }

--- a/openstack/bms/v2/servers/results.go
+++ b/openstack/bms/v2/servers/results.go
@@ -21,7 +21,7 @@ func (r ServerPage) IsEmpty() (bool, error) {
 // NextPageURL uses the response's embedded link reference to navigate to the next page of results.
 func (r ServerPage) NextPageURL() (string, error) {
 	var res []golangsdk.Link
-	err := extract.IntoSlicePtr(res, &res, "servers_links")
+	err := extract.IntoSlicePtr(r.BodyReader(), &res, "servers_links")
 	if err != nil {
 		return "", err
 	}
@@ -33,7 +33,7 @@ func (r ServerPage) NextPageURL() (string, error) {
 // a generic collection is mapped into a relevant slice.
 func ExtractServers(r pagination.Page) ([]Server, error) {
 	var res []Server
-	err := extract.IntoSlicePtr(r.(ServerPage).Body, &res, "servers")
+	err := extract.IntoSlicePtr(r.(ServerPage).BodyReader(), &res, "servers")
 	return res, err
 }
 

--- a/openstack/common/metadata/metadata.go
+++ b/openstack/common/metadata/metadata.go
@@ -1,0 +1,22 @@
+package metadata
+
+import (
+	"io"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// result is a struct wrapper for a metadata map
+type result struct {
+	Metadata map[string]interface{} `json:"metadata"`
+}
+
+func Extract(reader io.Reader) (map[string]interface{}, error) {
+	metadata := new(result)
+	err := extract.Into(reader, metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	return metadata.Metadata, nil
+}

--- a/openstack/compute/v2/extensions/quotasets/requests.go
+++ b/openstack/compute/v2/extensions/quotasets/requests.go
@@ -16,7 +16,7 @@ func GetDetail(client *golangsdk.ServiceClient, tenantID string) (r GetDetailRes
 	return
 }
 
-// Updates the quotas for the given tenantID and returns the new QuotaSet.
+// Update updates the quotas for the given tenantID and returns the new QuotaSet.
 func Update(client *golangsdk.ServiceClient, tenantID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	reqBody, err := opts.ToComputeQuotaUpdateMap()
 	if err != nil {
@@ -28,15 +28,15 @@ func Update(client *golangsdk.ServiceClient, tenantID string, opts UpdateOptsBui
 	return
 }
 
-// Resets the quotas for the given tenant to their default values.
+// Delete resets the quotas for the given tenant to their default values.
 func Delete(client *golangsdk.ServiceClient, tenantID string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, tenantID), nil)
 	return
 }
 
-// Options for Updating the quotas of a Tenant.
-// All int-values are pointers so they can be nil if they are not needed.
-// You can use gopercloud.IntToPointer() for convenience
+// UpdateOpts - options for Updating the quotas of a Tenant.
+// All int-values are pointers, so they can be nil if they are not needed.
+// You can use golangsdk.IntToPointer() for convenience
 type UpdateOpts struct {
 	// FixedIPs is number of fixed ips alloted this quota_set.
 	FixedIPs *int `json:"fixed_ips,omitempty"`

--- a/openstack/compute/v2/extensions/quotasets/testing/requests_test.go
+++ b/openstack/compute/v2/extensions/quotasets/testing/requests_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestGet(t *testing.T) {
 	th.SetupHTTP()
-	defer th.TeardownHTTP()
+	t.Cleanup(th.TeardownHTTP)
 	HandleGetSuccessfully(t)
 	actual, err := quotasets.Get(client.ServiceClient(), FirstTenantID).Extract()
 	th.AssertNoErr(t, err)
@@ -21,7 +21,7 @@ func TestGet(t *testing.T) {
 
 func TestGetDetail(t *testing.T) {
 	th.SetupHTTP()
-	defer th.TeardownHTTP()
+	t.Cleanup(th.TeardownHTTP)
 	HandleGetDetailSuccessfully(t)
 	actual, err := quotasets.GetDetail(client.ServiceClient(), FirstTenantID).Extract()
 	th.CheckDeepEquals(t, FirstQuotaDetailsSet, actual)
@@ -30,7 +30,7 @@ func TestGetDetail(t *testing.T) {
 
 func TestUpdate(t *testing.T) {
 	th.SetupHTTP()
-	defer th.TeardownHTTP()
+	t.Cleanup(th.TeardownHTTP)
 	HandlePutSuccessfully(t)
 	actual, err := quotasets.Update(client.ServiceClient(), FirstTenantID, UpdatedQuotaSet).Extract()
 	th.AssertNoErr(t, err)
@@ -39,7 +39,7 @@ func TestUpdate(t *testing.T) {
 
 func TestPartialUpdate(t *testing.T) {
 	th.SetupHTTP()
-	defer th.TeardownHTTP()
+	t.Cleanup(th.TeardownHTTP)
 	HandlePartialPutSuccessfully(t)
 	opts := quotasets.UpdateOpts{Cores: golangsdk.IntToPointer(200), Force: true}
 	actual, err := quotasets.Update(client.ServiceClient(), FirstTenantID, opts).Extract()
@@ -49,7 +49,7 @@ func TestPartialUpdate(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	th.SetupHTTP()
-	defer th.TeardownHTTP()
+	t.Cleanup(th.TeardownHTTP)
 	HandleDeleteSuccessfully(t)
 	_, err := quotasets.Delete(client.ServiceClient(), FirstTenantID).Extract()
 	th.AssertNoErr(t, err)
@@ -58,7 +58,7 @@ func TestDelete(t *testing.T) {
 type ErrorUpdateOpts quotasets.UpdateOpts
 
 func (opts ErrorUpdateOpts) ToComputeQuotaUpdateMap() (map[string]interface{}, error) {
-	return nil, errors.New("This is an error")
+	return nil, errors.New("this is an error")
 }
 
 func TestErrorInToComputeQuotaUpdateMap(t *testing.T) {

--- a/openstack/compute/v2/images/testing/requests_test.go
+++ b/openstack/compute/v2/images/testing/requests_test.go
@@ -1,7 +1,6 @@
 package testing
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -183,13 +182,8 @@ func TestGetImage(t *testing.T) {
 
 func TestNextPageURL(t *testing.T) {
 	var page images.ImagePage
-	var body map[string]interface{}
 	bodyString := []byte(`{"images":{"links":[{"href":"http://192.154.23.87/12345/images/image3","rel":"bookmark"}]}, "images_links":[{"href":"http://192.154.23.87/12345/images/image4","rel":"next"}]}`)
-	err := json.Unmarshal(bodyString, &body)
-	if err != nil {
-		t.Fatalf("Error unmarshaling data into page body: %v", err)
-	}
-	page.Body = body
+	page.Body = bodyString
 
 	expected := "http://192.154.23.87/12345/images/image4"
 	actual, err := page.NextPageURL()

--- a/openstack/compute/v2/servers/testing/results_test.go
+++ b/openstack/compute/v2/servers/testing/results_test.go
@@ -2,8 +2,6 @@ package testing
 
 import (
 	"crypto/rsa"
-	"encoding/json"
-	"fmt"
 	"testing"
 
 	"golang.org/x/crypto/ssh"
@@ -16,13 +14,7 @@ import (
 
 // Fail - No password in JSON.
 func TestExtractPassword_no_pwd_data(t *testing.T) {
-
-	var dejson interface{}
-	err := json.Unmarshal([]byte(`{ "Crappy data": ".-.-." }`), &dejson)
-	if err != nil {
-		t.Fatalf("%s", err)
-	}
-	resp := servers.GetPasswordResult{Result: golangsdk.Result{Body: dejson}}
+	resp := servers.GetPasswordResult{Result: golangsdk.Result{Body: []byte(`{ "Crappy data": ".-.-." }`)}}
 
 	pwd, err := resp.ExtractPassword(nil)
 	th.AssertNoErr(t, err)
@@ -32,15 +24,9 @@ func TestExtractPassword_no_pwd_data(t *testing.T) {
 // Ok - return encrypted password when no private key is given.
 func TestExtractPassword_encrypted_pwd(t *testing.T) {
 
-	var dejson interface{}
 	sejson := []byte(`{"password":"PP8EnwPO9DhEc8+O/6CKAkPF379mKsUsfFY6yyw0734XXvKsSdV9KbiHQ2hrBvzeZxtGMrlFaikVunCRizyLLWLMuOi4hoH+qy9F9sQid61gQIGkxwDAt85d/7Eau2/KzorFnZhgxArl7IiqJ67X6xjKkR3zur+Yp3V/mtVIehpPYIaAvPbcp2t4mQXl1I9J8yrQfEZOctLL1L4heDEVXnxvNihVLK6pivlVggp6SZCtjj9cduZGrYGsxsOCso1dqJQr7GCojfwvuLOoG0OYwEGuWVTZppxWxi/q1QgeHFhGKA5QUXlz7pS71oqpjYsTeViuHnfvlqb5TVYZpQ1haw=="}`)
 
-	err := json.Unmarshal(sejson, &dejson)
-	fmt.Printf("%v\n", dejson)
-	if err != nil {
-		t.Fatalf("%s", err)
-	}
-	resp := servers.GetPasswordResult{Result: golangsdk.Result{Body: dejson}}
+	resp := servers.GetPasswordResult{Result: golangsdk.Result{Body: sejson}}
 
 	pwd, err := resp.ExtractPassword(nil)
 	th.AssertNoErr(t, err)
@@ -49,7 +35,8 @@ func TestExtractPassword_encrypted_pwd(t *testing.T) {
 
 // Ok - return decrypted password when private key is given.
 // Decrytion can be verified by:
-//   echo "<enc_pwd>" | base64 -D | openssl rsautl -decrypt -inkey <privateKey.pem>
+//
+//	echo "<enc_pwd>" | base64 -D | openssl rsautl -decrypt -inkey <privateKey.pem>
 func TestExtractPassword_decrypted_pwd(t *testing.T) {
 
 	privateKey, err := ssh.ParseRawPrivateKey([]byte(`
@@ -85,15 +72,9 @@ KSde3I0ybDz7iS2EtceKB7m4C0slYd+oBkm4efuF00rCOKDwpFq45m0=
 		t.Fatalf("Error parsing private key: %s\n", err)
 	}
 
-	var dejson interface{}
 	sejson := []byte(`{"password":"PP8EnwPO9DhEc8+O/6CKAkPF379mKsUsfFY6yyw0734XXvKsSdV9KbiHQ2hrBvzeZxtGMrlFaikVunCRizyLLWLMuOi4hoH+qy9F9sQid61gQIGkxwDAt85d/7Eau2/KzorFnZhgxArl7IiqJ67X6xjKkR3zur+Yp3V/mtVIehpPYIaAvPbcp2t4mQXl1I9J8yrQfEZOctLL1L4heDEVXnxvNihVLK6pivlVggp6SZCtjj9cduZGrYGsxsOCso1dqJQr7GCojfwvuLOoG0OYwEGuWVTZppxWxi/q1QgeHFhGKA5QUXlz7pS71oqpjYsTeViuHnfvlqb5TVYZpQ1haw=="}`)
 
-	err = json.Unmarshal(sejson, &dejson)
-	fmt.Printf("%v\n", dejson)
-	if err != nil {
-		t.Fatalf("%s", err)
-	}
-	resp := servers.GetPasswordResult{Result: golangsdk.Result{Body: dejson}}
+	resp := servers.GetPasswordResult{Result: golangsdk.Result{Body: sejson}}
 
 	pwd, err := resp.ExtractPassword(privateKey.(*rsa.PrivateKey))
 	th.AssertNoErr(t, err)

--- a/openstack/css/v1/clusters/results.go
+++ b/openstack/css/v1/clusters/results.go
@@ -69,7 +69,7 @@ func ExtractClusters(r pagination.Page) ([]Cluster, error) {
 	return clusters, err
 }
 
-func (p ClusterPage) GetBody() interface{} {
+func (p ClusterPage) GetBody() []byte {
 	return p.Body
 }
 

--- a/openstack/dns/v2/recordsets/testing/requests_test.go
+++ b/openstack/dns/v2/recordsets/testing/requests_test.go
@@ -1,7 +1,6 @@
 package testing
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dns/v2/recordsets"
@@ -74,12 +73,7 @@ func TestGet(t *testing.T) {
 
 func TestNextPageURL(t *testing.T) {
 	var page recordsets.RecordSetPage
-	var body map[string]interface{}
-	err := json.Unmarshal([]byte(NextPageRequest), &body)
-	if err != nil {
-		t.Fatalf("Error unmarshaling data into page body: %v", err)
-	}
-	page.Body = body
+	page.Body = []byte(NextPageRequest)
 	expected := "http://127.0.0.1:9001/v2/zones/2150b1bf-dee2-4221-9d85-11f7886fb15f/recordsets?limit=1&marker=f7b10e9b-0cae-4a91-b162-562bc6096648"
 	actual, err := page.NextPageURL()
 	th.AssertNoErr(t, err)

--- a/openstack/identity/v3/tokens/testing/fixtures.go
+++ b/openstack/identity/v3/tokens/testing/fixtures.go
@@ -1,14 +1,12 @@
 package testing
 
 import (
-	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3/tokens"
-	"github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
 
 const testTokenID = "130f6c17-420e-4a0b-97b0-0c9cf2a05f30"
@@ -293,12 +291,13 @@ var ExpectedProject = tokens.Project{
 }
 
 func getGetResult(t *testing.T) tokens.GetResult {
+	t.Helper()
+
 	result := tokens.GetResult{}
 	result.Header = http.Header{
 		"X-Subject-Token": []string{testTokenID},
 	}
-	err := json.Unmarshal([]byte(TokenOutput), &result.Body)
-	testhelper.AssertNoErr(t, err)
+	result.Body = []byte(TokenOutput)
 	return result
 }
 
@@ -309,11 +308,12 @@ var ExpectedDomain = tokens.Domain{
 }
 
 func getGetDomainResult(t *testing.T) tokens.GetResult {
+	t.Helper()
+
 	result := tokens.GetResult{}
 	result.Header = http.Header{
 		"X-Subject-Token": []string{testTokenID},
 	}
-	err := json.Unmarshal([]byte(DomainToken), &result.Body)
-	testhelper.AssertNoErr(t, err)
+	result.Body = []byte(DomainToken)
 	return result
 }

--- a/openstack/imageservice/v2/imagedata/requests.go
+++ b/openstack/imageservice/v2/imagedata/requests.go
@@ -32,7 +32,8 @@ func Download(client *golangsdk.ServiceClient, id string) (r DownloadResult) {
 	var resp *http.Response
 	resp, r.Err = client.Get(downloadURL(client, id), nil, nil)
 	if resp != nil {
-		r.Body = resp.Body
+		r.Body = nil
+		r.reader = resp.Body
 		r.Header = resp.Header
 	}
 	return

--- a/openstack/imageservice/v2/imagedata/results.go
+++ b/openstack/imageservice/v2/imagedata/results.go
@@ -1,7 +1,6 @@
 package imagedata
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/opentelekomcloud/gophertelekomcloud"
@@ -23,12 +22,11 @@ type StageResult struct {
 // method to gain access to the image data.
 type DownloadResult struct {
 	golangsdk.Result
+
+	reader io.ReadCloser
 }
 
 // Extract builds images model from io.Reader
-func (r DownloadResult) Extract() (io.Reader, error) {
-	if r, ok := r.Body.(io.Reader); ok {
-		return r, nil
-	}
-	return nil, fmt.Errorf("Expected io.Reader but got: %T(%#v)", r.Body, r.Body)
+func (r DownloadResult) Extract() (io.ReadCloser, error) {
+	return r.reader, nil
 }

--- a/openstack/imageservice/v2/imagedata/testing/requests_test.go
+++ b/openstack/imageservice/v2/imagedata/testing/requests_test.go
@@ -94,6 +94,10 @@ func TestDownload(t *testing.T) {
 	rdr, err := imagedata.Download(fakeclient.ServiceClient(), "da3b75d9-3f4a-40e7-8a2c-bfab23927dea").Extract()
 	th.AssertNoErr(t, err)
 
+	t.Cleanup(func() {
+		_ = rdr.Close()
+	})
+
 	bs, err := ioutil.ReadAll(rdr)
 	th.AssertNoErr(t, err)
 

--- a/openstack/networking/v2/extensions/vpnaas/siteconnections/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/vpnaas/siteconnections/testing/requests_test.go
@@ -335,36 +335,34 @@ func TestUpdate(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 
 		_, _ = fmt.Fprint(w, `
-
-	{
-    "ipsec_site_connection": {
-        "status": "ACTIVE",
-        "psk": "updatedsecret",
-        "initiator": "response-only",
-        "name": "updatedconnection",
-        "admin_state_up": true,
-        "project_id": "10039663455a446d8ba2cbb058b0f578",
-        "tenant_id": "10039663455a446d8ba2cbb058b0f578",
-        "auth_mode": "psk",
-        "peer_cidrs": [],
-        "mtu": 1500,
-        "peer_ep_group_id": "9ad5a7e0-6dac-41b4-b20d-a7b8645fddf1",
-        "ikepolicy_id": "9b00d6b0-6c93-4ca5-9747-b8ade7bb514f",
-        "vpnservice_id": "5c561d9d-eaea-45f6-ae3e-08d1a7080828",
-        "dpd": {
-            "action": "hold",
-            "interval": 30,
-            "timeout": 120
-        },
-        "route_mode": "static",
-        "ipsecpolicy_id": "e6e23d0c-9519-4d52-8ea4-5b1f96d857b1",
-        "local_ep_group_id": "3e1815dd-e212-43d0-8f13-b494fa553e68",
-        "peer_address": "172.24.4.233",
-        "peer_id": "172.24.4.233",
-        "id": "851f280f-5639-4ea3-81aa-e298525ab74b",
-        "description": "updateddescription"
-    }
-}
+{
+  "ipsec_site_connection": {
+    "status": "ACTIVE",
+    "psk": "updatedsecret",
+    "initiator": "response-only",
+    "name": "updatedconnection",
+    "admin_state_up": true,
+    "project_id": "10039663455a446d8ba2cbb058b0f578",
+    "tenant_id": "10039663455a446d8ba2cbb058b0f578",
+    "auth_mode": "psk",
+    "peer_cidrs": [],
+    "mtu": 1500,
+    "peer_ep_group_id": "9ad5a7e0-6dac-41b4-b20d-a7b8645fddf1",
+    "ikepolicy_id": "9b00d6b0-6c93-4ca5-9747-b8ade7bb514f",
+    "vpnservice_id": "5c561d9d-eaea-45f6-ae3e-08d1a7080828",
+    "dpd": {
+      "action": "hold",
+      "interval": 30,
+      "timeout": 120
+    },
+    "route_mode": "static",
+    "ipsecpolicy_id": "e6e23d0c-9519-4d52-8ea4-5b1f96d857b1",
+    "local_ep_group_id": "3e1815dd-e212-43d0-8f13-b494fa553e68",
+    "peer_address": "172.24.4.233",
+    "peer_id": "172.24.4.233",
+    "id": "851f280f-5639-4ea3-81aa-e298525ab74b",
+    "description": "updateddescription"
+  }
 }
 `)
 	})

--- a/openstack/networking/v2/subnets/testing/results_test.go
+++ b/openstack/networking/v2/subnets/testing/results_test.go
@@ -1,7 +1,6 @@
 package testing
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud"
@@ -39,17 +38,11 @@ func TestHostRoute(t *testing.T) {
   }}
 `)
 
-	var dejson interface{}
-	err := json.Unmarshal(sejson, &dejson)
-	if err != nil {
-		t.Fatalf("%s", err)
-	}
-
-	resp := golangsdk.Result{Body: dejson}
+	resp := golangsdk.Result{Body: sejson}
 	var subnetWrapper struct {
 		Subnet subnets.Subnet `json:"subnet"`
 	}
-	err = resp.ExtractInto(&subnetWrapper)
+	err := resp.ExtractInto(&subnetWrapper)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}

--- a/openstack/objectstorage/v1/containers/results.go
+++ b/openstack/objectstorage/v1/containers/results.go
@@ -76,7 +76,7 @@ func ExtractNames(page pagination.Page) ([]string, error) {
 	case strings.HasPrefix(ct, "text/plain"):
 		names := make([]string, 0, 50)
 
-		body := string(page.(ContainerPage).Body.([]uint8))
+		body := string(page.(ContainerPage).Body)
 		for _, name := range strings.Split(body, "\n") {
 			if len(name) > 0 {
 				names = append(names, name)

--- a/openstack/objectstorage/v1/objects/results.go
+++ b/openstack/objectstorage/v1/objects/results.go
@@ -113,7 +113,7 @@ func ExtractNames(r pagination.Page) ([]string, error) {
 	case strings.HasPrefix(ct, "text/plain"):
 		names := make([]string, 0, 50)
 
-		body := string(r.(ObjectPage).Body.([]uint8))
+		body := string(r.(ObjectPage).Body)
 		for _, name := range strings.Split(body, "\n") {
 			if len(name) > 0 {
 				names = append(names, name)
@@ -563,7 +563,7 @@ func extractLastMarker(r pagination.Page) (string, error) {
 	case strings.HasPrefix(ct, "text/plain"):
 		names := make([]string, 0, 50)
 
-		body := string(r.(ObjectPage).Body.([]uint8))
+		body := string(r.(ObjectPage).Body)
 		for _, name := range strings.Split(body, "\n") {
 			if len(name) > 0 {
 				names = append(names, name)

--- a/openstack/rts/v1/stacktemplates/results.go
+++ b/openstack/rts/v1/stacktemplates/results.go
@@ -16,7 +16,14 @@ func (r GetResult) Extract() ([]byte, error) {
 	if r.Err != nil {
 		return nil, r.Err
 	}
-	template, err := json.MarshalIndent(r.Body, "", "  ")
+	mapBody := make(map[string]interface{})
+
+	// make sure return pretty-printed body
+	if err := json.Unmarshal(r.Body, &mapBody); err != nil {
+		return nil, err
+	}
+
+	template, err := json.MarshalIndent(mapBody, "", "  ")
 	if err != nil {
 		return nil, err
 	}

--- a/openstack/waf/v1/certificates/results.go
+++ b/openstack/waf/v1/certificates/results.go
@@ -92,6 +92,15 @@ func (p CertificatePage) NextPageURL() (string, error) {
 	return currentURL.String(), nil
 }
 
+func (p CertificatePage) IsEmpty() (bool, error) {
+	certificates, err := ExtractCertificates(p)
+	if err != nil {
+		return false, err
+	}
+
+	return len(certificates) == 0, nil
+}
+
 func ExtractCertificates(p pagination.Page) ([]Certificate, error) {
 	var certs []Certificate
 	body := p.(CertificatePage).BodyReader()

--- a/pagination/http.go
+++ b/pagination/http.go
@@ -1,13 +1,12 @@
 package pagination
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 )
 
 // PageResult stores the HTTP response that returned the current page of results.
@@ -16,39 +15,44 @@ type PageResult struct {
 	url.URL
 }
 
+// GetBodyAsSlice tries to convert page body to a slice, returning nil on fail
+func (r PageResult) GetBodyAsSlice() ([]interface{}, error) {
+	result := make([]interface{}, 0)
+
+	if err := extract.Into(r.BodyReader(), &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetBodyAsMap tries to convert page body to a map, returning nil on fail
+func (r PageResult) GetBodyAsMap() (map[string]interface{}, error) {
+	result := make(map[string]interface{}, 0)
+
+	if err := extract.Into(r.BodyReader(), &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // PageResultFrom parses an HTTP response as JSON and returns a PageResult containing the
 // results, interpreting it as JSON if the content type indicates.
 func PageResultFrom(resp *http.Response) (PageResult, error) {
-	var parsedBody interface{}
-
 	defer resp.Body.Close()
 	rawBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return PageResult{}, err
 	}
 
-	if strings.HasPrefix(resp.Header.Get("Content-Type"), "application/json") {
-		err = json.Unmarshal(rawBody, &parsedBody)
-		if err != nil {
-			return PageResult{}, err
-		}
-	} else {
-		parsedBody = rawBody
-	}
-
-	return PageResultFromParsed(resp, parsedBody), err
-}
-
-// PageResultFromParsed constructs a PageResult from an HTTP response that has already had its
-// body parsed as JSON (and closed).
-func PageResultFromParsed(resp *http.Response, body interface{}) PageResult {
 	return PageResult{
 		Result: golangsdk.Result{
-			Body:   body,
+			Body:   rawBody,
 			Header: resp.Header,
 		},
 		URL: *resp.Request.URL,
-	}
+	}, nil
 }
 
 // Request performs an HTTP request and extracts the http.Response from the result.

--- a/pagination/marker.go
+++ b/pagination/marker.go
@@ -2,9 +2,6 @@ package pagination
 
 import (
 	"fmt"
-	"reflect"
-
-	"github.com/opentelekomcloud/gophertelekomcloud"
 )
 
 // MarkerPage is a stricter Page interface that describes additional functionality required for use with NewMarkerPager.
@@ -42,17 +39,16 @@ func (current MarkerPageBase) NextPageURL() (string, error) {
 
 // IsEmpty satisifies the IsEmpty method of the Page interface
 func (current MarkerPageBase) IsEmpty() (bool, error) {
-	if b, ok := current.Body.([]interface{}); ok {
-		return len(b) == 0, nil
+	body, err := current.GetBodyAsSlice()
+	if err != nil {
+		return false, fmt.Errorf("error converting page body to slice: %w", err)
 	}
-	err := golangsdk.ErrUnexpectedType{}
-	err.Expected = "[]interface{}"
-	err.Actual = fmt.Sprintf("%v", reflect.TypeOf(current.Body))
-	return true, err
+
+	return len(body) == 0, nil
 }
 
 // GetBody returns the linked page's body. This method is needed to satisfy the
 // Page interface.
-func (current MarkerPageBase) GetBody() interface{} {
+func (current MarkerPageBase) GetBody() []byte {
 	return current.Body
 }

--- a/pagination/offset.go
+++ b/pagination/offset.go
@@ -2,10 +2,7 @@ package pagination
 
 import (
 	"fmt"
-	"reflect"
 	"strconv"
-
-	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 )
 
 type OffsetPage interface {
@@ -49,16 +46,15 @@ func (p OffsetPageBase) NextPageURL() (string, error) {
 
 // IsEmpty returns true if this Page has no items in it.
 func (p OffsetPageBase) IsEmpty() (bool, error) {
-	if b, ok := p.Body.([]interface{}); ok {
-		return len(b) == 0, nil
+	body, err := p.GetBodyAsSlice()
+	if err != nil {
+		return false, fmt.Errorf("error converting page body to slice: %w", err)
 	}
-	err := golangsdk.ErrUnexpectedType{}
-	err.Expected = "[]interface{}"
-	err.Actual = fmt.Sprintf("%v", reflect.TypeOf(p.Body))
-	return true, err
+
+	return len(body) == 0, nil
 }
 
 // GetBody returns the Page Body. This is used in the `AllPages` method.
-func (p OffsetPageBase) GetBody() interface{} {
+func (p OffsetPageBase) GetBody() []byte {
 	return p.Body
 }

--- a/pagination/pager.go
+++ b/pagination/pager.go
@@ -1,6 +1,7 @@
 package pagination
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -30,7 +31,11 @@ type Page interface {
 	IsEmpty() (bool, error)
 
 	// GetBody returns the Page Body. This is used in the `AllPages` method.
-	GetBody() interface{}
+	GetBody() []byte
+	// GetBodyAsSlice tries to convert page body to a slice.
+	GetBodyAsSlice() ([]interface{}, error)
+	// GetBodyAsMap tries to convert page body to a map.
+	GetBodyAsMap() (map[string]interface{}, error)
 }
 
 // Pager knows how to advance through a specific resource collection, one page at a time.
@@ -123,17 +128,15 @@ func (p Pager) EachPage(handler func(Page) (bool, error)) error {
 // AllPages returns all the pages from a `List` operation in a single page,
 // allowing the user to retrieve all the pages at once.
 func (p Pager) AllPages() (Page, error) {
-	// pagesSlice holds all the pages until they get converted into as Page Body.
-	var pagesSlice []interface{}
 	// body will contain the final concatenated Page body.
-	var body reflect.Value
+	var body []byte
 
 	// Grab a test page to ascertain the page body type.
 	testPage, err := p.fetchNextPage(p.initialURL)
 	if err != nil {
 		return nil, err
 	}
-	// Store the page type so we can use reflection to create a new mega-page of
+	// Store the page type, so we can use reflection to create a new mega-page of
 	// that type.
 	pageType := reflect.TypeOf(testPage)
 
@@ -142,15 +145,37 @@ func (p Pager) AllPages() (Page, error) {
 		return testPage, nil
 	}
 
-	// Switch on the page body type. Recognized types are `map[string]interface{}`,
-	// `[]byte`, and `[]interface{}`.
-	switch pb := testPage.GetBody().(type) {
-	case map[string]interface{}:
+	if _, err := testPage.GetBodyAsSlice(); err != nil {
+		var pagesSlice []interface{}
+
+		// Iterate over the pages to concatenate the bodies.
+		err = p.EachPage(func(page Page) (bool, error) {
+			b, err := page.GetBodyAsSlice()
+			if err != nil {
+				return false, fmt.Errorf("error paginating page with slice body: %w", err)
+			}
+			pagesSlice = append(pagesSlice, b...)
+			return true, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		body, err = json.Marshal(pagesSlice)
+		if err != nil {
+			return nil, err
+		}
+	} else if _, err := testPage.GetBodyAsMap(); err != nil {
+		var pagesSlice []interface{}
+
 		// key is the map key for the page body if the body type is `map[string]interface{}`.
 		var key string
 		// Iterate over the pages to concatenate the bodies.
 		err = p.EachPage(func(page Page) (bool, error) {
-			b := page.GetBody().(map[string]interface{})
+			b, err := page.GetBodyAsMap()
+			if err != nil {
+				return false, fmt.Errorf("error paginating page with map body: %w", err)
+			}
 			for k, v := range b {
 				// If it's a linked page, we don't want the `links`, we want the other one.
 				if !strings.HasSuffix(k, "links") {
@@ -167,15 +192,23 @@ func (p Pager) AllPages() (Page, error) {
 		if err != nil {
 			return nil, err
 		}
-		// Set body to value of type `map[string]interface{}`
-		body = reflect.MakeMap(reflect.MapOf(reflect.TypeOf(key), reflect.TypeOf(pagesSlice)))
-		body.SetMapIndex(reflect.ValueOf(key), reflect.ValueOf(pagesSlice))
-	case []byte:
+
+		mapBody := map[string]interface{}{
+			key: pagesSlice,
+		}
+
+		body, err = json.Marshal(mapBody)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		var pagesSlice [][]byte
+
 		// Iterate over the pages to concatenate the bodies.
 		err = p.EachPage(func(page Page) (bool, error) {
-			b := page.GetBody().([]byte)
+			b := page.GetBody()
 			pagesSlice = append(pagesSlice, b)
-			// seperate pages with a comma
+			// separate pages with a comma
 			pagesSlice = append(pagesSlice, []byte{10})
 			return true, nil
 		})
@@ -189,31 +222,10 @@ func (p Pager) AllPages() (Page, error) {
 		var b []byte
 		// Combine the slice of slices in to a single slice.
 		for _, slice := range pagesSlice {
-			b = append(b, slice.([]byte)...)
+			b = append(b, slice...)
 		}
-		// Set body to value of type `bytes`.
-		body = reflect.New(reflect.TypeOf(b)).Elem()
-		body.SetBytes(b)
-	case []interface{}:
-		// Iterate over the pages to concatenate the bodies.
-		err = p.EachPage(func(page Page) (bool, error) {
-			b := page.GetBody().([]interface{})
-			pagesSlice = append(pagesSlice, b...)
-			return true, nil
-		})
-		if err != nil {
-			return nil, err
-		}
-		// Set body to value of type `[]interface{}`
-		body = reflect.MakeSlice(reflect.TypeOf(pagesSlice), len(pagesSlice), len(pagesSlice))
-		for i, s := range pagesSlice {
-			body.Index(i).Set(reflect.ValueOf(s))
-		}
-	default:
-		err := golangsdk.ErrUnexpectedType{}
-		err.Expected = "map[string]interface{}/[]byte/[]interface{}"
-		err.Actual = fmt.Sprintf("%T", pb)
-		return nil, err
+
+		body = b
 	}
 
 	// Each `Extract*` function is expecting a specific type of page coming back,
@@ -223,7 +235,7 @@ func (p Pager) AllPages() (Page, error) {
 	// pages.
 	page := reflect.New(pageType)
 	// Set the page body to be the concatenated pages.
-	page.Elem().FieldByName("Body").Set(body)
+	page.Elem().FieldByName("Body").Set(reflect.ValueOf(body))
 	// Set any additional headers that were pass along. The `objectstorage` pacakge,
 	// for example, passes a Content-Type header.
 	h := make(http.Header)

--- a/pagination/pager.go
+++ b/pagination/pager.go
@@ -2,18 +2,12 @@ package pagination
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
 
 	"github.com/opentelekomcloud/gophertelekomcloud"
-)
-
-var (
-	// ErrPageNotAvailable is returned from a Pager when a next or previous page is requested, but does not exist.
-	ErrPageNotAvailable = errors.New("The requested page does not exist.")
 )
 
 // Page must be satisfied by the result type of any resource collection.
@@ -145,7 +139,7 @@ func (p Pager) AllPages() (Page, error) {
 		return testPage, nil
 	}
 
-	if _, err := testPage.GetBodyAsSlice(); err != nil {
+	if _, err := testPage.GetBodyAsSlice(); err == nil {
 		var pagesSlice []interface{}
 
 		// Iterate over the pages to concatenate the bodies.
@@ -165,7 +159,7 @@ func (p Pager) AllPages() (Page, error) {
 		if err != nil {
 			return nil, err
 		}
-	} else if _, err := testPage.GetBodyAsMap(); err != nil {
+	} else if _, err := testPage.GetBodyAsMap(); err == nil {
 		var pagesSlice []interface{}
 
 		// key is the map key for the page body if the body type is `map[string]interface{}`.

--- a/pagination/single.go
+++ b/pagination/single.go
@@ -2,14 +2,23 @@ package pagination
 
 import (
 	"fmt"
-	"reflect"
-
-	"github.com/opentelekomcloud/gophertelekomcloud"
 )
 
 // SinglePageBase may be embedded in a Page that contains all the results from an operation at once.
-// Deprecated: Use client.Get directly.
+// Deprecated: use element slice as a return result.
 type SinglePageBase PageResult
+
+func (current SinglePageBase) GetBody() []byte {
+	return current.Body
+}
+
+func (current SinglePageBase) GetBodyAsSlice() ([]interface{}, error) {
+	return PageResult(current).GetBodyAsSlice()
+}
+
+func (current SinglePageBase) GetBodyAsMap() (map[string]interface{}, error) {
+	return PageResult(current).GetBodyAsMap()
+}
 
 // NextPageURL always returns "" to indicate that there are no more pages to return.
 func (current SinglePageBase) NextPageURL() (string, error) {
@@ -18,17 +27,10 @@ func (current SinglePageBase) NextPageURL() (string, error) {
 
 // IsEmpty satisfies the IsEmpty method of the Page interface
 func (current SinglePageBase) IsEmpty() (bool, error) {
-	if b, ok := current.Body.([]interface{}); ok {
-		return len(b) == 0, nil
+	body, err := current.GetBodyAsSlice()
+	if err != nil {
+		return false, fmt.Errorf("error converting page body to slice: %w", err)
 	}
-	err := golangsdk.ErrUnexpectedType{}
-	err.Expected = "[]interface{}"
-	err.Actual = fmt.Sprintf("%v", reflect.TypeOf(current.Body))
-	return true, err
-}
 
-// GetBody returns the single page's body. This method is needed to satisfy the
-// Page interface.
-func (current SinglePageBase) GetBody() interface{} {
-	return current.Body
+	return len(body) == 0, nil
 }

--- a/pagination/testing/marker_test.go
+++ b/pagination/testing/marker_test.go
@@ -67,7 +67,7 @@ func createMarkerPaged(t *testing.T) pagination.Pager {
 }
 
 func ExtractMarkerStrings(page pagination.Page) ([]string, error) {
-	content := page.(MarkerPageResult).Body.([]uint8)
+	content := page.(MarkerPageResult).Body
 	parts := strings.Split(string(content), "\n")
 	results := make([]string, 0, len(parts))
 	for _, part := range parts {

--- a/provider_client.go
+++ b/provider_client.go
@@ -2,7 +2,6 @@ package golangsdk
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -399,8 +398,7 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 	// Parse the response body as JSON, if requested to do so.
 	// TODO: When all refactoring of the extract is done, remove this.
 	if options.JSONResponse != nil && resp.StatusCode != http.StatusNoContent {
-		defer func() { _ = resp.Body.Close() }()
-		if err := json.NewDecoder(resp.Body).Decode(options.JSONResponse); err != nil {
+		if err := extract.Into(resp.Body, &options.JSONResponse); err != nil {
 			return nil, err
 		}
 	}

--- a/testing/results_test.go
+++ b/testing/results_test.go
@@ -95,18 +95,12 @@ type TestPersonWithExtensionsNamed struct {
 func TestUnmarshalAnonymousStructs(t *testing.T) {
 	var actual TestPersonWithExtensions
 
-	var dejson interface{}
 	sejson := []byte(singleResponse)
-	err := json.Unmarshal(sejson, &dejson)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	var singleResult = golangsdk.Result{
-		Body: dejson,
+		Body: sejson,
 	}
 
-	err = singleResult.ExtractIntoStructPtr(&actual, "person")
+	err := singleResult.ExtractIntoStructPtr(&actual, "person")
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "Bill unmarshalled", actual.Name)
@@ -118,18 +112,13 @@ func TestUnmarshalAnonymousStructs(t *testing.T) {
 func TestUnmarshalSliceOfAnonymousStructs(t *testing.T) {
 	var actual []TestPersonWithExtensions
 
-	var dejson interface{}
 	sejson := []byte(multiResponse)
-	err := json.Unmarshal(sejson, &dejson)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	var multiResult = golangsdk.Result{
-		Body: dejson,
+		Body: sejson,
 	}
 
-	err = multiResult.ExtractIntoSlicePtr(&actual, "people")
+	err := multiResult.ExtractIntoSlicePtr(&actual, "people")
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "Bill unmarshalled", actual[0].Name)
@@ -143,18 +132,12 @@ func TestUnmarshalSliceOfAnonymousStructs(t *testing.T) {
 func TestUnmarshalSliceofStruct(t *testing.T) {
 	var actual []TestPerson
 
-	var dejson interface{}
 	sejson := []byte(multiResponse)
-	err := json.Unmarshal(sejson, &dejson)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	var multiResult = golangsdk.Result{
-		Body: dejson,
+		Body: sejson,
 	}
 
-	err = multiResult.ExtractIntoSlicePtr(&actual, "people")
+	err := multiResult.ExtractIntoSlicePtr(&actual, "people")
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "Bill unmarshalled", actual[0].Name)
@@ -165,18 +148,13 @@ func TestUnmarshalSliceofStruct(t *testing.T) {
 func TestUnmarshalNamedStructs(t *testing.T) {
 	var actual TestPersonWithExtensionsNamed
 
-	var dejson interface{}
 	sejson := []byte(singleResponse)
-	err := json.Unmarshal(sejson, &dejson)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	var singleResult = golangsdk.Result{
-		Body: dejson,
+		Body: sejson,
 	}
 
-	err = singleResult.ExtractIntoStructPtr(&actual, "person")
+	err := singleResult.ExtractIntoStructPtr(&actual, "person")
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "", actual.TestPerson.Name)
@@ -187,18 +165,13 @@ func TestUnmarshalNamedStructs(t *testing.T) {
 func TestUnmarshalSliceOfNamedStructs(t *testing.T) {
 	var actual []TestPersonWithExtensionsNamed
 
-	var dejson interface{}
 	sejson := []byte(multiResponse)
-	err := json.Unmarshal(sejson, &dejson)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	var multiResult = golangsdk.Result{
-		Body: dejson,
+		Body: sejson,
 	}
 
-	err = multiResult.ExtractIntoSlicePtr(&actual, "people")
+	err := multiResult.ExtractIntoSlicePtr(&actual, "people")
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, "", actual[0].TestPerson.Name)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Restrict `extract` method arguments to `io.Reader`

Make `Result.Body` a byte slice

Make pagination handling less cryptic

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->
Resolves #408

### Special notes for your reviewer
The reason why `Result.Body` is `[]bytes` - we can read and unmarshall it multiple times. Readers are expected to be read once.

#### Progress:

- [x] lint passing
- [x] pagination unit tests passing
- [x] other unit tests passing (here previous implementation iterations died)
- [x] acceptance tests passing