### PR TITLE
[VPCEP]: parameter type change after v2.0

### DIFF
--- a/openstack/vpcep/v1/endpoints/results.go
+++ b/openstack/vpcep/v1/endpoints/results.go
@@ -37,7 +37,7 @@ type Endpoint struct {
 	// Specifies the domain status.
 	//    frozen: indicates that the domain is frozen.
 	//    active: indicates that the domain is normal.
-	ActiveStatus string `json:"active_status"`
+	ActiveStatus []string `json:"active_status"`
 
 	// Specifies the ID of the VPC where the VPC endpoint is to be created.
 	RouterID string `json:"vpc_id"`

--- a/openstack/vpcep/v1/endpoints/testing/fixtures.go
+++ b/openstack/vpcep/v1/endpoints/testing/fixtures.go
@@ -51,7 +51,9 @@ const (
       "status": "accepted",
       "ip": "192.168.0.232",
       "marker_id": 16777337,
-      "active_status": "active",
+      "active_status": [
+		"active"
+	  ],
       "vpc_id": "84758cf5-9c62-43ae-a778-3dbd8370c0a4",
       "service_type": "interface",
       "project_id": "295dacf46a4842fcbf7844dc2dc2489d",
@@ -78,7 +80,9 @@ const (
       "status": "accepted",
       "ip": "192.168.0.115",
       "marker_id": 16777322,
-      "active_status": "active",
+      "active_status": [
+		"active"
+	  ],
       "vpc_id": "84758cf5-9c62-43ae-a778-3dbd8370c0a4",
       "service_type": "interface",
       "project_id": "295dacf46a4842fcbf7844dc2dc2489d",


### PR DESCRIPTION
### What this PR does / why we need it
After ``VPCEP v2.0`` release one parameter type has changed.
Issue can be checked here:
https://jira.tsi-dev.otc-service.com/browse/ONS-9581

### Which issue this PR fixes
PR fixes normal JSON unmarshall for VPCEP after service update.

### Acceptance tests
```
=== RUN   TestEndpointLifecycle
=== PAUSE TestEndpointLifecycle
=== CONT  TestEndpointLifecycle
--- PASS: TestEndpointLifecycle (14.82s)
PASS

Process finished with the exit code 0
```