### PR TITLE
Move building opts to `internal/build` package / Add pointer converter

### DIFF
--- a/internal/build/backward_test.go
+++ b/internal/build/backward_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Backward compatibility test.
-// Proofing we can replace deprecated methods with new ones.
+// Proving we can replace deprecated methods with new ones.
 //
 // Compare results of old methods with results of currently used methods.
 //

--- a/internal/build/backward_test.go
+++ b/internal/build/backward_test.go
@@ -1,0 +1,88 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/servers"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dns/v2/zones"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/objectstorage/v1/accounts"
+	"github.com/stretchr/testify/require"
+)
+
+// Backward compatibility test.
+// Proofing we can replace deprecated methods with new ones.
+//
+// Compare results of old methods with results of currently used methods.
+//
+// Those tests can be used as an example of replacing deprecated methods.
+
+func TestCompareQueryOpts(t *testing.T) {
+	listOpts := &servers.ListOpts{
+		ChangesSince: "2012-06-12",
+		Image:        "some-random-image",
+		Flavor:       "top-flavor",
+		Limit:        64,
+		AllTenants:   true,
+	}
+
+	expected, err := listOpts.ToServerListQuery()
+	require.NoError(t, err)
+
+	actual, err := QueryString(listOpts)
+	require.NoError(t, err)
+
+	require.EqualValues(t, expected, actual.String()) // inside ToServerListQuery `.String()` for URL is called
+}
+
+func TestCompareHeaderOpts(t *testing.T) {
+	headerOpts := &accounts.UpdateOpts{
+		ContentType:       "application/lolson",
+		DetectContentType: true,
+		TempURLKey:        "key1",
+		TempURLKey2:       "key2",
+	}
+
+	expected, err := headerOpts.ToAccountUpdateMap()
+	require.NoError(t, err)
+
+	actual, err := Headers(headerOpts)
+	require.NoError(t, err)
+
+	require.EqualValues(t, expected, actual)
+}
+
+func TestCompareRequestBodyOpts(t *testing.T) {
+	bodyOpts := &zones.CreateOpts{
+		Email:       "mail@me.plz",
+		Description: "email here",
+		Name:        "this is a name",
+		TTL:         1600,
+		ZoneType:    "TYPE1",
+		Router: &zones.RouterOpts{
+			RouterID:     "1a23d5a8-1027-4b82-96a2-780b945fa294",
+			RouterRegion: "nord",
+		},
+		Tags: []tags.ResourceTag{
+			{
+				Key:   "Foo",
+				Value: "Bar",
+			},
+		},
+	}
+
+	expected, err := bodyOpts.ToZoneCreateMap()
+	require.NoError(t, err)
+
+	expectedJSON, err := extract.JsonMarshal(expected)
+	require.NoError(t, err)
+
+	actual, err := RequestBody(bodyOpts, "")
+	require.NoError(t, err)
+
+	actualJSON, err := extract.JsonMarshal(actual)
+	require.NoError(t, err)
+
+	require.JSONEq(t, string(expectedJSON), string(actualJSON))
+}

--- a/internal/build/doc.go
+++ b/internal/build/doc.go
@@ -1,0 +1,4 @@
+/*
+Package build contains internal methods for building request parts: query string, headers, body.
+*/
+package build

--- a/internal/build/errs.go
+++ b/internal/build/errs.go
@@ -1,0 +1,7 @@
+package build
+
+import "errors"
+
+// ErrNilOpts used to be returned in case opts passed are nil.
+// This can be expected in some cases.
+var ErrNilOpts = errors.New("nil options provided")

--- a/internal/build/headers.go
+++ b/internal/build/headers.go
@@ -1,0 +1,106 @@
+package build
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/multierr"
+)
+
+/*
+Headers is an internal function to be used by request methods in
+individual resource packages.
+
+It accepts an arbitrary tagged structure and produces a string map that's
+suitable for use as the HTTP headers of an outgoing request. Field names are
+mapped to header names based in "h" tags.
+
+	type struct QueryStruct {
+	  Bar string `h:"x_bar"`
+	  Baz int    `h:"lorem_ipsum"`
+	}
+
+	instance := QueryStruct{
+	  Bar: "AAA",
+	  Baz: "BBB",
+	}
+
+will be converted into:
+
+	map[string]string{
+	  "x_bar": "AAA",
+	  "lorem_ipsum": "BBB",
+	}
+
+Untagged fields and fields left at their zero values are skipped. Integers,
+booleans and string values are supported.
+*/
+func Headers(opts interface{}) (map[string]string, error) {
+	if opts == nil {
+		return nil, fmt.Errorf("error building headers: %w", ErrNilOpts)
+	}
+
+	optsValue := reflect.ValueOf(opts)
+	if optsValue.Kind() == reflect.Ptr {
+		optsValue = optsValue.Elem()
+	}
+
+	optsType := reflect.TypeOf(opts)
+	if optsType.Kind() == reflect.Ptr {
+		optsType = optsType.Elem()
+	}
+
+	if optsValue.Kind() != reflect.Struct {
+		// Return an error if the underlying type of 'opts' isn't a struct.
+		return nil, fmt.Errorf("error building headers: options type is not a struct")
+	}
+
+	mErr := multierr.MultiError{}
+	result := make(map[string]string)
+
+	for i := 0; i < optsValue.NumField(); i++ {
+		value := optsValue.Field(i)
+		field := optsType.Field(i)
+
+		headerName := field.Tag.Get("h")
+		if headerName == "" {
+			continue
+		}
+
+		if value.IsZero() {
+			// We duplicate the check from ValidateTags to avoid double reflect package usage
+			// TODO: investigate performance difference when using ValidateTags
+			if structFieldRequired(field) {
+				mErr = append(mErr, fmt.Errorf("required header [%s] not set", field.Name))
+			}
+			continue
+		}
+
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+
+		var headerValue string
+
+		// if the field is set, add it to the slice of query pieces
+		switch value.Kind() {
+		case reflect.String:
+			headerValue = value.String()
+		case reflect.Int, reflect.Int32, reflect.Int64:
+			headerValue = strconv.FormatInt(value.Int(), 10)
+		case reflect.Bool:
+			headerValue = strconv.FormatBool(value.Bool())
+		default:
+			mErr = append(mErr, fmt.Errorf("value of unsupported type %s", value.Type()))
+		}
+
+		result[headerName] = headerValue
+	}
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return nil, fmt.Errorf("error building headers: %w", err)
+	}
+
+	return result, nil
+}

--- a/internal/build/headers_test.go
+++ b/internal/build/headers_test.go
@@ -1,0 +1,89 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	"github.com/stretchr/testify/require"
+)
+
+type HeadersStruct struct {
+	Bar    string `h:"x_bar" required:"true"`
+	Baz    int    `h:"lorem_ipsum"`
+	Boop   *bool  `h:"boop"`
+	Foo    []int  `h:"foo"`
+	SkipMe string
+}
+
+func TestHeaders_ok(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		opts     *HeadersStruct
+		expected map[string]string
+	}{
+		"simple": {
+			&HeadersStruct{
+				Bar:    "bar",
+				Baz:    67,
+				Boop:   pointerto.Bool(false),
+				SkipMe: "skipping",
+			},
+			map[string]string{
+				"x_bar":       "bar",
+				"lorem_ipsum": "67",
+				"boop":        "false",
+			},
+		},
+	}
+
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			data := data
+
+			t.Parallel()
+
+			headers, err := Headers(data.opts)
+			require.NoError(t, err)
+			require.EqualValues(t, data.expected, headers)
+		})
+	}
+}
+
+func TestHeaders_notOk(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		opts   interface{}
+		errMsg string
+	}{
+		"nil": {
+			nil,
+			"error building headers: nil options provided",
+		},
+		"not_struct": {
+			map[string]interface{}{},
+			"error building headers: options type is not a struct",
+		},
+		"no_required": {
+			&HeadersStruct{},
+			"error building headers: required header [Bar] not set",
+		},
+		"unsupported_type": {
+			&HeadersStruct{Bar: "1", Foo: []int{1, 2}},
+			"error building headers: value of unsupported type []int",
+		},
+	}
+
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			data := data
+
+			t.Parallel()
+
+			_, err := Headers(data.opts)
+			require.Error(t, err)
+			require.EqualError(t, err, data.errMsg)
+		})
+	}
+}

--- a/internal/build/query_string.go
+++ b/internal/build/query_string.go
@@ -1,0 +1,127 @@
+package build
+
+import (
+	"fmt"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/multierr"
+)
+
+/*
+QueryString is an internal function to be used by request methods in
+individual resource packages.
+
+It accepts a tagged structure and expands it into a URL struct. Field names are
+converted into query parameters based on a "q" tag. For example:
+
+	type QueryStruct struct {
+	   Bar string `q:"x_bar"`
+	   Baz int    `q:"lorem_ipsum"`
+	}
+
+	instance := QueryStruct{
+	   Bar: "AAA",
+	   Baz: "BBB",
+	}
+
+will be converted into "?x_bar=AAA&lorem_ipsum=BBB".
+
+The struct's fields may be strings, integers, or boolean values. Fields left at
+their type's zero value will be omitted from the query.
+*/
+func QueryString(opts interface{}) (*url.URL, error) {
+	if opts == nil {
+		return nil, fmt.Errorf("error building query string: %w", ErrNilOpts)
+	}
+
+	optsValue := reflect.ValueOf(opts)
+	if optsValue.Kind() == reflect.Ptr {
+		optsValue = optsValue.Elem()
+	}
+
+	optsType := reflect.TypeOf(opts)
+	if optsType.Kind() == reflect.Ptr {
+		optsType = optsType.Elem()
+	}
+
+	params := url.Values{}
+
+	if optsValue.Kind() != reflect.Struct {
+		// Return an error if the underlying type of 'opts' isn't a struct.
+		return nil, fmt.Errorf("error building query string: options type is not a struct")
+	}
+
+	mErr := multierr.MultiError{}
+
+	for i := 0; i < optsValue.NumField(); i++ {
+		v := optsValue.Field(i)
+		field := optsType.Field(i)
+
+		// Otherwise, the field is not set.
+		// We duplicate the check from ValidateTags to avoid double reflect package usage
+		// TODO: investigate performance difference when using ValidateTags
+		if v.IsZero() {
+			if structFieldRequired(field) {
+				// And the field is required. Return an error.
+				mErr = append(mErr, fmt.Errorf("required query parameter [%s] not set", field.Name))
+			}
+			continue // skip empty fields
+		}
+
+		if v.Kind() == reflect.Ptr {
+			v = v.Elem()
+		}
+
+		// if the field is set, add it to the slice of query pieces
+		qTag := field.Tag.Get("q")
+
+		// if the field has a 'q' tag, it goes in the query string
+		if qTag == "" {
+			continue
+		}
+
+		tags := strings.Split(qTag, ",")
+
+		switch v.Kind() {
+		case reflect.String:
+			params.Add(tags[0], v.String())
+		case reflect.Int, reflect.Int32, reflect.Int64:
+			params.Add(tags[0], strconv.FormatInt(v.Int(), 10))
+		case reflect.Bool:
+			params.Add(tags[0], strconv.FormatBool(v.Bool()))
+		case reflect.Slice:
+			switch v.Type().Elem() {
+			case reflect.TypeOf(0):
+				for i := 0; i < v.Len(); i++ {
+					params.Add(tags[0], strconv.FormatInt(v.Index(i).Int(), 10))
+				}
+			default:
+				for i := 0; i < v.Len(); i++ {
+					params.Add(tags[0], v.Index(i).String())
+				}
+			}
+		case reflect.Map:
+			keyKind := v.Type().Key().Kind()
+			valueKind := v.Type().Elem().Kind()
+			if keyKind == reflect.String && valueKind == reflect.String {
+				var s []string
+				for _, k := range v.MapKeys() {
+					value := v.MapIndex(k).String()
+					s = append(s, fmt.Sprintf("'%s':'%s'", k.String(), value))
+				}
+				params.Add(tags[0], fmt.Sprintf("{%s}", strings.Join(s, ", ")))
+			} else {
+				mErr = append(mErr, fmt.Errorf("expected map[string]string, got map[%s]%s", keyKind, valueKind))
+			}
+		}
+	}
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return nil, fmt.Errorf("error building query string: %w", err)
+	}
+
+	return &url.URL{RawQuery: params.Encode()}, nil
+}

--- a/internal/build/query_string_test.go
+++ b/internal/build/query_string_test.go
@@ -1,0 +1,111 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	"github.com/stretchr/testify/require"
+)
+
+type QueryStruct struct {
+	Bar     string            `q:"x_bar" required:"true"`
+	Baz     int               `q:"lorem_ipsum"`
+	Foo     []int             `q:"foo"`
+	FooStr  []string          `q:"foostr"`
+	Map1    map[string]string `q:"map"`
+	Map2    map[string]int    `q:"map_invalid"` // not supported
+	Req     *bool             `q:"req"`
+	NotHere string
+}
+
+func TestQueryString_ok(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		opts     *QueryStruct
+		expected string
+	}{
+		"simple": {
+			&QueryStruct{
+				Bar:     "AAA",
+				Baz:     200,
+				Req:     pointerto.Bool(false),
+				NotHere: "no",
+			},
+			"?lorem_ipsum=200&req=false&x_bar=AAA",
+		},
+		"with_int_slice": {
+			&QueryStruct{
+				Bar: "AAA",
+				Foo: []int{1, 2, 3},
+			},
+			"?foo=1&foo=2&foo=3&x_bar=AAA",
+		},
+		"with_str_slice": {
+			&QueryStruct{
+				Bar:    "AAA",
+				FooStr: []string{"a", "b"},
+			},
+			"?foostr=a&foostr=b&x_bar=AAA",
+		},
+		"with_str_map": {
+			&QueryStruct{
+				Bar:  "AAA",
+				Map1: map[string]string{"foo": "bar"},
+			},
+			"?map=%7B%27foo%27%3A%27bar%27%7D&x_bar=AAA",
+		},
+	}
+
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			data := data
+
+			t.Parallel()
+
+			query, err := QueryString(data.opts)
+
+			require.NoError(t, err)
+			require.EqualValues(t, data.expected, query.String())
+		})
+	}
+}
+
+func TestQueryString_notOk(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		opts   interface{}
+		errMsg string
+	}{
+		"nil opts": {
+			nil,
+			"error building query string: nil options provided",
+		},
+		"missing_required": {
+			&QueryStruct{},
+			"error building query string: required query parameter [Bar] not set",
+		},
+		"not_struct": {
+			map[string]interface{}{},
+			"error building query string: options type is not a struct",
+		},
+		"with_non_str_map": {
+			&QueryStruct{Bar: "1", Map2: map[string]int{"foo": 1}},
+			"error building query string: expected map[string]string, got map[string]int",
+		},
+	}
+
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			data := data
+
+			t.Parallel()
+
+			_, err := QueryString(data.opts)
+
+			require.Error(t, err)
+			require.EqualError(t, err, data.errMsg)
+		})
+	}
+}

--- a/internal/build/request_body.go
+++ b/internal/build/request_body.go
@@ -1,0 +1,71 @@
+package build
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Body wraps original request data providing root tag support.
+//
+// Example:
+//
+//	wrapped := structure {
+//		Field string `json:"field"`
+//	} {"data"}
+//
+//	Body{
+//		RootTag: "root",
+//		Wrapped: wrapped,
+//	}
+//
+// Will produce the following json:
+//
+//	{
+//	  "root": {"field": "data"}
+//	}
+type Body struct {
+	RootTag string
+	Wrapped interface{}
+}
+
+// prepared returns request body, wrapped into a root tag, if required.
+func (r Body) prepared() interface{} {
+	if r.RootTag == "" {
+		return r.Wrapped
+	}
+
+	return map[string]interface{}{
+		r.RootTag: r.Wrapped,
+	}
+}
+
+// MarshalJSON satisfies json.Marshaler interface.
+func (r Body) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.prepared())
+}
+
+// String allows simple pretty-print of prepared value.
+func (r Body) String() string {
+	jsonData, err := json.MarshalIndent(r.prepared(), "", "  ")
+	if err != nil {
+		return fmt.Sprintf("!err: %s", err.Error())
+	}
+
+	return string(jsonData)
+}
+
+// RequestBody validates given structure by its tags and build the body ready to be marshalled to the JSON.
+func RequestBody(opts interface{}, parent string) (*Body, error) {
+	if opts == nil {
+		return nil, fmt.Errorf("error building request body: %w", ErrNilOpts)
+	}
+
+	if err := ValidateTags(opts); err != nil {
+		return nil, fmt.Errorf("error building request body: %w", err)
+	}
+
+	return &Body{
+		RootTag: parent,
+		Wrapped: opts,
+	}, nil
+}

--- a/internal/build/request_body_test.go
+++ b/internal/build/request_body_test.go
@@ -2,7 +2,6 @@ package build
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
@@ -106,7 +105,7 @@ func TestRequestBody_String(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			require.Equal(t, data.expected, fmt.Sprintf("%s", data.requestBody))
+			require.Equal(t, data.expected, data.requestBody.String())
 		})
 	}
 }
@@ -115,7 +114,7 @@ func TestRequestBody_String_Err(t *testing.T) {
 	t.Parallel()
 
 	body := Body{Wrapped: complex(float64(1), float64(2))}
-	require.Equal(t, "!err: json: unsupported type: complex128", fmt.Sprintf("%s", body))
+	require.Equal(t, "!err: json: unsupported type: complex128", body.String())
 }
 
 func TestBuildRequestBody(t *testing.T) {

--- a/internal/build/request_body_test.go
+++ b/internal/build/request_body_test.go
@@ -1,0 +1,147 @@
+package build
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	"github.com/stretchr/testify/require"
+)
+
+type testStruct struct {
+	Data string `json:"data"`
+}
+
+type testStructWPtr struct {
+	Data *string `json:"data"`
+}
+
+func TestRequestBody_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		body     Body
+		expected string
+	}{
+		"int_slice": {
+			Body{
+				Wrapped: []int{1, 2, 3},
+			},
+			"[1, 2, 3]",
+		},
+		"int_slice_wrapped": {
+			Body{
+				RootTag: "items",
+				Wrapped: []int{1, 2, 3},
+			},
+			`{"items": [1, 2, 3]}`,
+		},
+		"struct": {
+			Body{
+				RootTag: "",
+				Wrapped: &testStruct{Data: "123"},
+			},
+			`{"data": "123"}`,
+		},
+		"struct_wrapped": {
+			Body{
+				RootTag: "root",
+				Wrapped: &testStruct{Data: "123"},
+			},
+			`{"root": {"data": "123"}}`,
+		},
+		"struct_w_pointer_field": {
+			Body{
+				RootTag: "",
+				Wrapped: testStructWPtr{Data: pointerto.String("123")},
+			},
+			`{"data": "123"}`,
+		},
+		"struct_w_pointer_field_wrapped": {
+			Body{
+				RootTag: "root",
+				Wrapped: testStructWPtr{Data: pointerto.String("123")},
+			},
+			`{"root": {"data": "123"}}`,
+		},
+	}
+
+	for name, data := range cases {
+		data := data
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := json.Marshal(data.body)
+			require.NoError(t, err)
+
+			require.JSONEq(t, data.expected, string(actual))
+		})
+	}
+}
+
+func TestRequestBody_String(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		requestBody Body
+		expected    string
+	}{
+		"simple": {
+			Body{Wrapped: "data"},
+			`"data"`,
+		},
+		"with_parent": {
+			Body{Wrapped: "data", RootTag: "root"},
+			`{
+  "root": "data"
+}`,
+		},
+	}
+
+	for name, data := range cases {
+		data := data
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, data.expected, fmt.Sprintf("%s", data.requestBody))
+		})
+	}
+}
+
+func TestRequestBody_String_Err(t *testing.T) {
+	t.Parallel()
+
+	body := Body{Wrapped: complex(float64(1), float64(2))}
+	require.Equal(t, "!err: json: unsupported type: complex128", fmt.Sprintf("%s", body))
+}
+
+func TestBuildRequestBody(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ok", func(t *testing.T) {
+		source := testStruct{"data"}
+
+		expected := &Body{
+			Wrapped: source,
+		}
+
+		actual, err := RequestBody(source, "")
+		require.NoError(t, err)
+		require.EqualValues(t, expected, actual)
+	})
+
+	t.Run("validation_fail", func(t *testing.T) {
+		source := testStructRequired{}
+
+		_, err := RequestBody(source, "")
+		require.EqualError(t, err, "error building request body: missing input for argument [Field]")
+	})
+
+	t.Run("nil_body", func(t *testing.T) {
+		_, err := RequestBody(nil, "")
+		require.EqualError(t, err, "error building request body: nil options provided")
+	})
+}

--- a/internal/build/tags.go
+++ b/internal/build/tags.go
@@ -1,0 +1,98 @@
+package build
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/multierr"
+)
+
+type fieldValue struct {
+	// Name of the field in the type.
+	Name string
+	// Value of the field in the structure.
+	Value reflect.Value
+	// `required` tag value.
+	TagRequired bool
+	// `xor` tag value.
+	TagXOR string
+	// `or` tag value.
+	TagOR string
+}
+
+// ValidateTags validating structure by tags.
+//
+// Supported validations:
+//
+//	required (`required:"true"`)  - mark field required, returns error if it is empty.
+//	or:      (`or:"OtherField"`)  - requires at least one field to be not empty.
+//	xor:     (`xor:"OtherField"`) - requires exactly of this and the other field to be set.
+func ValidateTags(opts interface{}) error {
+	if opts == nil {
+		return nil // nil is an ideal value
+	}
+
+	optsValue := reflect.ValueOf(opts)
+	if optsValue.Kind() == reflect.Ptr {
+		optsValue = optsValue.Elem()
+	}
+
+	optsType := reflect.TypeOf(opts)
+	if optsType.Kind() == reflect.Ptr {
+		optsType = optsType.Elem()
+	}
+
+	fields := make(map[string]fieldValue)
+
+	if optsValue.Kind() != reflect.Struct {
+		return nil // no need to go deep
+	}
+
+	// fill the structure fields map
+	for i := 0; i < optsValue.NumField(); i++ {
+		value := optsValue.Field(i)
+		field := optsType.Field(i)
+
+		fields[field.Name] = fieldValue{
+			Name:        field.Name,
+			Value:       value,
+			TagRequired: structFieldRequired(field),
+			TagXOR:      field.Tag.Get("xor"),
+			TagOR:       field.Tag.Get("or"),
+		}
+	}
+
+	errors := multierr.MultiError{}
+
+	for name, field := range fields {
+		fieldErrors := make([]error, 0)
+
+		if field.TagRequired && field.Value.IsZero() {
+			fieldErrors = append(fieldErrors,
+				fmt.Errorf("missing input for argument [%s]", name),
+			)
+		}
+
+		orField := field.TagOR
+		if orField != "" && field.Value.IsZero() && fields[orField].Value.IsZero() {
+			fieldErrors = append(fieldErrors,
+				fmt.Errorf("at least one of %s and %s must be provided", name, orField),
+			)
+		}
+
+		xorField := field.TagXOR
+		if xorField != "" && (field.Value.IsZero() == fields[xorField].Value.IsZero()) {
+			fieldErrors = append(fieldErrors,
+				fmt.Errorf("exactly one of %s and %s must be provided", name, xorField),
+			)
+		}
+
+		errors = append(errors, fieldErrors...)
+	}
+
+	return errors.ErrorOrNil()
+}
+
+func structFieldRequired(field reflect.StructField) bool {
+	return field.Tag.Get("required") == "true"
+}

--- a/internal/build/tags_test.go
+++ b/internal/build/tags_test.go
@@ -1,0 +1,204 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateTags_nil(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ValidateTags(nil))
+}
+
+func TestValidateTags_notStruct(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ValidateTags("data"))
+}
+
+type testStructRequired struct {
+	Field string `json:"field" required:"true"`
+}
+
+type testStructRequiredPtrField struct {
+	Field *string `json:"field" required:"true"`
+}
+
+func TestValidateTags_required(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+
+		cases := map[string]interface{}{
+			"simple":                     testStructRequired{"data"},
+			"pointer_struct":             &testStructRequired{"data"},
+			"pointer_value":              testStructRequiredPtrField{pointerto.String("data")},
+			"pointer_value_empty_string": testStructRequiredPtrField{pointerto.String("")},
+		}
+
+		for name, data := range cases {
+			data := data
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				require.NoError(t, ValidateTags(data))
+			})
+		}
+	})
+
+	t.Run("not_ok", func(t *testing.T) {
+		t.Parallel()
+
+		cases := map[string]interface{}{
+			"simple":                     testStructRequired{},
+			"pointer_struct":             &testStructRequired{},
+			"pointer_value":              testStructRequiredPtrField{},
+			"pointer_value_empty_string": &testStructRequiredPtrField{},
+		}
+
+		for name, data := range cases {
+			data := data
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				require.EqualError(t, ValidateTags(data), "missing input for argument [Field]")
+			})
+		}
+	})
+
+}
+
+type testStructOr struct {
+	Field1 string `json:"field1" or:"Field2"`
+	Field2 string `json:"field2" or:"Field1"`
+}
+
+type testStructOrPtrField struct {
+	Field1 *string `json:"field1" or:"Field2"`
+	Field2 *string `json:"field2" or:"Field1"`
+}
+
+func TestValidateTags_or(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ok", func(t *testing.T) {
+		// pair-wise testing :D
+		cases := map[string]interface{}{
+			"simple_one":                 testStructOr{"data", ""},
+			"simple_both":                testStructOr{"data1", "data2"},
+			"pointer_struct":             &testStructOr{"", "data"},
+			"pointer_value":              testStructOrPtrField{nil, pointerto.String("data")},
+			"pointer_value_empty_string": &testStructOrPtrField{pointerto.String(""), nil},
+		}
+
+		for name, data := range cases {
+			data := data
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				require.NoError(t, ValidateTags(data))
+			})
+		}
+	})
+
+	t.Run("not_ok", func(t *testing.T) {
+		cases := map[string]interface{}{
+			"simple":                     testStructOr{},
+			"pointer_struct":             &testStructOr{},
+			"pointer_value":              testStructOrPtrField{},
+			"pointer_value_empty_string": &testStructOrPtrField{},
+		}
+
+		for name, data := range cases {
+			data := data
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				err := ValidateTags(data)
+				require.NotNil(t, err)
+
+				errText := err.Error()
+				require.Contains(t, errText, `multiple errors returned:`)
+				require.Contains(t, errText, `at least one of Field1 and Field2 must be provided`)
+				require.Contains(t, errText, `at least one of Field2 and Field1 must be provided`)
+			})
+		}
+	})
+}
+
+type testStructXor struct {
+	Field1 string `json:"field1" xor:"Field2"`
+	Field2 string `json:"field2" xor:"Field1"`
+}
+
+type testStructXorPtrField struct {
+	Field1 *string `json:"field1" xor:"Field2"`
+	Field2 *string `json:"field2" xor:"Field1"`
+}
+
+func TestValidateTags_xor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ok", func(t *testing.T) {
+		cases := map[string]interface{}{
+			"simple":                     testStructXor{"data", ""},
+			"pointer_struct":             &testStructXor{"", "data"},
+			"pointer_value":              testStructXorPtrField{nil, pointerto.String("data")},
+			"pointer_value_empty_string": &testStructXorPtrField{pointerto.String(""), nil},
+		}
+
+		for name, data := range cases {
+			data := data
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				require.NoError(t, ValidateTags(data))
+			})
+		}
+	})
+
+	t.Run("neither", func(t *testing.T) {
+		cases := map[string]interface{}{
+			"simple":                     testStructXor{},
+			"pointer_struct":             &testStructXor{},
+			"pointer_value":              testStructXorPtrField{},
+			"pointer_value_empty_string": &testStructXorPtrField{},
+		}
+
+		for name, data := range cases {
+			data := data
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				err := ValidateTags(data)
+				require.NotNil(t, err)
+
+				errText := err.Error()
+				require.Contains(t, errText, `multiple errors returned:`)
+				require.Contains(t, errText, `exactly one of Field1 and Field2 must be provided`)
+				require.Contains(t, errText, `exactly one of Field2 and Field1 must be provided`)
+			})
+		}
+	})
+
+	t.Run("both", func(t *testing.T) {
+		cases := map[string]interface{}{
+			"simple":                     testStructXor{"data1", "data2"},
+			"pointer_struct":             &testStructXor{"data1", "data2"},
+			"pointer_value":              testStructXorPtrField{pointerto.String(""), pointerto.String("")},
+			"pointer_value_empty_string": &testStructXorPtrField{pointerto.String(""), pointerto.String("")},
+		}
+
+		for name, data := range cases {
+			data := data
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				err := ValidateTags(data)
+				require.NotNil(t, err)
+
+				errText := err.Error()
+				require.Contains(t, errText, `multiple errors returned:`)
+				require.Contains(t, errText, `exactly one of Field1 and Field2 must be provided`)
+				require.Contains(t, errText, `exactly one of Field2 and Field1 must be provided`)
+			})
+		}
+	})
+}

--- a/internal/multierr/multierr.go
+++ b/internal/multierr/multierr.go
@@ -1,0 +1,57 @@
+// Package multierr contains simple implementation of multiple error handling.
+// Inspired by https://github.com/hashicorp/go-multierror.
+package multierr
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// MultiError is container for multiple errors.
+type MultiError []error
+
+// Error returns an error message.
+func (m MultiError) Error() string {
+	errorMessages := make([]string, 0, len(m))
+
+	for _, err := range m {
+		// can contain nil errors
+		if err != nil {
+			errorMessages = append(errorMessages, err.Error())
+		}
+	}
+
+	switch len(errorMessages) {
+	case 0:
+		return ""
+	case 1:
+		return errorMessages[0]
+	default:
+		return fmt.Sprintf("multiple errors returned:\n\t%s", strings.Join(errorMessages, ",\n\t"))
+	}
+}
+
+// ErrorOrNil returns nil in case there are no errors inside.
+func (m MultiError) ErrorOrNil() error {
+	if m.Error() == "" {
+		return nil
+	}
+
+	return m
+}
+
+// Is validates whenever any of included errors Is target error.
+func (m MultiError) Is(target error) bool {
+	if target == nil {
+		return false
+	}
+
+	for _, err := range m {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/openstack/common/pointerto/doc.go
+++ b/openstack/common/pointerto/doc.go
@@ -1,0 +1,6 @@
+/*
+Package pointerto provides functions for simple pointer wrapping: type -> *type.
+
+After moving to Go 1.18+ this should be replaced (with deprecation) with a single generic function.
+*/
+package pointerto

--- a/openstack/common/pointerto/pointers.go
+++ b/openstack/common/pointerto/pointers.go
@@ -1,0 +1,16 @@
+package pointerto
+
+// Int returns pointer to given int value.
+func Int(src int) *int {
+	return &src
+}
+
+// String returns pointer to given string value.
+func String(src string) *string {
+	return &src
+}
+
+// Bool returns pointer to given bool value.
+func Bool(src bool) *bool {
+	return &src
+}

--- a/openstack/common/pointerto/pointers_test.go
+++ b/openstack/common/pointerto/pointers_test.go
@@ -1,0 +1,31 @@
+package pointerto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBool(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []bool{true, false} {
+		require.EqualValues(t, value, *Bool(value))
+	}
+}
+
+func TestString(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"", "info"} {
+		require.EqualValues(t, value, *String(value))
+	}
+}
+
+func TestInt(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []int{0, 0xff} {
+		require.EqualValues(t, value, *Int(value))
+	}
+}

--- a/params.go
+++ b/params.go
@@ -13,19 +13,23 @@ import (
 /*
 BuildRequestBody builds a map[string]interface from the given `struct`. If
 parent is not an empty string, the final map[string]interface returned will
-encapsulate the built one. For example:
+encapsulate the built one.
 
-  disk := 1
-  createOpts := flavors.CreateOpts{
-    ID:         "1",
-    Name:       "m1.tiny",
-    Disk:       &disk,
-    RAM:        512,
-    VCPUs:      1,
-    RxTxFactor: 1.0,
-  }
+Deprecated: use `internal/params.BuildRequestBody` instead.
 
-  body, err := golangsdk.BuildRequestBody(createOpts, "flavor")
+For example:
+
+	disk := 1
+	createOpts := flavors.CreateOpts{
+	  ID:         "1",
+	  Name:       "m1.tiny",
+	  Disk:       &disk,
+	  RAM:        512,
+	  VCPUs:      1,
+	  RxTxFactor: 1.0,
+	}
+
+	body, err := golangsdk.BuildRequestBody(createOpts, "flavor")
 
 The above example can be run as-is, however it is recommended to look at how
 BuildRequestBody is used within Gophercloud to more fully understand how it
@@ -172,14 +176,18 @@ func BuildRequestBody(opts interface{}, parent string) (map[string]interface{}, 
 // EnabledState is a convenience type, mostly used in Create and Update
 // operations. Because the zero value of a bool is FALSE, we need to use a
 // pointer instead to indicate zero-ness.
+// Deprecated, use pointerto.Bool instead
 type EnabledState *bool
 
 // Convenience vars for EnabledState values.
+// Deprecated: use `pointerto.Bool` instead.
 var (
 	iTrue  = true
 	iFalse = false
 
-	Enabled  EnabledState = &iTrue
+	// Enabled is a pointer to `true`.
+	Enabled EnabledState = &iTrue
+	// Disabled is a pointer to `false`.
 	Disabled EnabledState = &iFalse
 )
 
@@ -196,6 +204,7 @@ const (
 
 // IntToPointer is a function for converting integers into integer pointers.
 // This is useful when passing in options to operations.
+// Deprecated: use `pointerto.Int` instead.
 func IntToPointer(i int) *int {
 	return &i
 }
@@ -208,6 +217,8 @@ It takes a string that might be a zero value and returns either a pointer to its
 address or nil. This is useful for allowing users to conveniently omit values
 from an options struct by leaving them zeroed, but still pass nil to the JSON
 serializer so they'll be omitted from the request body.
+
+Deprecated
 */
 func MaybeString(original string) *string {
 	if original != "" {
@@ -223,6 +234,8 @@ resource packages.
 Like MaybeString, it accepts an int that may or may not be a zero value, and
 returns either a pointer to its address or nil. It's intended to hint that the
 JSON serializer should omit its field.
+
+Deprecated
 */
 func MaybeInt(original int) *int {
 	if original != 0 {
@@ -231,19 +244,9 @@ func MaybeInt(original int) *int {
 	return nil
 }
 
-/*
-func isUnderlyingStructZero(v reflect.Value) bool {
-	switch v.Kind() {
-	case reflect.Ptr:
-		return isUnderlyingStructZero(v.Elem())
-	default:
-		return isZero(v)
-	}
-}
-*/
-
 var t time.Time
 
+// isZero checks if given argument has default type value.
 func isZero(v reflect.Value) bool {
 	// fmt.Printf("\n\nchecking isZero for value: %+v\n", v)
 	switch v.Kind() {
@@ -379,22 +382,22 @@ It accepts an arbitrary tagged structure and produces a string map that's
 suitable for use as the HTTP headers of an outgoing request. Field names are
 mapped to header names based in "h" tags.
 
-  type struct Something {
-    Bar string `h:"x_bar"`
-    Baz int    `h:"lorem_ipsum"`
-  }
+	type struct Something {
+	  Bar string `h:"x_bar"`
+	  Baz int    `h:"lorem_ipsum"`
+	}
 
-  instance := Something{
-    Bar: "AAA",
-    Baz: "BBB",
-  }
+	instance := Something{
+	  Bar: "AAA",
+	  Baz: "BBB",
+	}
 
 will be converted into:
 
-  map[string]string{
-    "x_bar": "AAA",
-    "lorem_ipsum": "BBB",
-  }
+	map[string]string{
+	  "x_bar": "AAA",
+	  "lorem_ipsum": "BBB",
+	}
 
 Untagged fields and fields left at their zero values are skipped. Integers,
 booleans and string values are supported.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Deprecate methods for building request bodies, query strings, headers in `golangsdk` package
Move them to `internal/build` package

Add helper package `common/pointerto`

Add helper `internal/multierr` package for handling multiple errors

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->
Part of #419 
Resolve #294

### Special notes for your reviewer

Current SDK methods are not affected.
