### PR TITLE
[RDS]: Remove job % output and increase sleep time

### DIFF
--- a/openstack/rds/v3/instances/job.go
+++ b/openstack/rds/v3/instances/job.go
@@ -32,8 +32,7 @@ func WaitForJobCompleted(client *golangsdk.ServiceClient, secs int, jobID string
 			return false, err
 		}
 
-		_, _ = fmt.Printf("Job Progress: %s.\n", job.Job.Process)
-		time.Sleep(2 * time.Second)
+		time.Sleep(10 * time.Second)
 		return false, nil
 	})
 }


### PR DESCRIPTION
### What this PR does / why we need it
Remove job progress % output and increase sleep time so we don't receive outputs like these:
<img width="468" alt="Screenshot 2022-12-26 at 18 09 44" src="https://user-images.githubusercontent.com/55093318/209562315-34d48a2f-ce5d-4e4c-968f-b03083649f96.png">
