### PR TITLE
[CTS]: Small fix for trackers

### DIFF
--- a/acceptance/openstack/cts/v1/trackers_test.go
+++ b/acceptance/openstack/cts/v1/trackers_test.go
@@ -43,7 +43,7 @@ func TestTrackersLifecycle(t *testing.T) {
 	_, err = tracker.Update(client, tracker.UpdateOpts{
 		BucketName: bucketName,
 		Status:     "disabled",
-	})
+	}, ctsTracker.TrackerName)
 	th.AssertNoErr(t, err)
 	t.Logf("Updated CTSv1 Tracker: %s", ctsTracker.TrackerName)
 

--- a/openstack/cts/v1/tracker/Update.go
+++ b/openstack/cts/v1/tracker/Update.go
@@ -20,13 +20,13 @@ type UpdateOpts struct {
 	Lts CreateLts `json:"lts,omitempty"`
 }
 
-func Update(client *golangsdk.ServiceClient, opts UpdateOpts) (*Tracker, error) {
+func Update(client *golangsdk.ServiceClient, opts UpdateOpts, trackerName string) (*Tracker, error) {
 	b, err := build.RequestBody(opts, "")
 	if err != nil {
 		return nil, err
 	}
 
-	raw, err := client.Put(client.ServiceURL("tracker", "system"), b, nil, &golangsdk.RequestOpts{
+	raw, err := client.Put(client.ServiceURL("tracker", trackerName), b, nil, &golangsdk.RequestOpts{
 		OkCodes: []int{200},
 	})
 	return extra(err, raw)

--- a/openstack/cts/v1/tracker/results.go
+++ b/openstack/cts/v1/tracker/results.go
@@ -16,17 +16,8 @@ type Tracker struct {
 	FilePrefixName string `json:"file_prefix_name"`
 	// Tracker name. The default value is system.
 	TrackerName string `json:"tracker_name"`
-	Lts         Lts    `json:"lts"`
-
-	IsSupportTraceFilesEncryption bool   `json:"is_support_trace_files_encryption"`
-	CreateTime                    int64  `json:"create_time"`
-	StreamId                      string `json:"streamId"`
-	GroupId                       string `json:"groupId"`
-	IsSupportValidate             bool   `json:"is_support_validate"`
-	TrackerType                   string `json:"tracker_type"`
-	DomainId                      string `json:"domain_id"`
-	ProjectId                     string `json:"project_id"`
-	Id                            string `json:"id"`
+	// Lts whether trace analysis is enabled.
+	Lts Lts `json:"lts"`
 }
 
 type Lts struct {


### PR DESCRIPTION
### What this PR does / why we need it
Some fields are removed from `Tracker `struct, `Update` function changed.

### Acceptance tests
=== RUN   TestTrackersLifecycle
    helpers.go:14: Attempting to create OBS bucket
    helpers.go:27: Created OBS Bucket: obs-cts-testwctyi
    trackers_test.go:22: Attempting to create CTSv1 Tracker
    trackers_test.go:38: Created CTSv1 Tracker: system
    trackers_test.go:42: Attempting to update CTSv1 Tracker: system
    trackers_test.go:48: Updated CTSv1 Tracker: system
    trackers_test.go:31: Attempting to delete CTSv1 Tracker: system
    trackers_test.go:34: Deleted CTSv1 Tracker: system
    helpers.go:33: Attempting to delete OBS bucket: obs-cts-testwctyi
    helpers.go:53: Deleted OBS Bucket objects: [{{ } CloudTraces/ }]
    helpers.go:57: Deleted OBS Bucket: obs-cts-testwctyi
--- PASS: TestTrackersLifecycle (6.43s)
PASS

Process finished with the exit code 0
