### PR TITLE
[ELB] l7policy fixed url redirect config for `Port`

### DIFF
--- a/acceptance/openstack/elb/v3/policies_test.go
+++ b/acceptance/openstack/elb/v3/policies_test.go
@@ -72,7 +72,7 @@ func TestPolicyWorkflow(t *testing.T) {
 	th.AssertDeepEquals(t, updated, got2)
 }
 
-func TestPolicyWorkflowNewParams(t *testing.T) {
+func TestPolicyWorkflowFixedResponse(t *testing.T) {
 	t.Parallel()
 
 	client, err := clients.NewElbV3Client()
@@ -136,6 +136,89 @@ func TestPolicyWorkflowNewParams(t *testing.T) {
 			StatusCode:  "200",
 			ContentType: "text/plain",
 			MessageBody: "Fixed Response Update",
+		},
+	}
+	updated, err := policies.Update(client, id, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	t.Log("Updated l7 Policy")
+	th.AssertEquals(t, created.Action, updated.Action)
+	th.AssertEquals(t, id, updated.ID)
+
+	got2, _ := policies.Get(client, id).Extract()
+	th.AssertDeepEquals(t, updated, got2)
+}
+
+func TestPolicyWorkflowUlrRedirect(t *testing.T) {
+	t.Parallel()
+
+	client, err := clients.NewElbV3Client()
+	th.AssertNoErr(t, err)
+
+	lbID := createLoadBalancer(t, client)
+	defer deleteLoadbalancer(t, client, lbID)
+
+	listener, err := listeners.Create(client, listeners.CreateOpts{
+		LoadbalancerID:  lbID,
+		Protocol:        listeners.ProtocolHTTP,
+		ProtocolPort:    80,
+		EnhanceL7policy: pointerto.Bool(true),
+	}).Extract()
+	th.AssertNoErr(t, err)
+	defer deleteListener(t, client, listener.ID)
+
+	poolID := createPool(t, client, lbID)
+	defer deletePool(t, client, poolID)
+
+	createOpts := policies.CreateOpts{
+		Action:      policies.ActionUrlRedirect,
+		ListenerID:  listener.ID,
+		RedirectUrl: "https://www.bing.com:443",
+		RedirectUrlConfig: &policies.RedirectUrlOptions{
+			StatusCode: "302",
+			Protocol:   "${protocol}",
+			Port:       "${port}",
+			Path:       "${path}",
+			Query:      "${query}&name=my_name",
+			Host:       "${host}",
+		},
+		Description: "Go SDK test policy",
+		Name:        tools.RandomString("sdk-pol-", 5),
+		Position:    37,
+	}
+	created, err := policies.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Created L7 Policy")
+	id := created.ID
+
+	defer func() {
+		th.AssertNoErr(t, policies.Delete(client, id).ExtractErr())
+		t.Log("Deleted L7 Policy")
+	}()
+
+	got, err := policies.Get(client, id).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, created, got)
+
+	listOpts := policies.ListOpts{
+		ListenerID: []string{listener.ID},
+	}
+	pages, err := policies.List(client, listOpts).AllPages()
+	th.AssertNoErr(t, err)
+	policySlice, err := policies.ExtractPolicies(pages)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(policySlice))
+	th.AssertEquals(t, id, policySlice[0].ID)
+
+	nameUpdated := tools.RandomString("updated-", 5)
+	updateOpts := policies.UpdateOpts{
+		Name: &nameUpdated,
+		RedirectUrlConfig: &policies.RedirectUrlOptions{
+			StatusCode: "308",
+			Protocol:   "${protocol}",
+			Port:       "${port}",
+			Path:       "${path}",
+			Query:      "${query}&name=my_name",
+			Host:       "${host}",
 		},
 	}
 	updated, err := policies.Update(client, id, updateOpts).Extract()

--- a/openstack/elb/v3/policies/requests.go
+++ b/openstack/elb/v3/policies/requests.go
@@ -12,6 +12,7 @@ const (
 	ActionRedirectToPool     Action = "REDIRECT_TO_POOL"
 	ActionRedirectToListener Action = "REDIRECT_TO_LISTENER"
 	ActionFixedResponse      Action = "FIXED_RESPONSE"
+	ActionUrlRedirect        Action = "REDIRECT_TO_URL"
 )
 
 type Rule struct {
@@ -73,7 +74,7 @@ type RedirectUrlOptions struct {
 
 	// Specifies the port that requests are redirected to.
 	// The default value is ${port}, indicating that the port of the request will be used.
-	Port int `json:"port"`
+	Port string `json:"port"`
 
 	// Specifies the path that requests are redirected to. The default value is ${path}, indicating that the path of the request will be used.
 	//


### PR DESCRIPTION
fixed url redirect config Port parameter

### Acceptance test
API server listening at: 127.0.0.1:62318
=== RUN   TestPolicyWorkflowUlrRedirect
=== PAUSE TestPolicyWorkflowUlrRedirect
=== CONT  TestPolicyWorkflowUlrRedirect
    helpers.go:19: Attempting to create ELBv3 LoadBalancer
    helpers.go:57: Created ELBv3 LoadBalancer: 99f6e080-489c-42fd-8a4a-9b1a61ecc4e3
    helpers.go:150: Attempting to create ELBv3 Pool
    helpers.go:172: Created ELBv3 Pool: fab00d78-c352-45e3-9323-4ade3c281138
    policies_test.go:190: Created L7 Policy
    policies_test.go:226: Updated l7 Policy
    policies_test.go:195: Deleted L7 Policy
    helpers.go:178: Attempting to delete ELBv3 Pool: fab00d78-c352-45e3-9323-4ade3c281138
    helpers.go:181: Deleted ELBv3 Pool: fab00d78-c352-45e3-9323-4ade3c281138
    helpers.go:63: Attempting to delete ELBv3 LoadBalancer: 99f6e080-489c-42fd-8a4a-9b1a61ecc4e3
    helpers.go:66: Deleted ELBv3 LoadBalancer: 99f6e080-489c-42fd-8a4a-9b1a61ecc4e3
--- PASS: TestPolicyWorkflowUlrRedirect (36.02s)
PASS


Debugger finished with the exit code 0