### PR TITLE
[CSS]: Fix `ExtendCluster` usage with special opts

### DIFF
--- a/acceptance/openstack/css/v1/clusters_test.go
+++ b/acceptance/openstack/css/v1/clusters_test.go
@@ -46,6 +46,10 @@ func TestClusterWorkflow(t *testing.T) {
 		DiskEncryption: &clusters.DiskEncryption{
 			Encrypted: "0",
 		},
+		Datastore: &clusters.Datastore{
+			Version: "7.6.2",
+			Type:    "elasticsearch",
+		},
 	}
 	created, err := clusters.Create(client, opts)
 	th.AssertNoErr(t, err)
@@ -77,6 +81,17 @@ func TestClusterWorkflow(t *testing.T) {
 	if !found {
 		t.Errorf("cluster %s is not found in list", created.ID)
 	}
+
+	_, err = clusters.ExtendCluster(client, created.ID, []clusters.ClusterExtendSpecialOpts{
+		{
+			Type:     "ess",
+			NodeSize: 0,
+			DiskSize: 160,
+		},
+	})
+	th.AssertNoErr(t, err)
+
+	th.AssertNoErr(t, clusters.WaitForClusterToExtend(client, created.ID, timeout))
 
 	_, err = clusters.ExtendCluster(client, created.ID, clusters.ClusterExtendCommonOpts{
 		ModifySize: 1,

--- a/openstack/css/v1/clusters/ExtendCluster.go
+++ b/openstack/css/v1/clusters/ExtendCluster.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 )
 
@@ -42,19 +43,19 @@ func ExtendCluster(client *golangsdk.ServiceClient, clusterID string, opts Clust
 	switch opts.(type) {
 	case ClusterExtendCommonOpts:
 		url = client.ServiceURL("clusters", clusterID, "extend")
-	case ClusterExtendSpecialOpts:
+	case []ClusterExtendSpecialOpts:
 		url = client.ServiceURL("clusters", clusterID, "role_extend")
 	default:
 		return nil, fmt.Errorf("invalid options type provided: %T", opts)
 	}
 
-	b, err := golangsdk.BuildRequestBody(opts, "grow")
+	b, err := build.RequestBody(opts, "grow")
 	if err != nil {
 		return nil, err
 	}
 
 	raw, err := client.Post(url, b, nil, &golangsdk.RequestOpts{
-		OkCodes: []int{200},
+		OkCodes: []int{200, 202},
 	})
 	if err != nil {
 		return nil, err

--- a/openstack/css/v1/clusters/util.go
+++ b/openstack/css/v1/clusters/util.go
@@ -47,7 +47,7 @@ func WaitForClusterToExtend(client *golangsdk.ServiceClient, id string, timeout 
 		if len(cluster.Actions) == 0 {
 			return true, nil
 		}
-		if cluster.Actions[0] == "GROWING" {
+		if cluster.Actions[0] == "GROWING" || cluster.Actions[0] == "RESIZING_VOLUME" {
 			time.Sleep(30 * time.Second) // make a bigger wait if it's not ready
 			return false, nil
 		}


### PR DESCRIPTION
### What this PR does / why we need it
Current version of `ExtendCluster` has a bug where `ClusterExtendSpecialOpts` are not supported and return 400 error.

### Which issue this PR fixes
PR fixes `ExtendCluster` usage with `ClusterExtendSpecialOpts` and corresponding `WaitForClusterToExtend` func.

### Acceptance test
=== RUN   TestClusterWorkflow
2022/12/18 00:00:06 Creating cluster, ID: cef5ff82-80a3-4fb0-841f-e2b31f5481a1
--- PASS: TestClusterWorkflow (2137.05s)
PASS

Process finished with the exit code 0

