### PR TITLE
VPC: security rules fix for `0` int values

### DIFF
--- a/acceptance/openstack/networking/v2/sgs/sg_test.go
+++ b/acceptance/openstack/networking/v2/sgs/sg_test.go
@@ -62,11 +62,13 @@ func CreateMultipleSgsRules(clientV2 *golangsdk.ServiceClient, sgID string, coun
 	i := 0
 	createdSgs := make([]string, count)
 	for i < count {
+		portRangeMin := startIndex*1000 + i
+		portRangeMax := startIndex*5000 + i
 		opts := rules.CreateOpts{
 			Description:  "description",
 			SecGroupID:   sgID,
-			PortRangeMin: startIndex*1000 + i,
-			PortRangeMax: startIndex*5000 + i,
+			PortRangeMin: &portRangeMin,
+			PortRangeMax: &portRangeMax,
 			Direction:    "ingress",
 			EtherType:    "IPv4",
 			Protocol:     "TCP",

--- a/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/openstack/networking/v2/extensions/security/rules/requests.go
@@ -76,12 +76,6 @@ const (
 	ProtocolVRRP      RuleProtocol  = "vrrp"
 )
 
-// CreateOptsBuilder allows extensions to add additional parameters to the
-// Create request.
-type CreateOptsBuilder interface {
-	ToSecGroupRuleCreateMap() (map[string]interface{}, error)
-}
-
 // CreateOpts contains all the values needed to create a new security group
 // rule.
 type CreateOpts struct {
@@ -128,15 +122,10 @@ type CreateOpts struct {
 	TenantID string `json:"tenant_id,omitempty"`
 }
 
-// ToSecGroupRuleCreateMap builds a request body from CreateOpts.
-func (opts CreateOpts) ToSecGroupRuleCreateMap() (map[string]interface{}, error) {
-	return golangsdk.BuildRequestBody(opts, "security_group_rule")
-}
-
 // Create is an operation which adds a new security group rule and associates it
 // with an existing security group (whose ID is specified in CreateOpts).
-func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
-	b, err := build.RequestBody(opts, "")
+func Create(c *golangsdk.ServiceClient, opts CreateOpts) (r CreateResult) {
+	b, err := build.RequestBody(opts, "security_group_rule")
 	if err != nil {
 		r.Err = err
 		return

--- a/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/openstack/networking/v2/extensions/security/rules/requests.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
 
@@ -135,7 +136,7 @@ func (opts CreateOpts) ToSecGroupRuleCreateMap() (map[string]interface{}, error)
 // Create is an operation which adds a new security group rule and associates it
 // with an existing security group (whose ID is specified in CreateOpts).
 func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
-	b, err := opts.ToSecGroupRuleCreateMap()
+	b, err := build.RequestBody(opts, "")
 	if err != nil {
 		r.Err = err
 		return

--- a/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/openstack/networking/v2/extensions/security/rules/requests.go
@@ -96,13 +96,13 @@ type CreateOpts struct {
 	// The maximum port number in the range that is matched by the security group
 	// rule. The PortRangeMin attribute constrains the PortRangeMax attribute. If
 	// the protocol is ICMP, this value must be an ICMP type.
-	PortRangeMax int `json:"port_range_max,omitempty"`
+	PortRangeMax *int `json:"port_range_max,omitempty"`
 
 	// The minimum port number in the range that is matched by the security group
 	// rule. If the protocol is TCP or UDP, this value must be less than or equal
 	// to the value of the PortRangeMax attribute. If the protocol is ICMP, this
 	// value must be an ICMP type.
-	PortRangeMin int `json:"port_range_min,omitempty"`
+	PortRangeMin *int `json:"port_range_min,omitempty"`
 
 	// The protocol that is matched by the security group rule. Valid values are
 	// "tcp", "udp", "icmp" or an empty string.

--- a/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
@@ -145,11 +145,13 @@ func TestCreate(t *testing.T) {
     `)
 	})
 
+	portRangeMin := 80
+	portRangeMax := 80
 	opts := rules.CreateOpts{
 		Direction:     "ingress",
-		PortRangeMin:  80,
+		PortRangeMin:  &portRangeMin,
 		EtherType:     rules.EtherType4,
-		PortRangeMax:  80,
+		PortRangeMax:  &portRangeMax,
 		Protocol:      "tcp",
 		RemoteGroupID: "85cc3048-abc3-43cc-89b3-377341426ac5",
 		SecGroupID:    "a7734e61-b545-452d-a3cd-0189cbd9747a",


### PR DESCRIPTION
### What this PR does / why we need it
PR changes value types in `CreateOpts` from int to *int so they wouldn't be skipped by SDK.

### Which issue this PR fixes
Refers to: [#2148](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/2148)