### PR TITLE
Provider: fix plugin crash

### DIFF
--- a/openstack/loader.go
+++ b/openstack/loader.go
@@ -554,7 +554,7 @@ func (e *Env) loadOpenstackConfig() (*Config, error) {
 		if err != nil {
 			log.Printf("Failed to load %s as cloud config", securePath)
 		}
-		if c != nil {
+		if c.Clouds != nil {
 			cloudConfig = c
 		}
 	}


### PR DESCRIPTION
### What this PR does / why we need it
Issue opened on terraform side: [#2152](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/2152).

### Which issue this PR fixes
PR fixes provider plugin crash in cases when `clouds.yaml` file is not properly configured.
One of the possible ways to reproduce the issue it is to provide `null` value inside `clouds.yaml` file. 
This way the loaded config parameter will have `nil` value which crashes provider on map assignment (detailed log can be checked here: https://gist.github.com/strowi/47613251543d10b676d964d9626b66a2).
