### PR TITLE
Revert "Auth: implementation of temp AK/SK auth"

### DIFF
--- a/acceptance/openstack/client_test.go
+++ b/acceptance/openstack/client_test.go
@@ -45,44 +45,6 @@ func TestAuthenticatedClient(t *testing.T) {
 	t.Logf("Located a storage service at endpoint: [%s]", storage.Endpoint)
 }
 
-func TestAuthTempAKSK(t *testing.T) {
-	securityToken := os.Getenv("OS_SECURITY_TOKEN")
-	if securityToken == "" {
-		t.Skip("OS_SECURITY_TOKEN env var is missing but client_test requires")
-	}
-	cc, err := clients.CloudAndClient()
-	th.AssertNoErr(t, err)
-
-	if cc.ProjectID == "" {
-		t.Errorf("Project ID is not set for the client")
-	}
-	if cc.AuthInfo.AuthURL == "" {
-		t.Errorf("Auth URL is not set for the client")
-	}
-	if cc.AKSKAuthOptions.AccessKey == "" {
-		t.Errorf("Access Key is not set for the client")
-	}
-	if cc.AKSKAuthOptions.SecretKey == "" {
-		t.Errorf("Secret Key is not set for the client")
-	}
-	if cc.AKSKAuthOptions.SecurityToken == "" {
-		t.Errorf("Security Token is not set for the client")
-	}
-
-	// Find several services in the service catalog.
-	storage, err := openstack.NewObjectStorageV1(cc.ProviderClient, golangsdk.EndpointOpts{
-		Region: cc.RegionName,
-	})
-	th.AssertNoErr(t, err)
-	t.Logf("Located a storage service at endpoint: [%s]", storage.Endpoint)
-
-	compute, err := openstack.NewComputeV2(cc.ProviderClient, golangsdk.EndpointOpts{
-		Region: cc.RegionName,
-	})
-	th.AssertNoErr(t, err)
-	t.Logf("Located a compute service at endpoint: [%s]", compute.Endpoint)
-}
-
 func TestAuthTokenNoRegion(t *testing.T) {
 	cc, err := clients.CloudAndClient()
 	th.AssertNoErr(t, err)

--- a/openstack/loader.go
+++ b/openstack/loader.go
@@ -115,10 +115,6 @@ func (e *Env) cloudFromEnv() *Cloud {
 	if secret == "" {
 		secret = e.GetEnv("SECRET_KEY", "ACCESS_KEY_SECRET", "SK")
 	}
-	security := aws.GetEnv("SECURITY_TOKEN")
-	if security == "" {
-		security = e.GetEnv("SECURITY_TOKEN", "AKSK_SECURITY_TOKEN", "ST")
-	}
 	region := e.GetEnv("REGION_NAME", "REGION_ID")
 	if region == "" {
 		region = utils.GetRegion(authOpts)
@@ -145,7 +141,6 @@ func (e *Env) cloudFromEnv() *Cloud {
 			DefaultDomain:     e.GetEnv("DEFAULT_DOMAIN"),
 			AccessKey:         access,
 			SecretKey:         secret,
-			SecurityToken:     security,
 			AgencyName:        authOpts.AgencyName,
 			AgencyDomainName:  authOpts.AgencyDomainName,
 			DelegatedProject:  authOpts.DelegatedProject,
@@ -268,9 +263,8 @@ type AuthInfo struct {
 	DefaultDomain string `yaml:"default_domain,omitempty" json:"default_domain,omitempty"`
 
 	// AK/SK auth means
-	AccessKey     string `yaml:"ak,omitempty" json:"ak,omitempty"`
-	SecretKey     string `yaml:"sk,omitempty" json:"sk,omitempty"`
-	SecurityToken string `yaml:"security_token,omitempty" json:"security_token,omitempty"`
+	AccessKey string `yaml:"ak,omitempty" json:"ak,omitempty"`
+	SecretKey string `yaml:"sk,omitempty" json:"sk,omitempty"`
 
 	// OTC Agency config
 	AgencyName string `yaml:"target_agency_name,omitempty" json:"agency_name,omitempty"`
@@ -665,7 +659,6 @@ func AuthOptionsFromInfo(authInfo *AuthInfo, authType AuthType) (golangsdk.AuthO
 			DomainID:         ao.DomainID,
 			AccessKey:        authInfo.AccessKey,
 			SecretKey:        authInfo.SecretKey,
-			SecurityToken:    authInfo.SecurityToken,
 			AgencyName:       ao.AgencyName,
 			AgencyDomainName: ao.AgencyDomainName,
 			DelegatedProject: ao.DelegatedProject,

--- a/provider_client.go
+++ b/provider_client.go
@@ -254,9 +254,6 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 		if client.AKSKAuthOptions.DomainID != "" {
 			req.Header.Set("X-Domain-Id", client.AKSKAuthOptions.DomainID)
 		}
-		if client.AKSKAuthOptions.SecurityToken != "" {
-			req.Header.Set("X-Security-Token", client.AKSKAuthOptions.SecurityToken)
-		}
 	}
 
 	// Issue the request.


### PR DESCRIPTION
Reverts opentelekomcloud/gophertelekomcloud#517
Temporary AK/SK can create project level clients but fails to create domain clients.
Therefore revert is needed.