### PR TITLE
[CTS]: Remove redundant structs and const

### DIFF
--- a/openstack/cts/v3/keyevent/Create.go
+++ b/openstack/cts/v3/keyevent/Create.go
@@ -15,7 +15,7 @@ type CreateNotificationOpts struct {
 	// Enumerated values:
 	// complete
 	// customized
-	OperationType OperationType `json:"operation_type"`
+	OperationType string `json:"operation_type"`
 	// Operation list.
 	Operations []Operations `json:"operations,omitempty"`
 	// List of users whose operations will trigger notifications.
@@ -26,13 +26,6 @@ type CreateNotificationOpts struct {
 	// Example URN: urn:smn:regionId:f96188c7ccaf4ffba0c9aa149ab2bd57:test_topic_v2
 	TopicId string `json:"topic_id,omitempty"`
 }
-
-type OperationType string
-
-const (
-	Complete   OperationType = "complete"
-	Customized OperationType = "customized"
-)
 
 type Operations struct {
 	// Cloud service. The value must be the acronym of a cloud service that has been connected with CTS. It is a word composed of uppercase letters.
@@ -61,16 +54,3 @@ func Create(client *golangsdk.ServiceClient, opts CreateNotificationOpts) (*Noti
 	raw, err := client.Post(client.ServiceURL("notifications"), b, nil, nil)
 	return extra(err, raw)
 }
-
-type NotificationStatus string
-
-const (
-	Enabled  NotificationStatus = "enabled"
-	Disabled NotificationStatus = "disabled"
-)
-
-type NotificationType string
-
-const (
-	Smn NotificationType = "smn"
-)

--- a/openstack/cts/v3/keyevent/List.go
+++ b/openstack/cts/v3/keyevent/List.go
@@ -9,7 +9,7 @@ type ListNotificationsOpts struct {
 	// Notification type.
 	// Enumerated value:
 	// smn
-	NotificationType NotificationType
+	NotificationType string
 	// Notification name. If this parameter is not specified, all key event notifications configured in the current tenant account are returned.
 	NotificationName string `q:"notification_name,omitempty"`
 }
@@ -21,7 +21,7 @@ func List(client *golangsdk.ServiceClient, opts ListNotificationsOpts) ([]Notifi
 	}
 
 	// GET /v3/{project_id}/notifications/{notification_type}
-	url := client.ServiceURL("notifications", string(opts.NotificationType)) + q.String()
+	url := client.ServiceURL("notifications", opts.NotificationType) + q.String()
 	raw, err := client.Get(url, nil, nil)
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ type NotificationResponse struct {
 	// Enumerated values:
 	// customized
 	// complete
-	OperationType OperationType `json:"operation_type,omitempty"`
+	OperationType string `json:"operation_type,omitempty"`
 	// Operation list.
 	Operations []Operations `json:"operations,omitempty"`
 	// List of users whose operations will trigger notifications.
@@ -49,7 +49,7 @@ type NotificationResponse struct {
 	// Enumerated values:
 	// enabled
 	// disabled
-	Status NotificationStatus `json:"status,omitempty"`
+	Status string `json:"status,omitempty"`
 	// Unique resource ID of an SMN topic. You can obtain the ID by querying the topic list.
 	TopicId string `json:"topic_id,omitempty"`
 	// Unique notification ID.
@@ -57,7 +57,7 @@ type NotificationResponse struct {
 	// Notification type.
 	// Enumerated value:
 	// smn
-	NotificationType NotificationType `json:"notification_type,omitempty"`
+	NotificationType string `json:"notification_type,omitempty"`
 	// Project ID.
 	ProjectId string `json:"project_id,omitempty"`
 	// Time when a notification rule was created.

--- a/openstack/cts/v3/keyevent/Update.go
+++ b/openstack/cts/v3/keyevent/Update.go
@@ -18,7 +18,7 @@ type UpdateNotificationOpts struct {
 	// Enumerated values:
 	// complete
 	// customized
-	OperationType OperationType `json:"operation_type"`
+	OperationType string `json:"operation_type"`
 	// Operation list.
 	Operations []Operations `json:"operations,omitempty"`
 	// List of users whose operations will trigger notifications.
@@ -28,7 +28,7 @@ type UpdateNotificationOpts struct {
 	// Enumerated values:
 	// enabled
 	// disabled
-	Status NotificationStatus `json:"status"`
+	Status string `json:"status"`
 	// Topic URN.
 	// To obtain the topic_urn, call the SMN API for querying topics.
 	// Example URN: urn:smn:regionId:f96188c7ccaf4ffba0c9aa149ab2bd57:test_topic_v2


### PR DESCRIPTION
### What this PR does / why we need it
Terraform conversions for deleted structs doesn't work the intended way.
Const are redundant and therefore are removed