### PR TITLE
[DDS]: Fix `AddNodes` method for mongo nodes

### DIFF
--- a/acceptance/openstack/dds/v3/instances_test.go
+++ b/acceptance/openstack/dds/v3/instances_test.go
@@ -64,6 +64,7 @@ func TestDdsClusterLifeCycle(t *testing.T) {
 		SpecCode:   "dds.mongodb.s2.large.4.mongos",
 		Num:        2,
 	})
+	th.AssertNoErr(t, err)
 	err = waitForInstanceAvailable(client, 600, ddsInstance.Id)
 	th.AssertNoErr(t, err)
 
@@ -77,6 +78,7 @@ func TestDdsClusterLifeCycle(t *testing.T) {
 			Size: 70,
 		},
 	})
+	th.AssertNoErr(t, err)
 	err = waitForInstanceAvailable(client, 600, ddsInstance.Id)
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/dds/v3/instances_test.go
+++ b/acceptance/openstack/dds/v3/instances_test.go
@@ -20,30 +20,75 @@ func TestDdsList(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	listOpts := instances.ListInstanceOpts{}
-	ddsInstances, err := instances.List(client, listOpts)
+	_, err = instances.List(client, listOpts)
 	th.AssertNoErr(t, err)
-	for _, val := range ddsInstances.Instances {
-		tools.PrintResource(t, val)
-	}
 }
 
-func TestDdsLifeCycle(t *testing.T) {
+func TestDdsSingleLifeCycle(t *testing.T) {
 	client, err := clients.NewDdsV3Client()
 	th.AssertNoErr(t, err)
 
+	t.Logf("Attempting to create DDSv3 single instance")
 	ddsInstance := createDdsSingleInstance(t, client)
 	defer deleteDdsInstance(t, client, ddsInstance.Id)
 
-	tools.PrintResource(t, ddsInstance)
 	listOpts := instances.ListInstanceOpts{Id: ddsInstance.Id}
 	newDdsInstance, err := instances.List(client, listOpts)
 	th.AssertNoErr(t, err)
 	if newDdsInstance.TotalCount == 0 {
 		t.Fatalf("No DDSv3 instance was found: %s", err)
 	}
-	tools.PrintResource(t, newDdsInstance.Instances[0])
 
 	updateDdsInstance(t, client, newDdsInstance.Instances[0])
+}
+
+func TestDdsClusterLifeCycle(t *testing.T) {
+	client, err := clients.NewDdsV3Client()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to create DDSv3 cluster instance")
+	ddsInstance := createDdsClusterInstance(t, client)
+	defer deleteDdsInstance(t, client, ddsInstance.Id)
+
+	listOpts := instances.ListInstanceOpts{Id: ddsInstance.Id}
+	newDdsInstance, err := instances.List(client, listOpts)
+	th.AssertNoErr(t, err)
+	if newDdsInstance.TotalCount == 0 {
+		t.Fatalf("No DDSv3 instance was found: %s", err)
+	}
+
+	t.Logf("Attempting to add 2 mongo nodes to cluster")
+	_, err = instances.AddNode(client, instances.AddNodeOpts{
+		InstanceId: newDdsInstance.Instances[0].Id,
+		Type:       "mongos",
+		SpecCode:   "dds.mongodb.s2.large.4.mongos",
+		Num:        2,
+	})
+	err = waitForInstanceAvailable(client, 600, ddsInstance.Id)
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to add 2 shard nodes to cluster")
+	_, err = instances.AddNode(client, instances.AddNodeOpts{
+		InstanceId: newDdsInstance.Instances[0].Id,
+		Type:       "shard",
+		SpecCode:   "dds.mongodb.s2.large.4.shard",
+		Num:        2,
+		Volume: &instances.VolumeNode{
+			Size: 70,
+		},
+	})
+	err = waitForInstanceAvailable(client, 600, ddsInstance.Id)
+	th.AssertNoErr(t, err)
+
+	t.Log("Enable config IP")
+	err = instances.EnableConfigIp(client, instances.EnableConfigIpOpts{
+		InstanceId: ddsInstance.Id,
+		Type:       "config",
+		Password:   "5ecurePa55w0rd@@",
+	})
+	th.AssertNoErr(t, err)
+	err = waitForInstanceAvailable(client, 600, ddsInstance.Id)
+	th.AssertNoErr(t, err)
 }
 
 func TestDdsReplicaLifeCycle(t *testing.T) {
@@ -53,7 +98,6 @@ func TestDdsReplicaLifeCycle(t *testing.T) {
 	ddsInstance := createDdsReplicaInstance(t, client)
 	defer deleteDdsInstance(t, client, ddsInstance.Id)
 
-	tools.PrintResource(t, ddsInstance)
 	listOpts := instances.ListInstanceOpts{Id: ddsInstance.Id}
 	newDdsInstance, err := instances.List(client, listOpts)
 	th.AssertNoErr(t, err)
@@ -64,17 +108,6 @@ func TestDdsReplicaLifeCycle(t *testing.T) {
 	err = instances.ChangePassword(client, instances.ChangePasswordOpt{
 		InstanceId: ddsInstance.Id,
 		UserPwd:    "5ecurePa55w0rd@@",
-	})
-	th.AssertNoErr(t, err)
-	err = waitForInstanceAvailable(client, 600, ddsInstance.Id)
-	th.AssertNoErr(t, err)
-	tools.PrintResource(t, newDdsInstance.Instances[0])
-
-	t.Log("Enable config IP")
-	err = instances.EnableConfigIp(client, instances.EnableConfigIpOpts{
-		InstanceId: ddsInstance.Id,
-		Type:       "config",
-		Password:   "5ecurePa55w0rd@@",
 	})
 	th.AssertNoErr(t, err)
 	err = waitForInstanceAvailable(client, 600, ddsInstance.Id)
@@ -186,7 +219,6 @@ func updateDdsInstance(t *testing.T, client *golangsdk.ServiceClient, instance i
 }
 
 func createDdsSingleInstance(t *testing.T, client *golangsdk.ServiceClient) *instances.Instance {
-	t.Logf("Attempting to create DDSv3 replica set instance")
 	prefix := "dds-acc-"
 	ddsName := tools.RandomString(prefix, 8)
 	az := clients.EnvOS.GetEnv("AVAILABILITY_ZONE")
@@ -233,7 +265,7 @@ func createDdsSingleInstance(t *testing.T, client *golangsdk.ServiceClient) *ins
 	th.AssertNoErr(t, err)
 	err = waitForInstanceAvailable(client, 600, ddsInstance.Id)
 	th.AssertNoErr(t, err)
-	t.Logf("DDSv3 replica set instance successfully created: %s", ddsInstance.Id)
+	t.Logf("DDSv3 replica set instance successfully created")
 	return ddsInstance
 }
 
@@ -275,6 +307,70 @@ func createDdsReplicaInstance(t *testing.T, client *golangsdk.ServiceClient) *in
 				Storage:  "ULTRAHIGH",
 				Size:     20,
 				SpecCode: "dds.mongodb.s2.medium.4.repset",
+			},
+		},
+		BackupStrategy: instances.BackupStrategy{
+			StartTime: "08:15-09:15",
+		},
+	}
+	ddsInstance, err := instances.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+	err = waitForInstanceAvailable(client, 600, ddsInstance.Id)
+	th.AssertNoErr(t, err)
+	t.Logf("DDSv3 replica set instance successfully created")
+	return ddsInstance
+}
+
+func createDdsClusterInstance(t *testing.T, client *golangsdk.ServiceClient) *instances.Instance {
+	prefix := "dds-acc-"
+	ddsName := tools.RandomString(prefix, 8)
+	az := clients.EnvOS.GetEnv("AVAILABILITY_ZONE")
+	if az == "" {
+		az = "eu-de-01"
+	}
+	cloud, err := clients.EnvOS.Cloud()
+	th.AssertNoErr(t, err)
+
+	vpcID := clients.EnvOS.GetEnv("VPC_ID")
+	subnetID := clients.EnvOS.GetEnv("NETWORK_ID")
+	if vpcID == "" || subnetID == "" {
+		t.Skip("One of OS_VPC_ID or OS_NETWORK_ID env vars is missing but RDS test requires using existing network")
+	}
+
+	createOpts := instances.CreateOpts{
+		Name: ddsName,
+		DataStore: instances.DataStore{
+			Type:          "DDS-Community",
+			Version:       "3.4",
+			StorageEngine: "wiredTiger",
+		},
+		Region:           cloud.RegionName,
+		AvailabilityZone: az,
+		VpcId:            vpcID,
+		SubnetId:         subnetID,
+		SecurityGroupId:  openstack.DefaultSecurityGroup(t),
+		Password:         "5ecurePa55w0rd@",
+		Mode:             "Sharding",
+		Flavor: []instances.Flavor{
+			{
+				Type:     "mongos",
+				Num:      2,
+				Storage:  "ULTRAHIGH",
+				SpecCode: "dds.mongodb.s2.medium.4.mongos",
+			},
+			{
+				Type:     "shard",
+				Num:      2,
+				Storage:  "ULTRAHIGH",
+				Size:     20,
+				SpecCode: "dds.mongodb.s2.medium.4.shard",
+			},
+			{
+				Type:     "config",
+				Num:      1,
+				Storage:  "ULTRAHIGH",
+				Size:     20,
+				SpecCode: "dds.mongodb.s2.large.2.config",
 			},
 		},
 		BackupStrategy: instances.BackupStrategy{
@@ -337,7 +433,7 @@ func waitForInstanceAvailable(client *golangsdk.ServiceClient, secs int, instanc
 		}
 		if ddsInstances.TotalCount == 1 {
 			dds := ddsInstances.Instances
-			if len(dds) == 1 && len(dds[0].Actions) == 0 {
+			if len(dds) == 1 && len(dds[0].Actions) == 0 && dds[0].Status == "normal" {
 				return true, nil
 			}
 			return false, nil

--- a/openstack/dds/v3/instances/AddNode.go
+++ b/openstack/dds/v3/instances/AddNode.go
@@ -6,11 +6,11 @@ import (
 )
 
 type AddNodeOpts struct {
-	Type       string     `json:"type" required:"true"`
-	SpecCode   string     `json:"spec_code" required:"true"`
-	Num        int        `json:"num" required:"true"`
-	Volume     VolumeNode `json:"volume,omitempty"`
-	InstanceId string     `json:"-"`
+	Type       string      `json:"type" required:"true"`
+	SpecCode   string      `json:"spec_code" required:"true"`
+	Num        int         `json:"num" required:"true"`
+	Volume     *VolumeNode `json:"volume,omitempty"`
+	InstanceId string      `json:"-"`
 }
 
 type VolumeNode struct {


### PR DESCRIPTION
### What this PR does / why we need it
Fixes addition of `mongo` nodes for cluster DDS instances.
Tests reworked/added.

### Acceptance tests
=== RUN   TestDdsSingleLifeCycle
    instances_test.go:34: Attempting to create DDSv3 single instance
    instances_test.go:219: Attempting to create DDSv3 replica set instance
    instances_test.go:266: DDSv3 replica set instance successfully created: 18fba47ed9d64b7aa9fa063b06d6f74ein02
    instances_test.go:115: Update name
    helpers.go:59: Attempting to create eip/bandwidth
    helpers.go:75: Waiting for eip 7cbdb80d-1d04-4431-8c9b-5e4c73787015 to be active
    helpers.go:82: Created eip/bandwidth: 7cbdb80d-1d04-4431-8c9b-5e4c73787015
    instances_test.go:132: AttachEip
    instances_test.go:144: UnbindEip
    instances_test.go:154: Enable the SSL
    instances_test.go:161: Modify instance internal IP
    instances_test.go:171: Modify instance port
    instances_test.go:180: Modify instance SG
    instances_test.go:189: Modify instance specs
    instances_test.go:207: Modify instance volume size
    instances_test.go:387: Attempting to delete DDSv3 instance: 18fba47ed9d64b7aa9fa063b06d6f74ein02
    instances_test.go:397: DDSv3 instance deleted successfully: 18fba47ed9d64b7aa9fa063b06d6f74ein02
    helpers.go:88: Attempting to delete eip/bandwidth: 7cbdb80d-1d04-4431-8c9b-5e4c73787015
    helpers.go:94: Waitting for eip 7cbdb80d-1d04-4431-8c9b-5e4c73787015 to be deleted
    helpers.go:99: Deleted eip/bandwidth: 7cbdb80d-1d04-4431-8c9b-5e4c73787015
--- PASS: TestDdsSingleLifeCycle (934.48s)
PASS

Process finished with the exit code 0

=== RUN   TestDdsReplicaLifeCycle
    instances_test.go:282: Attempting to create DDSv3 replica set instance
    instances_test.go:329: DDSv3 replica set instance successfully created
    instances_test.go:398: Attempting to delete DDSv3 instance: 2da2c3eb7b7b4bc896a770e94f7509d3in02
    instances_test.go:408: DDSv3 instance deleted successfully: 2da2c3eb7b7b4bc896a770e94f7509d3in02
--- PASS: TestDdsReplicaLifeCycle (607.05s)
PASS

Process finished with the exit code 0

=== RUN   TestDdsClusterLifeCycle
    instances_test.go:49: Attempting to create DDSv3 cluster instance
    instances_test.go:384: DDSv3 replica set instance successfully created: 2a45b05a5f24450b9147b8b69c733575in02
    instances_test.go:60: Attempting to add 2 mongo nodes to cluster
    instances_test.go:70: Attempting to add 2 shard nodes to cluster
    instances_test.go:83: Enable config IP
    instances_test.go:389: Attempting to delete DDSv3 instance: 2a45b05a5f24450b9147b8b69c733575in02
    instances_test.go:399: DDSv3 instance deleted successfully: 2a45b05a5f24450b9147b8b69c733575in02
--- PASS: TestDdsClusterLifeCycle (1227.97s)
PASS

Process finished with the exit code 0