### PR TITLE
[AS] API Updated

### DIFF
--- a/acceptance/openstack/autoscaling/helpers.go
+++ b/acceptance/openstack/autoscaling/helpers.go
@@ -38,7 +38,9 @@ func CreateAutoScalingGroup(t *testing.T, client *golangsdk.ServiceClient, netwo
 
 func DeleteAutoScalingGroup(t *testing.T, client *golangsdk.ServiceClient, groupID string) {
 	t.Logf("Attempting to delete AutoScaling Group")
-	err := groups.Delete(client, groupID)
+	err := groups.Delete(client, groups.DeleteOpts{
+		ScalingGroupId: groupID,
+	})
 	th.AssertNoErr(t, err)
 	t.Logf("Deleted AutoScaling Group: %s", groupID)
 }

--- a/acceptance/openstack/autoscaling/helpers.go
+++ b/acceptance/openstack/autoscaling/helpers.go
@@ -5,13 +5,14 @@ import (
 
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v1/configurations"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v1/groups"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
 
 func CreateAutoScalingGroup(t *testing.T, client *golangsdk.ServiceClient, networkID, vpcID, asName string) string {
 	defaultSGID := openstack.DefaultSecurityGroup(t)
-	deletePublicIP := true
 
 	createOpts := groups.CreateOpts{
 		Name: asName,
@@ -25,8 +26,11 @@ func CreateAutoScalingGroup(t *testing.T, client *golangsdk.ServiceClient, netwo
 				ID: defaultSGID,
 			},
 		},
-		VpcID:            vpcID,
-		IsDeletePublicip: &deletePublicIP,
+		VpcID:                vpcID,
+		IsDeletePublicip:     pointerto.Bool(true),
+		DesireInstanceNumber: 1,
+		MinInstanceNumber:    1,
+		MaxInstanceNumber:    5,
 	}
 	t.Logf("Attempting to create AutoScaling Group")
 	groupID, err := groups.Create(client, createOpts)
@@ -43,4 +47,46 @@ func DeleteAutoScalingGroup(t *testing.T, client *golangsdk.ServiceClient, group
 	})
 	th.AssertNoErr(t, err)
 	t.Logf("Deleted AutoScaling Group: %s", groupID)
+}
+
+func CreateASConfig(t *testing.T, client *golangsdk.ServiceClient, asCreateName string, imageID string, keyPairName string) string {
+	defaultSGID := openstack.DefaultSecurityGroup(t)
+
+	t.Logf("Attempting to create AutoScaling Configuration")
+	configID, err := configurations.Create(client, configurations.CreateOpts{
+		Name: asCreateName,
+		InstanceConfig: configurations.InstanceConfigOpts{
+			FlavorRef: "s3.medium.1",
+			ImageRef:  imageID,
+			Disk: []configurations.Disk{
+				{
+					Size:       40,
+					VolumeType: "SATA",
+					DiskType:   "SYS",
+					Metadata: configurations.SystemMetadata{
+						SystemEncrypted: "0",
+					},
+				},
+			},
+			SSHKey: keyPairName,
+			SecurityGroups: []configurations.SecurityGroup{
+				{
+					ID: defaultSGID,
+				},
+			},
+			Metadata: configurations.AdminPassMetadata{
+				AdminPass: "Test1234",
+			},
+		},
+	})
+	th.AssertNoErr(t, err)
+	t.Logf("Created AutoScaling Configuration: %s", configID)
+	return configID
+}
+
+func DeleteASConfig(t *testing.T, client *golangsdk.ServiceClient, configID string) {
+	t.Logf("Attempting to delete AutoScaling Configuration")
+	err := configurations.Delete(client, configID)
+	th.AssertNoErr(t, err)
+	t.Logf("Deleted AutoScaling Configuration: %s", configID)
 }

--- a/acceptance/openstack/autoscaling/v1/configurations_test.go
+++ b/acceptance/openstack/autoscaling/v1/configurations_test.go
@@ -19,7 +19,7 @@ func TestConfigurationsList(t *testing.T) {
 	configs, err := configurations.List(client, listOpts)
 	th.AssertNoErr(t, err)
 
-	for _, config := range configs {
+	for _, config := range configs.ScalingConfigurations {
 		tools.PrintResource(t, config)
 	}
 }

--- a/acceptance/openstack/autoscaling/v1/groups_test.go
+++ b/acceptance/openstack/autoscaling/v1/groups_test.go
@@ -20,7 +20,7 @@ func TestGroupsList(t *testing.T) {
 	asGroups, err := groups.List(client, listOpts)
 	th.AssertNoErr(t, err)
 
-	for _, group := range asGroups {
+	for _, group := range asGroups.ScalingGroups {
 		tools.PrintResource(t, group)
 	}
 }

--- a/acceptance/openstack/autoscaling/v1/groups_test.go
+++ b/acceptance/openstack/autoscaling/v1/groups_test.go
@@ -64,7 +64,9 @@ func TestGroupLifecycle(t *testing.T) {
 				ID: secGroupID,
 			},
 		},
-		IsDeletePublicip: pointerto.Bool(false),
+		IsDeletePublicip:     pointerto.Bool(false),
+		DesireInstanceNumber: 0,
+		MinInstanceNumber:    0,
 	})
 	th.AssertNoErr(t, err)
 	t.Logf("Updated AutoScaling Group")

--- a/acceptance/openstack/autoscaling/v1/instances_test.go
+++ b/acceptance/openstack/autoscaling/v1/instances_test.go
@@ -58,10 +58,9 @@ func TestInstances(t *testing.T) {
 		ConfigurationID:      configID,
 	}
 	t.Logf("Attempting to create AutoScaling Group")
-	groupID2, err2 := groups.Create(client, createOpts)
+	groupID, err2 := groups.Create(client, createOpts)
 	th.AssertNoErr(t, err2)
-	t.Logf("Created AutoScaling Group: %s", groupID2)
-	groupID := groupID2
+	t.Logf("Created AutoScaling Group: %s", groupID)
 
 	t.Cleanup(func() {
 		autoscaling.DeleteAutoScalingGroup(t, client, groupID)

--- a/acceptance/openstack/autoscaling/v1/instances_test.go
+++ b/acceptance/openstack/autoscaling/v1/instances_test.go
@@ -1,0 +1,120 @@
+package v1
+
+import (
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack/autoscaling"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v1/groups"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v1/instances"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v1/quotas"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestInstances(t *testing.T) {
+	client, err := clients.NewAutoscalingV1Client()
+	th.AssertNoErr(t, err)
+
+	asGroupCreateName := tools.RandomString("as-ins-", 3)
+	networkID := clients.EnvOS.GetEnv("NETWORK_ID")
+	vpcID := clients.EnvOS.GetEnv("VPC_ID")
+	if networkID == "" {
+		t.Skip("OS_NETWORK_ID or OS_VPC_ID env vars are missing but AS Group test requires")
+	}
+
+	asCreateName := tools.RandomString("as-ins-", 3)
+	keyPairName := clients.EnvOS.GetEnv("KEYPAIR_NAME")
+	imageID := clients.EnvOS.GetEnv("IMAGE_ID")
+	if keyPairName == "" || imageID == "" {
+		t.Skip("OS_KEYPAIR_NAME or OS_IMAGE_ID env vars is missing but AS Configuration test requires")
+	}
+
+	configID := autoscaling.CreateASConfig(t, client, asCreateName, imageID, keyPairName)
+	t.Cleanup(func() {
+		autoscaling.DeleteASConfig(t, client, configID)
+	})
+
+	createOpts := groups.CreateOpts{
+		Name: asGroupCreateName,
+		Networks: []groups.ID{
+			{
+				ID: networkID,
+			},
+		},
+		SecurityGroup: []groups.ID{
+			{
+				ID: openstack.DefaultSecurityGroup(t),
+			},
+		},
+		VpcID:                vpcID,
+		IsDeletePublicip:     pointerto.Bool(true),
+		DesireInstanceNumber: 1,
+		MinInstanceNumber:    0,
+		MaxInstanceNumber:    5,
+		ConfigurationID:      configID,
+	}
+	t.Logf("Attempting to create AutoScaling Group")
+	groupID2, err2 := groups.Create(client, createOpts)
+	th.AssertNoErr(t, err2)
+	t.Logf("Created AutoScaling Group: %s", groupID2)
+	groupID := groupID2
+
+	t.Cleanup(func() {
+		autoscaling.DeleteAutoScalingGroup(t, client, groupID)
+	})
+
+	err = groups.Enable(client, groupID)
+	th.AssertNoErr(t, err)
+
+	err = golangsdk.WaitFor(1000, func() (bool, error) {
+		n, err := groups.Get(client, groupID)
+		if err != nil {
+			return false, err
+		}
+
+		if n.ActualInstanceNumber == 1 {
+			return true, nil
+		}
+
+		return false, nil
+	})
+	th.AssertNoErr(t, err)
+
+	err = groups.Disable(client, groupID)
+
+	inst, err := instances.List(client, instances.ListOpts{
+		ScalingGroupId: groupID,
+	})
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, inst)
+
+	t.Cleanup(func() {
+		err = instances.Delete(client, instances.DeleteOpts{
+			InstanceId:     inst.ScalingGroupInstances[0].ID,
+			DeleteInstance: "yes",
+		})
+		th.AssertNoErr(t, err)
+
+		err = golangsdk.WaitFor(1000, func() (bool, error) {
+			n, err := groups.Get(client, groupID)
+			if err != nil {
+				return false, err
+			}
+
+			if n.ActualInstanceNumber == 0 {
+				return true, nil
+			}
+
+			return false, nil
+		})
+		th.AssertNoErr(t, err)
+	})
+
+	quota, err := quotas.ShowPolicyAndInstanceQuota(client, groupID)
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, quota)
+}

--- a/acceptance/openstack/autoscaling/v1/instances_test.go
+++ b/acceptance/openstack/autoscaling/v1/instances_test.go
@@ -85,6 +85,7 @@ func TestInstances(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	err = groups.Disable(client, groupID)
+	th.AssertNoErr(t, err)
 
 	inst, err := instances.List(client, instances.ListOpts{
 		ScalingGroupId: groupID,

--- a/acceptance/openstack/autoscaling/v1/policies_test.go
+++ b/acceptance/openstack/autoscaling/v1/policies_test.go
@@ -1,0 +1,97 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack/autoscaling"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v1/policies"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestPolicyLifecycle(t *testing.T) {
+	client, err := clients.NewAutoscalingV1Client()
+	th.AssertNoErr(t, err)
+
+	networkID := clients.EnvOS.GetEnv("NETWORK_ID")
+	vpcID := clients.EnvOS.GetEnv("VPC_ID")
+	if networkID == "" || vpcID == "" {
+		t.Skip("OS_NETWORK_ID or OS_VPC_ID env vars are missing but AS Policy test requires")
+	}
+
+	groupID := autoscaling.CreateAutoScalingGroup(t, client, networkID, vpcID, tools.RandomString("as-group-create-", 3))
+	t.Cleanup(func() {
+		autoscaling.DeleteAutoScalingGroup(t, client, groupID)
+	})
+
+	asPolicyCreateName := tools.RandomString("as-policy-create-", 3)
+	t.Logf("Attempting to create AutoScaling Policy")
+	policyID, err := policies.Create(client, policies.CreateOpts{
+		Name: asPolicyCreateName,
+		Type: "RECURRENCE",
+		ID:   groupID,
+		SchedulePolicy: policies.SchedulePolicyOpts{
+			LaunchTime:      "10:30",
+			RecurrenceType:  "Weekly",
+			RecurrenceValue: "1,3,5",
+			EndTime:         "2040-12-31T10:30Z",
+		},
+		Action: policies.Action{
+			Operation:          "ADD",
+			InstancePercentage: 15,
+		},
+	})
+	th.AssertNoErr(t, err)
+	t.Logf("Created AutoScaling Policy: %s", policyID)
+
+	t.Cleanup(func() {
+		t.Logf("Attempting to delete AutoScaling Policy")
+		err := policies.Delete(client, policyID)
+		th.AssertNoErr(t, err)
+		t.Logf("Deleted AutoScaling Policy: %s", policyID)
+	})
+
+	policy, err := policies.Get(client, policyID)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, asPolicyCreateName, policy.Name)
+	th.AssertEquals(t, 15, policy.Action.InstancePercentage)
+	th.AssertEquals(t, "ADD", policy.Action.Operation)
+
+	t.Logf("Attempting to update AutoScaling policy")
+	asPolicyUpdateName := tools.RandomString("as-policy-update-", 3)
+
+	updateOpts := policies.UpdateOpts{
+		Name: asPolicyUpdateName,
+		Type: "RECURRENCE",
+		SchedulePolicy: policies.CreateOpts{
+			Name: asPolicyCreateName,
+			Type: "RECURRENCE",
+			ID:   groupID,
+			SchedulePolicy: policies.SchedulePolicyOpts{
+				LaunchTime:      "10:30",
+				RecurrenceType:  "Weekly",
+				RecurrenceValue: "1,3,5",
+				EndTime:         "2040-12-31T10:30Z",
+			},
+			Action: policies.Action{
+				Operation:          "ADD",
+				InstancePercentage: 15,
+			},
+		}.SchedulePolicy,
+		Action: policies.Action{
+			InstancePercentage: 30,
+		},
+		CoolDownTime: 0,
+	}
+
+	policyID, err = policies.Update(client, policyID, updateOpts)
+	th.AssertNoErr(t, err)
+	t.Logf("Updated AutoScaling Policy")
+
+	policy, err = policies.Get(client, policyID)
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, policy)
+	th.AssertEquals(t, asPolicyUpdateName, policy.Name)
+	th.AssertEquals(t, 30, policy.Action.InstancePercentage)
+}

--- a/acceptance/openstack/autoscaling/v2/policies_test.go
+++ b/acceptance/openstack/autoscaling/v2/policies_test.go
@@ -69,6 +69,9 @@ func TestPolicyLifecycle(t *testing.T) {
 
 	updateOpts := policies.PolicyOpts{
 		PolicyName:     asPolicyUpdateName,
+		PolicyType:     "RECURRENCE",
+		ResourceID:     groupID,
+		ResourceType:   "SCALING_GROUP",
 		SchedulePolicy: createOpts.SchedulePolicy,
 		PolicyAction: policies.ActionOpts{
 			Percentage: 30,

--- a/acceptance/openstack/autoscaling/v2/policies_test.go
+++ b/acceptance/openstack/autoscaling/v2/policies_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack/autoscaling"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v2/logs"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v2/policies"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
@@ -88,4 +89,8 @@ func TestPolicyLifecycle(t *testing.T) {
 	tools.PrintResource(t, policy)
 	th.AssertEquals(t, asPolicyUpdateName, policy.PolicyName)
 	th.AssertEquals(t, 30, policy.PolicyAction.Percentage)
+
+	activityLogs, err := logs.ListScalingActivityLogs(client, logs.ListScalingActivityLogsOpts{ScalingGroupId: groupID})
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, activityLogs)
 }

--- a/acceptance/openstack/autoscaling/v2/policies_test.go
+++ b/acceptance/openstack/autoscaling/v2/policies_test.go
@@ -23,10 +23,11 @@ func TestPolicyLifecycle(t *testing.T) {
 	if networkID == "" || vpcID == "" {
 		t.Skip("OS_NETWORK_ID or OS_VPC_ID env vars are missing but AS Policy test requires")
 	}
+
 	groupID := autoscaling.CreateAutoScalingGroup(t, v1client, networkID, vpcID, asGroupCreateName)
-	defer func() {
+	t.Cleanup(func() {
 		autoscaling.DeleteAutoScalingGroup(t, v1client, groupID)
-	}()
+	})
 
 	createOpts := policies.PolicyOpts{
 		PolicyName:   asPolicyCreateName,
@@ -49,12 +50,13 @@ func TestPolicyLifecycle(t *testing.T) {
 	policyID, err := policies.Create(client, createOpts)
 	th.AssertNoErr(t, err)
 	t.Logf("Created AutoScaling Policy: %s", policyID)
-	defer func() {
+
+	t.Cleanup(func() {
 		t.Logf("Attempting to delete AutoScaling Policy")
 		err := policies.Delete(v1client, policyID)
 		th.AssertNoErr(t, err)
 		t.Logf("Deleted AutoScaling Policy: %s", policyID)
-	}()
+	})
 
 	policy, err := policies.Get(client, policyID)
 	th.AssertNoErr(t, err)

--- a/openstack/autoscaling/v1/configurations/BatchDeleteScalingConfigs.go
+++ b/openstack/autoscaling/v1/configurations/BatchDeleteScalingConfigs.go
@@ -1,0 +1,21 @@
+package configurations
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type BatchDeleteOpts struct {
+	ScalingConfigurationId []string `json:"scaling_configuration_id"`
+}
+
+func BatchDeleteScalingConfigs(client *golangsdk.ServiceClient, opts BatchDeleteOpts) (err error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return
+	}
+
+	// POST /autoscaling-api/v1/{project_id}/scaling_configurations
+	_, err = client.Post(client.ServiceURL("scaling_configurations"), b, nil, nil)
+	return
+}

--- a/openstack/autoscaling/v1/configurations/create.go
+++ b/openstack/autoscaling/v1/configurations/create.go
@@ -36,7 +36,7 @@ type InstanceConfigOpts struct {
 	// Specifies the EIP of the ECS. The EIP can be configured in two ways.
 	// Do not use an EIP. In this case, this parameter is unavailable.
 	// Automatically assign an EIP. You need to specify the information about the new EIP.
-	PubicIp *PublicIp `json:"public_ip,omitempty"`
+	PubicIp PublicIp `json:"public_ip,omitempty"`
 	// Specifies the user data to be injected during the ECS creation process. Text, text files, and gzip files can be injected.
 	// Constraints:
 	// The content to be injected must be encoded with base64. The maximum size of the content to be injected (before encoding) is 32 KB.
@@ -49,7 +49,7 @@ type InstanceConfigOpts struct {
 	// echo 111 > c:\aaa.txt
 	UserData []byte `json:"-"`
 	// Specifies the ECS metadata.
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	Metadata AdminPassMetadata `json:"metadata,omitempty"`
 	// Specifies security groups.
 	// If the security group is specified both in the AS configuration and AS group, scaled ECS instances
 	// will be added to the security group specified in the AS configuration.
@@ -58,6 +58,18 @@ type InstanceConfigOpts struct {
 	SecurityGroups []SecurityGroup `json:"security_groups,omitempty"`
 	// This parameter is reserved.
 	MarketType string `json:"market_type,omitempty"`
+}
+
+type AdminPassMetadata struct {
+	// Specifies the initial login password of the administrator account for logging in to an ECS using password authentication.
+	// The Linux administrator is root, and the Windows administrator is Administrator.
+	//
+	// Password complexity requirements:
+	// Consists of 8 to 26 characters.
+	// Contains at least three of the following character types: uppercase letters, lowercase letters, digits, and special characters !@$%^-_=+[{}]:,./?
+	// The password cannot contain the username or the username in reversed order.
+	// The Windows ECS password cannot contain the username, the username in reversed order, or more than two consecutive characters in the username.
+	AdminPass string `json:"admin_pass,omitempty"`
 }
 
 func (opts CreateOpts) toConfigurationCreateMap() (map[string]interface{}, error) {

--- a/openstack/autoscaling/v1/configurations/create.go
+++ b/openstack/autoscaling/v1/configurations/create.go
@@ -36,7 +36,7 @@ type InstanceConfigOpts struct {
 	// Specifies the EIP of the ECS. The EIP can be configured in two ways.
 	// Do not use an EIP. In this case, this parameter is unavailable.
 	// Automatically assign an EIP. You need to specify the information about the new EIP.
-	PubicIp PublicIp `json:"public_ip,omitempty"`
+	PubicIp *PublicIp `json:"public_ip,omitempty"`
 	// Specifies the user data to be injected during the ECS creation process. Text, text files, and gzip files can be injected.
 	// Constraints:
 	// The content to be injected must be encoded with base64. The maximum size of the content to be injected (before encoding) is 32 KB.

--- a/openstack/autoscaling/v1/configurations/get.go
+++ b/openstack/autoscaling/v1/configurations/get.go
@@ -28,6 +28,8 @@ type Configuration struct {
 	InstanceConfig InstanceConfig `json:"instance_config"`
 	// Specifies the time when AS configurations are created. The time format complies with UTC.
 	CreateTime string `json:"create_time"`
+	// Specifies the ID of the AS group to which the AS configuration is bound.
+	ScalingGroupId string `json:"scaling_group_id,omitempty"`
 }
 
 type InstanceConfig struct {
@@ -54,7 +56,7 @@ type InstanceConfig struct {
 	// Specifies the Cloud-Init user data, which is encoded using Base64.
 	UserData string `json:"user_data"`
 	// Specifies the ECS metadata.
-	Metadata map[string]interface{} `json:"metadata"`
+	Metadata AdminPassMetadata `json:"metadata"`
 	// Specifies the security group information.
 	SecurityGroups []SecurityGroup `json:"security_groups"`
 	// This parameter is reserved.

--- a/openstack/autoscaling/v1/configurations/get.go
+++ b/openstack/autoscaling/v1/configurations/get.go
@@ -109,7 +109,19 @@ type Disk struct {
 	// Each disk in an AS configuration must correspond to a disk backup in the full-ECS backup by snapshot_id.
 	SnapshotID string `json:"snapshot_id"`
 	// Specifies the metadata for creating disks.
-	Metadata map[string]interface{} `json:"metadata"`
+	Metadata SystemMetadata `json:"metadata"`
+}
+
+type SystemMetadata struct {
+	// Specifies encryption in metadata. The value can be 0 (encryption disabled) or 1 (encryption enabled).
+	// If this parameter does not exist, the disk will not be encrypted by default.
+	// System disk encryption is not supported.
+	SystemEncrypted string `json:"__system__encrypted"`
+	// Specifies the CMK ID, which indicates encryption in metadata. This parameter is used with __system__encrypted.
+	// NOTE:
+	// For details about how to obtain the CMK ID, see "Querying the List of CMKs" in Key Management Service API Reference.
+	// System disk encryption is not supported.
+	SystemCmkId string `json:"__system__cmkid"`
 }
 
 type Personality struct {

--- a/openstack/autoscaling/v1/configurations/get.go
+++ b/openstack/autoscaling/v1/configurations/get.go
@@ -139,7 +139,7 @@ type Personality struct {
 
 type PublicIp struct {
 	// Specifies the EIP automatically assigned to the ECS.
-	Eip Eip `json:"eip"`
+	Eip Eip `json:"eip,omitempty"`
 }
 
 type Eip struct {

--- a/openstack/autoscaling/v1/configurations/list.go
+++ b/openstack/autoscaling/v1/configurations/list.go
@@ -17,7 +17,7 @@ type ListOpts struct {
 	Limit int `q:"limit"`
 }
 
-func List(client *golangsdk.ServiceClient, opts ListOpts) ([]Configuration, error) {
+func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListScalingConfigsResponse, error) {
 	q, err := golangsdk.BuildQueryString(opts)
 	if err != nil {
 		return nil, err
@@ -28,7 +28,14 @@ func List(client *golangsdk.ServiceClient, opts ListOpts) ([]Configuration, erro
 		return nil, err
 	}
 
-	var res []Configuration
-	err = extract.IntoSlicePtr(raw.Body, &res, "scaling_configurations")
-	return res, err
+	var res ListScalingConfigsResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListScalingConfigsResponse struct {
+	TotalNumber           int32           `json:"total_number,omitempty"`
+	StartNumber           int32           `json:"start_number,omitempty"`
+	Limit                 int32           `json:"limit,omitempty"`
+	ScalingConfigurations []Configuration `json:"scaling_configurations,omitempty"`
 }

--- a/openstack/autoscaling/v1/groups/create.go
+++ b/openstack/autoscaling/v1/groups/create.go
@@ -89,6 +89,8 @@ type CreateOpts struct {
 	// If instances cannot be added in the target AZ, select another AZ based on the PICK_FIRST policy.
 	// PICK_FIRST: When adjusting the number of instances, target AZs are determined in the order in the available_zones list.
 	MultiAZPriorityPolicy string `json:"multi_az_priority_policy,omitempty"`
+	// Specifies the description of the AS group. The value can contain 1 to 256 characters.
+	Description string `json:"description,omitempty"`
 }
 
 type LBaaSListener struct {

--- a/openstack/autoscaling/v1/groups/delete.go
+++ b/openstack/autoscaling/v1/groups/delete.go
@@ -2,7 +2,17 @@ package groups
 
 import "github.com/opentelekomcloud/gophertelekomcloud"
 
-func Delete(client *golangsdk.ServiceClient, id string) (err error) {
-	_, err = client.Delete(client.ServiceURL("scaling_group", id), nil)
+type DeleteOpts struct {
+	ScalingGroupId string
+	ForceDelete    *bool `q:"force_delete"`
+}
+
+func Delete(client *golangsdk.ServiceClient, opts DeleteOpts) (err error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return
+	}
+
+	_, err = client.Delete(client.ServiceURL("scaling_group", opts.ScalingGroupId)+q.String(), nil)
 	return
 }

--- a/openstack/autoscaling/v1/groups/list.go
+++ b/openstack/autoscaling/v1/groups/list.go
@@ -26,7 +26,7 @@ type ListOpts struct {
 	EnterpriseProjectID string `q:"enterprise_project_id"`
 }
 
-func List(client *golangsdk.ServiceClient, opts ListOpts) ([]Group, error) {
+func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListScalingGroupsResponse, error) {
 	q, err := golangsdk.BuildQueryString(opts)
 	if err != nil {
 		return nil, err
@@ -37,7 +37,14 @@ func List(client *golangsdk.ServiceClient, opts ListOpts) ([]Group, error) {
 		return nil, err
 	}
 
-	var res []Group
-	err = extract.IntoSlicePtr(raw.Body, &res, "scaling_groups")
-	return res, err
+	var res ListScalingGroupsResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListScalingGroupsResponse struct {
+	TotalNumber   int32   `json:"total_number,omitempty"`
+	StartNumber   int32   `json:"start_number,omitempty"`
+	Limit         int32   `json:"limit,omitempty"`
+	ScalingGroups []Group `json:"scaling_groups,omitempty"`
 }

--- a/openstack/autoscaling/v1/groups/results.go
+++ b/openstack/autoscaling/v1/groups/results.go
@@ -28,7 +28,7 @@ type Group struct {
 	// Specifies the AZ information.
 	AvailableZones []string `json:"available_zones"`
 	// Specifies the network information.
-	Networks []Network `json:"networks"`
+	Networks []ID `json:"networks"`
 	// Specifies the security group information.
 	SecurityGroups []ID `json:"security_groups"`
 	// Specifies the time when an AS group was created. The time format complies with UTC.
@@ -62,11 +62,6 @@ type Group struct {
 	ActivityType string `json:"activity_type"`
 	// Specifies the priority policy used to select target AZs when adjusting the number of instances in an AS group.
 	MultiAZPriorityPolicy string `json:"multi_az_priority_policy"`
-}
-
-type Network struct {
-	// Specifies the subnet ID.
-	ID            string `json:"id"`
-	IPv6Enable    bool   `json:"ipv6_enable"`
-	IPv6Bandwidth ID     `json:"ipv6_bandwidth"`
+	// Specifies the description of the AS group. The value can contain 1 to 256 characters.
+	Description string `json:"description"`
 }

--- a/openstack/autoscaling/v1/groups/update.go
+++ b/openstack/autoscaling/v1/groups/update.go
@@ -97,6 +97,8 @@ type UpdateOpts struct {
 	// If instances cannot be added in the target AZ, select another AZ based on the PICK_FIRST policy.
 	// PICK_FIRST: When adjusting the number of instances, target AZs are determined in the order in the available_zones list.
 	MultiAZPriorityPolicy string `json:"multi_az_priority_policy,omitempty"`
+	// Specifies the description of the AS group. The value can contain 1 to 256 characters.
+	Description string `json:"description,omitempty"`
 }
 
 func Update(client *golangsdk.ServiceClient, id string, opts UpdateOpts) (string, error) {

--- a/openstack/autoscaling/v1/instances/batch.go
+++ b/openstack/autoscaling/v1/instances/batch.go
@@ -22,30 +22,16 @@ type BatchOpts struct {
 	Action string `json:"action,omitempty"`
 }
 
-func batch(client *golangsdk.ServiceClient, groupID string, opts BatchOpts) error {
+func BatchAction(client *golangsdk.ServiceClient, groupID string, opts BatchOpts) (err error) {
 	b, err := build.RequestBody(opts, "")
 	if err != nil {
-		return err
+		return
 	}
 
+	// POST /autoscaling-api/v1/{project_id}/scaling_group_instance/{scaling_group_id}/action
 	_, err = client.Post(client.ServiceURL("scaling_group_instance", groupID, "action"), b, nil, &golangsdk.RequestOpts{
 		OkCodes: []int{204},
 	})
 
-	return err
-}
-
-func BatchAdd(client *golangsdk.ServiceClient, groupID string, instances []string) error {
-	return batch(client, groupID, BatchOpts{
-		Instances: instances,
-		Action:    "ADD",
-	})
-}
-
-func BatchDelete(client *golangsdk.ServiceClient, groupID string, instances []string, deleteEcs string) error {
-	return batch(client, groupID, BatchOpts{
-		Instances:   instances,
-		IsDeleteEcs: deleteEcs,
-		Action:      "REMOVE",
-	})
+	return
 }

--- a/openstack/autoscaling/v1/instances/delete.go
+++ b/openstack/autoscaling/v1/instances/delete.go
@@ -3,15 +3,20 @@ package instances
 import "github.com/opentelekomcloud/gophertelekomcloud"
 
 type DeleteOpts struct {
-	DeleteInstance bool `q:"instance_delete"`
+	InstanceId string
+	// Specifies whether an instance is deleted when it is removed from the AS group.
+	// Options:
+	// no (default): The instance will not be deleted.
+	// yes: The instance will be deleted.
+	DeleteInstance *bool `q:"instance_delete"`
 }
 
-func Delete(client *golangsdk.ServiceClient, id string, opts DeleteOpts) error {
+func Delete(client *golangsdk.ServiceClient, opts DeleteOpts) error {
 	q, err := golangsdk.BuildQueryString(opts)
 	if err != nil {
 		return err
 	}
 
-	_, err = client.Delete(client.ServiceURL("scaling_group_instance", id)+q.String(), nil)
+	_, err = client.Delete(client.ServiceURL("scaling_group_instance", opts.InstanceId)+q.String(), nil)
 	return err
 }

--- a/openstack/autoscaling/v1/instances/delete.go
+++ b/openstack/autoscaling/v1/instances/delete.go
@@ -8,7 +8,7 @@ type DeleteOpts struct {
 	// Options:
 	// no (default): The instance will not be deleted.
 	// yes: The instance will be deleted.
-	DeleteInstance *bool `q:"instance_delete"`
+	DeleteInstance string `q:"instance_delete"`
 }
 
 func Delete(client *golangsdk.ServiceClient, opts DeleteOpts) error {

--- a/openstack/autoscaling/v1/instances/list.go
+++ b/openstack/autoscaling/v1/instances/list.go
@@ -5,29 +5,51 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 )
 
-type ListOptsBuilder interface {
-	ToInstancesListQuery() (string, error)
-}
-
 type ListOpts struct {
-	LifeCycleStatus string `q:"life_cycle_state"`
-	HealthStatus    string `q:"health_status"`
+	// Specifies the AS group ID.
+	ScalingGroupId string `json:"scaling_group_id"`
+	// Specifies the instance lifecycle status in the AS group.
+	// INSERVICE: The instance is enabled.
+	// PENDING: The instance is being added to the AS group.
+	// REMOVING: The instance is being removed from the AS group.
+	LifeCycleState string `json:"life_cycle_state,omitempty"`
+	// Specifies the instance health status.
+	// INITIALIZING: The instance is initializing.
+	// NORMAL: The instance is normal.
+	// ERROR: The instance is abnormal.
+	HealthStatus string `json:"health_status,omitempty"`
+	// Specifies the instance protection status.
+	// true: Instance protection is enabled.
+	// false: Instance protection is disabled.
+	ProtectFromScalingDown string `json:"protect_from_scaling_down,omitempty"`
+	// Specifies the start line number. The default value is 0. The minimum parameter value is 0.
+	StartNumber int32 `json:"start_number,omitempty"`
+	// Specifies the number of query records. The default value is 20. The value range is 0 to 100.
+	Limit int32 `json:"limit,omitempty"`
 }
 
-func List(client *golangsdk.ServiceClient, groupID string, opts ListOpts) ([]Instance, error) {
+func List(client *golangsdk.ServiceClient, groupID string, opts ListOpts) (*ListScalingInstancesResponse, error) {
 	q, err := golangsdk.BuildQueryString(opts)
 	if err != nil {
 		return nil, err
 	}
 
+	// GET /autoscaling-api/v1/{project_id}/scaling_group_instance/{scaling_group_id}/list
 	raw, err := client.Get(client.ServiceURL("scaling_group_instance", groupID, "list")+q.String(), nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var res []Instance
-	err = extract.IntoSlicePtr(raw.Body, &res, "scaling_group_instances")
-	return res, err
+	var res ListScalingInstancesResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListScalingInstancesResponse struct {
+	TotalNumber           int32      `json:"total_number,omitempty"`
+	StartNumber           int32      `json:"start_number,omitempty"`
+	Limit                 int32      `json:"limit,omitempty"`
+	ScalingGroupInstances []Instance `json:"scaling_group_instances,omitempty"`
 }
 
 type Instance struct {
@@ -58,4 +80,6 @@ type Instance struct {
 	ConfigurationID string `json:"scaling_configuration_id"`
 	// Specifies the time when the instance is added to the AS group. The time format complies with UTC.
 	CreateTime string `json:"create_time"`
+	// Specifies the instance protection status.
+	ProtectFromScalingDown bool `json:"protect_from_scaling_down"`
 }

--- a/openstack/autoscaling/v1/instances/list.go
+++ b/openstack/autoscaling/v1/instances/list.go
@@ -7,7 +7,7 @@ import (
 
 type ListOpts struct {
 	// Specifies the AS group ID.
-	ScalingGroupId string `q:"scaling_group_id"`
+	ScalingGroupId string
 	// Specifies the instance lifecycle status in the AS group.
 	// INSERVICE: The instance is enabled.
 	// PENDING: The instance is being added to the AS group.
@@ -28,14 +28,14 @@ type ListOpts struct {
 	Limit int32 `q:"limit,omitempty"`
 }
 
-func List(client *golangsdk.ServiceClient, groupID string, opts ListOpts) (*ListScalingInstancesResponse, error) {
+func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListScalingInstancesResponse, error) {
 	q, err := golangsdk.BuildQueryString(opts)
 	if err != nil {
 		return nil, err
 	}
 
 	// GET /autoscaling-api/v1/{project_id}/scaling_group_instance/{scaling_group_id}/list
-	raw, err := client.Get(client.ServiceURL("scaling_group_instance", groupID, "list")+q.String(), nil, nil)
+	raw, err := client.Get(client.ServiceURL("scaling_group_instance", opts.ScalingGroupId, "list")+q.String(), nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/openstack/autoscaling/v1/instances/list.go
+++ b/openstack/autoscaling/v1/instances/list.go
@@ -7,25 +7,25 @@ import (
 
 type ListOpts struct {
 	// Specifies the AS group ID.
-	ScalingGroupId string `json:"scaling_group_id"`
+	ScalingGroupId string `q:"scaling_group_id"`
 	// Specifies the instance lifecycle status in the AS group.
 	// INSERVICE: The instance is enabled.
 	// PENDING: The instance is being added to the AS group.
 	// REMOVING: The instance is being removed from the AS group.
-	LifeCycleState string `json:"life_cycle_state,omitempty"`
+	LifeCycleState string `q:"life_cycle_state,omitempty"`
 	// Specifies the instance health status.
 	// INITIALIZING: The instance is initializing.
 	// NORMAL: The instance is normal.
 	// ERROR: The instance is abnormal.
-	HealthStatus string `json:"health_status,omitempty"`
+	HealthStatus string `q:"health_status,omitempty"`
 	// Specifies the instance protection status.
 	// true: Instance protection is enabled.
 	// false: Instance protection is disabled.
-	ProtectFromScalingDown string `json:"protect_from_scaling_down,omitempty"`
+	ProtectFromScalingDown string `q:"protect_from_scaling_down,omitempty"`
 	// Specifies the start line number. The default value is 0. The minimum parameter value is 0.
-	StartNumber int32 `json:"start_number,omitempty"`
+	StartNumber int32 `q:"start_number,omitempty"`
 	// Specifies the number of query records. The default value is 20. The value range is 0 to 100.
-	Limit int32 `json:"limit,omitempty"`
+	Limit int32 `q:"limit,omitempty"`
 }
 
 func List(client *golangsdk.ServiceClient, groupID string, opts ListOpts) (*ListScalingInstancesResponse, error) {

--- a/openstack/autoscaling/v1/logs/ListScalingPolicyExecuteLogs.go
+++ b/openstack/autoscaling/v1/logs/ListScalingPolicyExecuteLogs.go
@@ -1,0 +1,135 @@
+package logs
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListLogsOpts struct {
+	// Specifies the AS policy ID.
+	ScalingPolicyId string
+	// Specifies the ID of an AS policy execution log.
+	LogId string `json:"log_id,omitempty"`
+	// Specifies the scaling resource type.
+	// AS group: SCALING_GROUP
+	// Bandwidth: BANDWIDTH
+	ScalingResourceType string `json:"scaling_resource_type,omitempty"`
+	// Specifies the scaling resource ID.
+	ScalingResourceId string `json:"scaling_resource_id,omitempty"`
+	// Specifies the AS policy execution type.
+	// SCHEDULED: automatically triggered at a specified time point
+	// RECURRENCE: automatically triggered at a specified time period
+	// ALARM: alarm-triggered
+	// MANUAL: manually triggered
+	ExecuteType string `json:"execute_type,omitempty"`
+	// Specifies the start time that complies with UTC for querying AS policy execution logs.
+	// The format of the start time is yyyy-MM-ddThh:mm:ssZ.
+	StartTime string `json:"start_time,omitempty"`
+	// Specifies the end time that complies with UTC for querying AS policy execution logs.
+	// The format of the end time is yyyy-MM-ddThh:mm:ssZ.
+	EndTime string `json:"end_time,omitempty"`
+	// Specifies the start line number. The default value is 0. The minimum parameter value is 0.
+	StartNumber int32 `json:"start_number,omitempty"`
+	// Specifies the number of query records. The default value is 20. The value range is 0 to 100.
+	Limit int32 `json:"limit,omitempty"`
+}
+
+func ListScalingPolicyExecuteLogs(client golangsdk.ServiceClient, opts ListLogsOpts) (*ListScalingPolicyExecuteLogsResponse, error) {
+	// GET /autoscaling-api/v1/{project_id}/scaling_policy_execute_log/{scaling_policy_id}
+	raw, err := client.Get(client.ServiceURL("scaling_policy_execute_log", opts.ScalingPolicyId), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListScalingPolicyExecuteLogsResponse
+	err = extract.IntoStructPtr(raw.Body, &res, "scaling_policy")
+	return &res, err
+}
+
+type ListScalingPolicyExecuteLogsResponse struct {
+	TotalNumber             int32                         `json:"total_number,omitempty"`
+	StartNumber             int32                         `json:"start_number,omitempty"`
+	Limit                   int32                         `json:"limit,omitempty"`
+	ScalingPolicyExecuteLog []ScalingPolicyExecuteLogList `json:"scaling_policy_execute_log,omitempty"`
+}
+
+type ScalingPolicyExecuteLogList struct {
+	// Specifies the AS policy execution status.
+	// SUCCESS: The AS policy has been executed.
+	// FAIL: Executing the AS policy failed.
+	// EXECUTING: The AS policy is being executed.
+	Status string `json:"status,omitempty"`
+	// Specifies the AS policy execution failure.
+	FailedReason string `json:"failed_reason,omitempty"`
+	// Specifies the AS policy execution type.
+	// SCHEDULED: automatically triggered at a specified time point
+	// RECURRENCE: automatically triggered at a specified time period
+	// ALARM: alarm-triggered
+	// MANUAL: manually triggered
+	ExecuteType string `json:"execute_type,omitempty"`
+	// Specifies the time when an AS policy was executed. The time format complies with UTC.
+	ExecuteTime string `json:"execute_time,omitempty"`
+	// Specifies the ID of an AS policy execution log.
+	Id string `json:"id,omitempty"`
+	// Specifies the project ID.
+	TenantId string `json:"tenant_id,omitempty"`
+	// Specifies the AS policy ID.
+	ScalingPolicyId string `json:"scaling_policy_id,omitempty"`
+	// Specifies the scaling resource type.
+	// AS group: SCALING_GROUP
+	// Bandwidth: BANDWIDTH
+	ScalingResourceType string `json:"scaling_resource_type,omitempty"`
+	// Specifies the scaling resource ID.
+	ScalingResourceId string `json:"scaling_resource_id,omitempty"`
+	// Specifies the source value.
+	OldValue string `json:"old_value,omitempty"`
+	// Specifies the target value.
+	DesireValue string `json:"desire_value,omitempty"`
+	// Specifies the operation restrictions.
+	// If scaling_resource_type is set to BANDWIDTH and operation is not SET, this parameter takes effect and the unit is Mbit/s.
+	// In this case:
+	// If operation is set to ADD, this parameter indicates the maximum bandwidth allowed.
+	// If operation is set to REDUCE, this parameter indicates the minimum bandwidth allowed.
+	LimitValue string `json:"limit_value,omitempty"`
+	// Specifies the AS policy execution type.
+	// ADD: indicates adding instances.
+	// REMOVE: indicates reducing instances.
+	// SET: indicates setting the number of instances to a specified value.
+	Type string `json:"type,omitempty"`
+	// Specifies the tasks contained in a scaling action based on an AS policy.
+	JobRecords []JobRecords `json:"job_records,omitempty"`
+
+	MetaData EipMetaData `json:"meta_data,omitempty"`
+}
+
+type JobRecords struct {
+	// Specifies the task name.
+	JobName string `json:"job_name,omitempty"`
+	// Specifies the record type.
+	// API: API calling type
+	// MEG: message type
+	RecordType string `json:"record_type,omitempty"`
+	// Specifies the record time.
+	RecordTime string `json:"record_time,omitempty"`
+	// Specifies the request body. This parameter is valid only if record_type is set to API.
+	Request string `json:"request,omitempty"`
+	// Specifies the response body. This parameter is valid only if record_type is set to API.
+	Response string `json:"response,omitempty"`
+	// Specifies the returned code. This parameter is valid only if record_type is set to API.
+	Code string `json:"code,omitempty"`
+	// Specifies the message. This parameter is valid only if record_type is set to MEG.
+	Message string `json:"message,omitempty"`
+	// Specifies the execution status of the task.
+	// SUCCESS: The task is successfully executed.
+	// FAIL: The task failed to be executed.
+	JobStatus string `json:"job_status,omitempty"`
+}
+
+type EipMetaData struct {
+	// Specifies the bandwidth sharing type in the bandwidth scaling policy.
+	MetadataBandwidthShareType string `json:"metadata_bandwidth_share_type,omitempty"`
+	// Specifies the EIP ID for the bandwidth in the bandwidth scaling policy.
+	MetadataEipId string `json:"metadata_eip_id,omitempty"`
+	// Specifies the EIP for the bandwidth in the bandwidth scaling policy.
+	MetadataeipAddress string `json:"metadataeip_address,omitempty"`
+}

--- a/openstack/autoscaling/v1/policies/ListScalingPolicyExecuteLogs.go
+++ b/openstack/autoscaling/v1/policies/ListScalingPolicyExecuteLogs.go
@@ -34,7 +34,7 @@ type ListLogsOpts struct {
 	Limit int32 `json:"limit,omitempty"`
 }
 
-func ListScalingPolicyExecuteLogs(client golangsdk.ServiceClient, opts ListLogsOpts) (*ListScalingPolicyExecuteLogsResponse, error) {
+func ListScalingPolicyExecuteLogs(client *golangsdk.ServiceClient, opts ListLogsOpts) (*ListScalingPolicyExecuteLogsResponse, error) {
 	// GET /autoscaling-api/v1/{project_id}/scaling_policy_execute_log/{scaling_policy_id}
 	raw, err := client.Get(client.ServiceURL("scaling_policy_execute_log", opts.ScalingPolicyId), nil, nil)
 	if err != nil {

--- a/openstack/autoscaling/v1/policies/ListScalingPolicyExecuteLogs.go
+++ b/openstack/autoscaling/v1/policies/ListScalingPolicyExecuteLogs.go
@@ -1,4 +1,4 @@
-package logs
+package policies
 
 import (
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"

--- a/openstack/autoscaling/v1/policies/ListScalingPolicyExecuteLogs.go
+++ b/openstack/autoscaling/v1/policies/ListScalingPolicyExecuteLogs.go
@@ -9,34 +9,39 @@ type ListLogsOpts struct {
 	// Specifies the AS policy ID.
 	ScalingPolicyId string
 	// Specifies the ID of an AS policy execution log.
-	LogId string `json:"log_id,omitempty"`
+	LogId string `q:"log_id,omitempty"`
 	// Specifies the scaling resource type.
 	// AS group: SCALING_GROUP
 	// Bandwidth: BANDWIDTH
-	ScalingResourceType string `json:"scaling_resource_type,omitempty"`
+	ScalingResourceType string `q:"scaling_resource_type,omitempty"`
 	// Specifies the scaling resource ID.
-	ScalingResourceId string `json:"scaling_resource_id,omitempty"`
+	ScalingResourceId string `q:"scaling_resource_id,omitempty"`
 	// Specifies the AS policy execution type.
 	// SCHEDULED: automatically triggered at a specified time point
 	// RECURRENCE: automatically triggered at a specified time period
 	// ALARM: alarm-triggered
 	// MANUAL: manually triggered
-	ExecuteType string `json:"execute_type,omitempty"`
+	ExecuteType string `q:"execute_type,omitempty"`
 	// Specifies the start time that complies with UTC for querying AS policy execution logs.
 	// The format of the start time is yyyy-MM-ddThh:mm:ssZ.
-	StartTime string `json:"start_time,omitempty"`
+	StartTime string `q:"start_time,omitempty"`
 	// Specifies the end time that complies with UTC for querying AS policy execution logs.
 	// The format of the end time is yyyy-MM-ddThh:mm:ssZ.
-	EndTime string `json:"end_time,omitempty"`
+	EndTime string `q:"end_time,omitempty"`
 	// Specifies the start line number. The default value is 0. The minimum parameter value is 0.
-	StartNumber int32 `json:"start_number,omitempty"`
+	StartNumber int32 `q:"start_number,omitempty"`
 	// Specifies the number of query records. The default value is 20. The value range is 0 to 100.
-	Limit int32 `json:"limit,omitempty"`
+	Limit int32 `q:"limit,omitempty"`
 }
 
 func ListScalingPolicyExecuteLogs(client *golangsdk.ServiceClient, opts ListLogsOpts) (*ListScalingPolicyExecuteLogsResponse, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+
 	// GET /autoscaling-api/v1/{project_id}/scaling_policy_execute_log/{scaling_policy_id}
-	raw, err := client.Get(client.ServiceURL("scaling_policy_execute_log", opts.ScalingPolicyId), nil, nil)
+	raw, err := client.Get(client.ServiceURL("scaling_policy_execute_log", opts.ScalingPolicyId)+q.String(), nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/openstack/autoscaling/v1/policies/action.go
+++ b/openstack/autoscaling/v1/policies/action.go
@@ -1,0 +1,29 @@
+package policies
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type ActionOpts struct {
+	ScalingPolicyId string
+	// Specifies the operation for an AS policy.
+	// execute: immediately executes the AS policy.
+	// resume: enables the AS group.
+	// pause: disables the AS group.
+	Action string `json:"action"`
+}
+
+func PolicyAction(client *golangsdk.ServiceClient, opts ActionOpts) (err error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return
+	}
+
+	// POST /autoscaling-api/v1/{project_id}/scaling_policy/{scaling_policy_id}/action
+	_, err = client.Post(client.ServiceURL("scaling_policy", opts.ScalingPolicyId, "action"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{204},
+	})
+
+	return
+}

--- a/openstack/autoscaling/v1/policies/batch_action.go
+++ b/openstack/autoscaling/v1/policies/batch_action.go
@@ -1,0 +1,38 @@
+package policies
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type BatchOpts struct {
+	ScalingPolicyId []string `json:"scaling_policy_id" required:"true"`
+	// Specifies an action to be performed on AS policies in batches. The options are as follows:
+	// delete: deletes AS policies.
+	// resume: enables AS policies.
+	// pause: disables AS policies.
+	Action string `json:"action" required:"true"`
+	// Specifies whether to forcibly delete an AS policy. If the value is set to no, in-progress AS policies cannot be deleted.
+	// Options:
+	// no (default): indicates that the AS policy is not forcibly deleted.
+	// yes: indicates that the AS policy is forcibly deleted.
+	// This parameter is available only when action is set to delete.
+	ForceDelete string `json:"force_delete,omitempty"`
+	// Specifies whether to delete the alarm rule used by the alarm policy. The value can be yes or no (default).
+	// This parameter is available only when action is set to delete.
+	DeleteAlarm string `json:"delete_alarm,omitempty"`
+}
+
+func BatchAction(client *golangsdk.ServiceClient, opts BatchOpts) (err error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return
+	}
+
+	// POST /autoscaling-api/v1/{project_id}/scaling_policies/action
+	_, err = client.Post(client.ServiceURL("scaling_policies", "action"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{204},
+	})
+
+	return
+}

--- a/openstack/autoscaling/v1/policies/get.go
+++ b/openstack/autoscaling/v1/policies/get.go
@@ -77,19 +77,19 @@ type Action struct {
 	// ADD: adds specified number of instances to the AS group.
 	// REMOVE/REDUCE: removes or reduces specified number of instances from the AS group.
 	// SET: sets the number of instances in the AS group.
-	Operation string `json:"operation"`
+	Operation string `json:"operation,omitempty"`
 	// Specifies the number of instances to be operated. The default number is 1.
 	// The value range is as follows for a default quota:
 	// If operation is set to SET, the value range is 0 to 200.
 	// If operation is set to ADD, REMOVE, or REDUCE, the value range is 1 to 200.
 	// NOTE:
 	// Either instance_number or instance_percentage is required.
-	InstanceNum int `json:"instance_number"`
+	InstanceNum int `json:"instance_number,omitempty"`
 	// Specifies the percentage of instances to be operated. You can increase, decrease,
 	// or set the number of instances in an AS group to the specified percentage of the current number of instances.
 	// If operation is set to ADD, REMOVE or REDUCE, the value of this parameter is an integer from 1 to 20000.
 	// If operation is set to SET, the value is an integer from 0 to 20000.
 	// If neither instance_number nor instance_percentage is specified, the number of instances to be operated is 1.
 	// Either instance_number or instance_percentage is required.
-	InstancePercentage int `json:"instance_percentage"`
+	InstancePercentage int `json:"instance_percentage,omitempty"`
 }

--- a/openstack/autoscaling/v1/policies/get.go
+++ b/openstack/autoscaling/v1/policies/get.go
@@ -50,7 +50,7 @@ type SchedulePolicy struct {
 	// If scaling_policy_type is set to SCHEDULED, the time format is YYYY-MM-DDThh:mmZ.
 	// If scaling_policy_type is set to RECURRENCE, the time format is hh:mm.
 	LaunchTime string `json:"launch_time"`
-	// Specifies the type of a periodically triggered scaling action.
+	// Specifies the type of periodically triggered scaling action.
 	// Daily: indicates that the scaling action is triggered once a day.
 	// Weekly: indicates that the scaling action is triggered once a week.
 	// Monthly: indicates that the scaling action is triggered once a month.
@@ -80,4 +80,11 @@ type Action struct {
 	Operation string `json:"operation"`
 	// Specifies the number of instances to be operated.
 	InstanceNum int `json:"instance_number"`
+	// Specifies the percentage of instances to be operated. You can increase, decrease,
+	// or set the number of instances in an AS group to the specified percentage of the current number of instances.
+	// If operation is set to ADD, REMOVE or REDUCE, the value of this parameter is an integer from 1 to 20000.
+	// If operation is set to SET, the value is an integer from 0 to 20000.
+	// If neither instance_number nor instance_percentage is specified, the number of instances to be operated is 1.
+	// Either instance_number or instance_percentage is required.
+	InstancePercentage int `json:"instance_percentage"`
 }

--- a/openstack/autoscaling/v1/policies/get.go
+++ b/openstack/autoscaling/v1/policies/get.go
@@ -73,12 +73,17 @@ type SchedulePolicy struct {
 }
 
 type Action struct {
-	// Specifies the scaling action.
+	// Specifies the operation to be performed. The default operation is ADD.
 	// ADD: adds specified number of instances to the AS group.
-	// REMOVE: removes specified number of instances from the AS group.
+	// REMOVE/REDUCE: removes or reduces specified number of instances from the AS group.
 	// SET: sets the number of instances in the AS group.
 	Operation string `json:"operation"`
-	// Specifies the number of instances to be operated.
+	// Specifies the number of instances to be operated. The default number is 1.
+	// The value range is as follows for a default quota:
+	// If operation is set to SET, the value range is 0 to 200.
+	// If operation is set to ADD, REMOVE, or REDUCE, the value range is 1 to 200.
+	// NOTE:
+	// Either instance_number or instance_percentage is required.
 	InstanceNum int `json:"instance_number"`
 	// Specifies the percentage of instances to be operated. You can increase, decrease,
 	// or set the number of instances in an AS group to the specified percentage of the current number of instances.

--- a/openstack/autoscaling/v1/policies/list.go
+++ b/openstack/autoscaling/v1/policies/list.go
@@ -10,18 +10,18 @@ type ListOpts struct {
 	ScalingGroupId string
 	// Specifies the AS policy name.
 	// Supports fuzzy search.
-	ScalingPolicyName string `json:"scaling_policy_name,omitempty"`
+	ScalingPolicyName string `q:"scaling_policy_name,omitempty"`
 	// Specifies the AS policy type.
 	// ALARM: alarm policy
 	// SCHEDULED: scheduled policy
 	// RECURRENCE: periodic policy
-	ScalingPolicyType string `json:"scaling_policy_type,omitempty"`
+	ScalingPolicyType string `q:"scaling_policy_type,omitempty"`
 	// Specifies the AS policy ID.
-	ScalingPolicyId string `json:"scaling_policy_id,omitempty"`
+	ScalingPolicyId string `q:"scaling_policy_id,omitempty"`
 	// Specifies the start line number. The default value is 0. The minimum parameter value is 0.
-	StartNumber int32 `json:"start_number,omitempty"`
+	StartNumber int32 `q:"start_number,omitempty"`
 	// Specifies the number of query records. The default value is 20. The value range is 0 to 100.
-	Limit int32 `json:"limit,omitempty"`
+	Limit int32 `q:"limit,omitempty"`
 }
 
 func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListScalingInstancesResponse, error) {

--- a/openstack/autoscaling/v1/policies/list.go
+++ b/openstack/autoscaling/v1/policies/list.go
@@ -1,0 +1,118 @@
+package policies
+
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListOpts struct {
+	// Specifies the AS group ID.
+	ScalingGroupId string
+	// Specifies the AS policy name.
+	// Supports fuzzy search.
+	ScalingPolicyName string `json:"scaling_policy_name,omitempty"`
+	// Specifies the AS policy type.
+	// ALARM: alarm policy
+	// SCHEDULED: scheduled policy
+	// RECURRENCE: periodic policy
+	ScalingPolicyType string `json:"scaling_policy_type,omitempty"`
+	// Specifies the AS policy ID.
+	ScalingPolicyId string `json:"scaling_policy_id,omitempty"`
+	// Specifies the start line number. The default value is 0. The minimum parameter value is 0.
+	StartNumber int32 `json:"start_number,omitempty"`
+	// Specifies the number of query records. The default value is 20. The value range is 0 to 100.
+	Limit int32 `json:"limit,omitempty"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListScalingInstancesResponse, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// GET /autoscaling-api/v1/{project_id}/scaling_policy/{scaling_group_id}/list
+	raw, err := client.Get(client.ServiceURL("scaling_policy", opts.ScalingGroupId, "list")+q.String(), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListScalingInstancesResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListScalingInstancesResponse struct {
+	TotalNumber     int32                   `json:"total_number,omitempty"`
+	StartNumber     int32                   `json:"start_number,omitempty"`
+	Limit           int32                   `json:"limit,omitempty"`
+	ScalingPolicies []ScalingV1PolicyDetail `json:"scaling_policies,omitempty"`
+}
+
+type ScalingV1PolicyDetail struct {
+	// Specifies the AS group ID.
+	ScalingGroupId string `json:"scaling_group_id,omitempty"`
+	// Specifies the AS policy name.
+	ScalingPolicyName string `json:"scaling_policy_name,omitempty"`
+	// Specifies the AS policy ID.
+	ScalingPolicyId string `json:"scaling_policy_id,omitempty"`
+	// Specifies the AS policy status.
+	// INSERVICE: The AS policy is enabled.
+	// PAUSED: The AS policy is disabled.
+	// EXECUTING: The AS policy is being executed.
+	PolicyStatus string `json:"policy_status,omitempty"`
+	// Specifies the AS policy type.
+	// ALARM: indicates that the scaling action is triggered by an alarm.
+	// A value is returned for alarm_id, and no value is returned for scheduled_policy.
+	// SCHEDULED: indicates that the scaling action is triggered as scheduled. A value is returned for scheduled_policy,
+	// and no value is returned for alarm_id, recurrence_type, recurrence_value, start_time, or end_time.
+	// RECURRENCE: indicates that the scaling action is triggered periodically. Values are returned for scheduled_policy,
+	// recurrence_type, recurrence_value, start_time, and end_time, and no value is returned for alarm_id.
+	ScalingPolicyType string `json:"scaling_policy_type,omitempty"`
+	// Specifies the alarm ID.
+	AlarmId string `json:"alarm_id,omitempty"`
+	// Specifies the periodic or scheduled AS policy.
+	ScheduledPolicy ScheduledPolicy `json:"scheduled_policy,omitempty"`
+	// Specifies the scaling action of the AS policy.
+	ScalingPolicyAction ScalingPolicyActionV1 `json:"scaling_policy_action,omitempty"`
+	// Specifies the cooldown period (s).
+	CoolDownTime int32 `json:"cool_down_time,omitempty"`
+	// Specifies the time when an AS policy was created. The time format complies with UTC.
+	CreateTime string `json:"create_time,omitempty"`
+}
+
+type ScheduledPolicy struct {
+	// Specifies the time when the scaling action is triggered. The time format complies with UTC.
+	// If scaling_policy_type is set to SCHEDULED, the time format is YYYY-MM-DDThh:mmZ.
+	// If scaling_policy_type is set to RECURRENCE, the time format is hh:mm.
+	LaunchTime string `json:"launch_time"`
+	// Specifies the type of periodically triggered scaling action.
+	// Daily: indicates that the scaling action is triggered once a day.
+	// Weekly: indicates that the scaling action is triggered once a week.
+	// Monthly: indicates that the scaling action is triggered once a month.
+	RecurrenceType string `json:"recurrence_type,omitempty"`
+	// Specifies the frequency at which scaling actions are triggered.
+	// If recurrence_type is set to Daily, the value is null, indicating that the scaling action is triggered once a day.
+	// If recurrence_type is set to Weekly, the value ranges from 1 (Sunday) to 7 (Saturday).
+	// The digits refer to dates in each week and separated by a comma, such as 1,3,5.
+	// If recurrence_type is set to Monthly, the value ranges from 1 to 31.
+	// The digits refer to the dates in each month and separated by a comma, such as 1,10,13,28.
+	RecurrenceValue string `json:"recurrence_value,omitempty"`
+	// Specifies the start time of the scaling action triggered periodically. The time format complies with UTC.
+	// The time format is YYYY-MM-DDThh:mmZ.
+	StartTime string `json:"start_time,omitempty"`
+	// Specifies the end time of the scaling action triggered periodically. The time format complies with UTC.
+	// The time format is YYYY-MM-DDThh:mmZ.
+	EndTime string `json:"end_time,omitempty"`
+}
+
+type ScalingPolicyActionV1 struct {
+	// Specifies the scaling action.
+	// ADD: adds specified number of instances to the AS group.
+	// REMOVE: removes specified number of instances from the AS group.
+	// SET: sets the number of instances in the AS group.
+	Operation string `json:"operation,omitempty"`
+	// Specifies the number of instances to be operated.
+	InstanceNumber int32 `json:"instance_number,omitempty"`
+	// Specifies the percentage of instances to be operated.
+	InstancePercentage int32 `json:"instance_percentage,omitempty"`
+}

--- a/openstack/autoscaling/v1/policies/update.go
+++ b/openstack/autoscaling/v1/policies/update.go
@@ -6,6 +6,29 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 )
 
+type UpdateOpts struct {
+	// Specifies the AS policy name. The name contains only letters, digits, underscores (_), and hyphens (-), and cannot exceed 64 characters.
+	Name string `json:"scaling_policy_name,omitempty"`
+	// Specifies the AS policy type.
+	// ALARM (corresponding to alarm_id): indicates that the scaling action is triggered by an alarm.
+	// SCHEDULED (corresponding to scheduled_policy): indicates that the scaling action is triggered as scheduled.
+	// RECURRENCE (corresponding to scheduled_policy): indicates that the scaling action is triggered periodically.
+	Type string `json:"scaling_policy_type,omitempty"`
+	// Specifies the alarm rule ID. This parameter is mandatory when scaling_policy_type is set to ALARM.
+	// After this parameter is specified, the value of scheduled_policy does not take effect.
+	// After you modify an alarm policy, the system automatically adds an alarm triggering activity of the autoscaling
+	// type to the alarm_actions field in the alarm rule specified by the parameter value.
+	// You can obtain the parameter value by querying Cloud Eye alarm rules.
+	AlarmID string `json:"alarm_id,omitempty"`
+	// Specifies the periodic or scheduled AS policy. This parameter is mandatory when scaling_policy_type is set to SCHEDULED or RECURRENCE.
+	// After this parameter is specified, the value of alarm_id does not take effect.
+	SchedulePolicy SchedulePolicyOpts `json:"scheduled_policy,omitempty"`
+	// Specifies the scaling action of the AS policy.
+	Action Action `json:"scaling_policy_action,omitempty"`
+	// Specifies the cooldown period (in seconds). The value ranges from 0 to 86400.
+	CoolDownTime int `json:"cool_down_time,omitempty"`
+}
+
 type SchedulePolicyOpts struct {
 	// Specifies the time when the scaling action is triggered. The time format complies with UTC.
 	// If scaling_policy_type is set to SCHEDULED, the time format is YYYY-MM-DDThh:mmZ.
@@ -31,29 +54,6 @@ type SchedulePolicyOpts struct {
 	// When the scaling action is triggered periodically, the end time cannot be earlier than the current and start time.
 	// The time format is YYYY-MM-DDThh:mmZ.
 	EndTime string `json:"end_time,omitempty"`
-}
-
-type UpdateOpts struct {
-	// Specifies the AS policy name. The name contains only letters, digits, underscores (_), and hyphens (-), and cannot exceed 64 characters.
-	Name string `json:"scaling_policy_name,omitempty"`
-	// Specifies the AS policy type.
-	// ALARM (corresponding to alarm_id): indicates that the scaling action is triggered by an alarm.
-	// SCHEDULED (corresponding to scheduled_policy): indicates that the scaling action is triggered as scheduled.
-	// RECURRENCE (corresponding to scheduled_policy): indicates that the scaling action is triggered periodically.
-	Type string `json:"scaling_policy_type,omitempty"`
-	// Specifies the alarm rule ID. This parameter is mandatory when scaling_policy_type is set to ALARM.
-	// After this parameter is specified, the value of scheduled_policy does not take effect.
-	// After you modify an alarm policy, the system automatically adds an alarm triggering activity of the autoscaling
-	// type to the alarm_actions field in the alarm rule specified by the parameter value.
-	// You can obtain the parameter value by querying Cloud Eye alarm rules.
-	AlarmID string `json:"alarm_id,omitempty"`
-	// Specifies the periodic or scheduled AS policy. This parameter is mandatory when scaling_policy_type is set to SCHEDULED or RECURRENCE.
-	// After this parameter is specified, the value of alarm_id does not take effect.
-	SchedulePolicy SchedulePolicyOpts `json:"scheduled_policy,omitempty"`
-	// Specifies the scaling action of the AS policy.
-	Action Action `json:"scaling_policy_action,omitempty"`
-	// Specifies the cooldown period (in seconds). The value ranges from 0 to 86400.
-	CoolDownTime int `json:"cool_down_time,omitempty"`
 }
 
 func Update(client *golangsdk.ServiceClient, id string, opts UpdateOpts) (string, error) {

--- a/openstack/autoscaling/v1/quotas/ShowPolicyAndInstanceQuota.go
+++ b/openstack/autoscaling/v1/quotas/ShowPolicyAndInstanceQuota.go
@@ -1,0 +1,18 @@
+package quotas
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func ShowPolicyAndInstanceQuota(client *golangsdk.ServiceClient, scalingGroupId string) (*AllQuotas, error) {
+	// GET /autoscaling-api/v1/{project_id}/quotas/{scaling_group_id}
+	raw, err := client.Get(client.ServiceURL("quotas", scalingGroupId), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res AllQuotas
+	err = extract.IntoStructPtr(raw.Body, &res, "quotas")
+	return &res, err
+}

--- a/openstack/autoscaling/v1/quotas/ShowResourceQuota.go
+++ b/openstack/autoscaling/v1/quotas/ShowResourceQuota.go
@@ -1,0 +1,43 @@
+package quotas
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func ShowResourceQuota(client *golangsdk.ServiceClient) (*AllQuotas, error) {
+	// GET https://{Endpoint}/autoscaling-api/v1/{project_id}/quotas
+	raw, err := client.Get(client.ServiceURL("quotas"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res AllQuotas
+	err = extract.IntoStructPtr(raw.Body, &res, "quotas")
+	return &res, err
+}
+
+type AllQuotas struct {
+	Resources []AllResources `json:"resources,omitempty"`
+}
+
+type AllResources struct {
+	// Specifies the quota type.
+	// scaling_Group: AS group quota
+	// scaling_Config: AS configuration quota
+	// scaling_Policy: AS policy quota
+	// scaling_Instance: instance quota
+	// bandwidth_scaling_policy: bandwidth scaling policy quota
+	Type string `json:"type,omitempty"`
+	// Specifies the used amount of the quota.
+	// When type is set to scaling_Policy or scaling_Instance,
+	// this parameter is reserved, and the system returns -1 as the parameter value.
+	// You can query the used quota of AS policies and AS instances in a specified AS group.
+	Used int32 `json:"used,omitempty"`
+	// Specifies the total quota.
+	Quota int32 `json:"quota,omitempty"`
+	// Specifies the quota upper limit.
+	Max int32 `json:"max,omitempty"`
+	// Specifies the quota lower limit.
+	Min int32 `json:"min,omitempty"`
+}

--- a/openstack/autoscaling/v1/tags/actions.go
+++ b/openstack/autoscaling/v1/tags/actions.go
@@ -3,19 +3,10 @@ package tags
 import (
 	"github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
 )
 
-type ActionOpts struct {
-	// Specifies the tag list.
-	// If action is set to delete, the tag structure cannot be missing, and the key cannot be left blank or an empty string.
-	Tags []ResourceTag `json:"tags" required:"true"`
-	// Operation ID (case sensitive)
-	// delete: indicates deleting a tag.
-	// create: indicates creating a tag. If the same key value already exists, it will be overwritten.
-	Action string `json:"action" required:"ture"`
-}
-
-func doAction(client *golangsdk.ServiceClient, id string, opts ActionOpts) (err error) {
+func doAction(client *golangsdk.ServiceClient, id string, opts tags.ActionOpts) (err error) {
 	b, err := build.RequestBody(opts, "")
 	if err != nil {
 		return
@@ -27,40 +18,26 @@ func doAction(client *golangsdk.ServiceClient, id string, opts ActionOpts) (err 
 	return
 }
 
-func Create(client *golangsdk.ServiceClient, id string, tags []ResourceTag) (err error) {
-	opts := ActionOpts{
-		Tags:   tags,
+func Create(client *golangsdk.ServiceClient, id string, tag []tags.ResourceTag) (err error) {
+	opts := tags.ActionOpts{
+		Tags:   tag,
 		Action: "create",
 	}
 	return doAction(client, id, opts)
 }
 
-func Update(client *golangsdk.ServiceClient, id string, tags []ResourceTag) (err error) {
-	opts := ActionOpts{
-		Tags:   tags,
+func Update(client *golangsdk.ServiceClient, id string, tag []tags.ResourceTag) (err error) {
+	opts := tags.ActionOpts{
+		Tags:   tag,
 		Action: "update",
 	}
 	return doAction(client, id, opts)
 }
 
-func Delete(client *golangsdk.ServiceClient, id string, tags []ResourceTag) (err error) {
-	opts := ActionOpts{
-		Tags:   tags,
+func Delete(client *golangsdk.ServiceClient, id string, tag []tags.ResourceTag) (err error) {
+	opts := tags.ActionOpts{
+		Tags:   tag,
 		Action: "delete",
 	}
 	return doAction(client, id, opts)
-}
-
-type ResourceTag struct {
-	// Specifies the resource tag key. Tag keys of a resource must be unique.
-	// A tag key contains a maximum of 36 Unicode characters and cannot be left blank.
-	// It can contain only digits, letters, hyphens (-), underscores (_), and at signs (@).
-	// When action is set to delete, the tag character set is not verified, and a key contains a maximum of 127 Unicode characters.
-	Key string `json:"key" required:"ture"`
-	// Specifies the resource tag value.
-	// A tag value contains a maximum of 43 Unicode characters and can be left blank.
-	// It can contain only digits, letters, hyphens (-), underscores (_), and at signs (@).
-	// When action is set to delete, the tag character set is not verified, and a value contains a maximum of 255 Unicode characters.
-	// If value is specified, tags are deleted by key and value. If value is not specified, tags are deleted by key.
-	Value string `json:"value,omitempty"`
 }

--- a/openstack/autoscaling/v1/tags/list.go
+++ b/openstack/autoscaling/v1/tags/list.go
@@ -3,6 +3,7 @@ package tags
 import (
 	"github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
 )
 
 func List(client *golangsdk.ServiceClient) (*ResourceTags, error) {
@@ -17,6 +18,6 @@ func List(client *golangsdk.ServiceClient) (*ResourceTags, error) {
 }
 
 type ResourceTags struct {
-	Tags    []ResourceTag `json:"tags"`
-	SysTags []ResourceTag `json:"sys_tags"`
+	Tags    []tags.ResourceTag `json:"tags"`
+	SysTags []tags.ResourceTag `json:"sys_tags"`
 }

--- a/openstack/autoscaling/v2/ListScalingActivityLogs.go
+++ b/openstack/autoscaling/v2/ListScalingActivityLogs.go
@@ -1,0 +1,131 @@
+package v2
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/autoscaling/v1/groups"
+)
+
+type ListScalingActivityLogsOpts struct {
+	ScalingGroupId string
+	// Specifies the scaling action log ID.
+	LogId string `q:"log_id,omitempty"`
+	// Specifies the start time that complies with UTC for querying scaling action logs.
+	// The format of the start time is yyyy-MM-ddThh:mm:ssZ.
+	StartTime string `q:"start_time,omitempty"`
+	// Specifies the end time that complies with UTC for querying scaling action logs.
+	// The format of the end time is yyyy-MM-ddThh:mm:ssZ.
+	EndTime string `q:"end_time,omitempty"`
+	// Specifies the start line number. The default value is 0. The minimum parameter value is 0.
+	StartNumber int32 `q:"start_number,omitempty"`
+	// Specifies the number of query records. The default value is 20. The value range is 0 to 100.
+	Limit int32 `q:"limit,omitempty"`
+	// Specifies the types of the scaling actions to be queried. Different types are separated by commas (,).
+	//
+	// NORMAL: indicates a common scaling action.
+	// MANUAL_REMOVE: indicates manually removing instances from an AS group.
+	// MANUAL_DELETE: indicates manually removing and deleting instances from an AS group.
+	// MANUAL_ADD: indicates manually adding instances to an AS group.
+	// ELB_CHECK_DELETE: indicates that instances are removed from an AS group and deleted based on the ELB health check result.
+	// AUDIT_CHECK_DELETE: indicates that instances are removed from an AS group and deleted based on the OpenStack audit.
+	// DIFF: indicates that the number of expected instances is different from the actual number of instances.
+	// MODIFY_ELB: indicates the load balancer migration.
+	Type string `q:"type,omitempty"`
+	// Specifies the status of the scaling action.
+	//
+	// SUCCESS: The scaling action has been performed.
+	// FAIL: Performing the scaling action failed.
+	// DOING: The scaling action is being performed.
+	Status string `q:"status,omitempty"`
+}
+
+func ListScalingActivityLogs(client golangsdk.ServiceClient, opts ListScalingActivityLogsOpts) (*ListScalingActivityLogsResponse, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// GET /autoscaling-api/v2/{project_id}/scaling_activity_log/{scaling_group_id}
+	raw, err := client.Get(client.ServiceURL("scaling_activity_log", opts.ScalingGroupId)+q.String(), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListScalingActivityLogsResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListScalingActivityLogsResponse struct {
+	TotalNumber        int32                `json:"total_number,omitempty"`
+	StartNumber        int32                `json:"start_number,omitempty"`
+	Limit              int32                `json:"limit,omitempty"`
+	ScalingActivityLog []ScalingActivityLog `json:"scaling_activity_log,omitempty"`
+}
+
+type ScalingActivityLog struct {
+	// Specifies the status of the scaling action.
+	//
+	// SUCCESS: The scaling action has been performed.
+	// FAIL: Performing the scaling action failed.
+	// DOING: The scaling action is being performed.
+	Status string `json:"status,omitempty"`
+	// Specifies the start time of the scaling action. The time format must comply with UTC.
+	StartTime string `json:"start_time,omitempty"`
+	// Specifies the end time of the scaling action. The time format must comply with UTC.
+	EndTime string `json:"end_time,omitempty"`
+	// Specifies the scaling action log ID.
+	Id string `json:"id,omitempty"`
+	// Specifies names of the ECSs that are removed from the AS group in a scaling action.
+	InstanceRemovedList []ScalingInstance `json:"instance_removed_list,omitempty"`
+	// Specifies names of the ECSs that are removed from the AS group and deleted in a scaling action.
+	InstanceDeletedList []ScalingInstance `json:"instance_deleted_list,omitempty"`
+	// Specifies names of the ECSs that are added to the AS group in a scaling action.
+	InstanceAddedList []ScalingInstance `json:"instance_added_list,omitempty"`
+	// Specifies the ECSs for which a scaling action fails.
+	InstanceFailedList []ScalingInstance `json:"instance_failed_list,omitempty"`
+	// Specifies the ECSs that are set to standby mode or for which standby mode is canceled in a scaling action.
+	InstanceStandbyList []ScalingInstance `json:"instance_standby_list,omitempty"`
+	// Specifies the number of added or deleted instances during the scaling.
+	ScalingValue string `json:"scaling_value,omitempty"`
+	// Specifies the description of the scaling action.
+	Description string `json:"description,omitempty"`
+	// Specifies the number of instances in the AS group.
+	InstanceValue int32 `json:"instance_value,omitempty"`
+	// Specifies the expected number of instances for the scaling action.
+	DesireValue int32 `json:"desire_value,omitempty"`
+	// Specifies the load balancers that are bound to the AS group.
+	LbBindSuccessList []ModifyLb `json:"lb_bind_success_list,omitempty"`
+	// Specifies the load balancers that failed to be bound to the AS group.
+	LbBindFailedList []ModifyLb `json:"lb_bind_failed_list,omitempty"`
+	// Specifies the load balancers that are unbound from the AS group.
+	LbUnbindSuccessList []ModifyLb `json:"lb_unbind_success_list,omitempty"`
+	// Specifies the load balancers that failed to be unbound from the AS group.
+	LbUnbindFailedList []ModifyLb `json:"lb_unbind_failed_list,omitempty"`
+	// Specifies the type of the scaling action.
+	Type string `json:"type,omitempty"`
+}
+
+type ScalingInstance struct {
+	// Specifies the ECS name.
+	InstanceName string `json:"instance_name,omitempty"`
+	// Specifies the ECS ID.
+	InstanceId string `json:"instance_id,omitempty"`
+	// Specifies the cause of the instance scaling failure.
+	FailedReason string `json:"failed_reason,omitempty"`
+	// Specifies details of the instance scaling failure.
+	FailedDetails string `json:"failed_details,omitempty"`
+	// Specifies the information about instance configurations.
+	InstanceConfig string `json:"instance_config,omitempty"`
+}
+
+type ModifyLb struct {
+	// Specifies information about an enhanced load balancer.
+	LbaasListener groups.LBaaSListener `json:"lbaas_listener,omitempty"`
+	// Specifies information about a classic load balancer.
+	Listener string `json:"listener,omitempty"`
+	// Specifies the cause of a load balancer migration failure.
+	FailedReason string `json:"failed_reason,omitempty"`
+	// Specifies the details of a load balancer migration failure.
+	FailedDetails string `json:"failed_details,omitempty"`
+}

--- a/openstack/autoscaling/v2/ListScalingActivityLogs.go
+++ b/openstack/autoscaling/v2/ListScalingActivityLogs.go
@@ -39,7 +39,7 @@ type ListScalingActivityLogsOpts struct {
 	Status string `q:"status,omitempty"`
 }
 
-func ListScalingActivityLogs(client golangsdk.ServiceClient, opts ListScalingActivityLogsOpts) (*ListScalingActivityLogsResponse, error) {
+func ListScalingActivityLogs(client *golangsdk.ServiceClient, opts ListScalingActivityLogsOpts) (*ListScalingActivityLogsResponse, error) {
 	q, err := golangsdk.BuildQueryString(opts)
 	if err != nil {
 		return nil, err

--- a/openstack/autoscaling/v2/logs/ListScalingActivityLogs.go
+++ b/openstack/autoscaling/v2/logs/ListScalingActivityLogs.go
@@ -1,4 +1,4 @@
-package v2
+package logs
 
 import (
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"


### PR DESCRIPTION
`metadata` is now a concrete type, not a generic map.

fix #456 