### PR TITLE
[LTS]: transfer API fix

### DIFF
--- a/acceptance/openstack/lts/v2/lts_test.go
+++ b/acceptance/openstack/lts/v2/lts_test.go
@@ -65,7 +65,6 @@ func TestLtsLifecycle(t *testing.T) {
 }
 
 func TestLtsTransferLifecycle(t *testing.T) {
-	t.Skipf("Released API are not working properly")
 	client, err := clients.NewLtsV2Client()
 	th.AssertNoErr(t, err)
 
@@ -135,6 +134,7 @@ func TestLtsTransferLifecycle(t *testing.T) {
 
 	listLogs, err := transfers.ListTransfers(client, transfers.ListTransfersOpts{})
 	th.AssertNoErr(t, err)
+	tools.PrintResource(t, listLogs)
 	if len(listLogs) < 1 {
 		t.Error("Log dump wasn't found")
 	}

--- a/openstack/lts/v2/transfers/DeleteTransfer.go
+++ b/openstack/lts/v2/transfers/DeleteTransfer.go
@@ -5,7 +5,8 @@ import "github.com/opentelekomcloud/gophertelekomcloud"
 func DeleteTransfer(client *golangsdk.ServiceClient, transferId string) (err error) {
 	// DELETE /v2/{project_id}/transfers
 	_, err = client.Delete(client.ServiceURL("transfers")+"?log_transfer_id="+transferId, &golangsdk.RequestOpts{
-		OkCodes: []int{200},
+		OkCodes:     []int{200},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
 	})
 	return
 }

--- a/openstack/lts/v2/transfers/ListTransfers.go
+++ b/openstack/lts/v2/transfers/ListTransfers.go
@@ -48,7 +48,9 @@ func ListTransfers(client *golangsdk.ServiceClient, opts ListTransfersOpts) ([]T
 	}
 
 	// GET /v2/{project_id}/transfers
-	raw, err := client.Get(client.ServiceURL("transfers")+q.String(), nil, nil)
+	raw, err := client.Get(client.ServiceURL("transfers")+q.String(), nil, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What this PR does / why we need it
Added `Content-type` headers (without them server returns 500 error).

#### Acceptance test
```=== RUN   TestLtsTransferLifecycle
    lts_test.go:132: Obs log dump created, id: aa1dff6d-d0d3-45cc-8c8b-44afe8a0cde7
    tools.go:72: [
          {
            "log_group_id": "2d6c3f7e-6efa-4874-8196-dae5b39c7bf6",
            "log_group_name": "test-group-jnN",
            "log_streams": [
              {
                "log_stream_id": "72100a69-a595-47c4-a642-9d5639f2744f",
                "log_stream_name": "test-stream-5iW"
              }
            ],
            "log_transfer_id": "aa1dff6d-d0d3-45cc-8c8b-44afe8a0cde7",
            "log_transfer_info": {
              "log_agency_transfer": {
                "agency_domain_id": "",
                "agency_domain_name": "",
                "agency_name": "",
                "agency_project_id": "",
                "be_agency_domain_id": "",
                "be_agency_project_id": ""
              },
              "log_create_time": 1685103867627,
              "log_storage_format": "RAW",
              "log_transfer_detail": {
                "obs_period": 3,
                "obs_prefix_name": "test",
                "obs_period_unit": "hour",
                "obs_transfer_path": "/obs-test9wwk3/LogTanks/eu-de/dir-test",
                "obs_bucket_name": "obs-test9wwk3",
                "obs_dir_pre_fix_name": "dir-test"
              },
              "log_transfer_mode": "cycle",
              "log_transfer_status": "DISABLE",
              "log_transfer_type": "OBS"
            }
          },
          {
            "log_group_id": "b880af8d-1fa3-42f8-b68c-cc8f73a0b5e7",
            "log_group_name": "test-group-N8L",
            "log_streams": [
              {
                "log_stream_id": "0d222a56-de5b-4fe6-96fc-d51560f8c340",
                "log_stream_name": "test-stream-IY2"
              }
            ],
            "log_transfer_id": "2e415e21-0412-4a36-9373-d2d932550ef3",
            "log_transfer_info": {
              "log_agency_transfer": {
                "agency_domain_id": "",
                "agency_domain_name": "",
                "agency_name": "",
                "agency_project_id": "",
                "be_agency_domain_id": "",
                "be_agency_project_id": ""
              },
              "log_create_time": 1685094765047,
              "log_storage_format": "RAW",
              "log_transfer_detail": {
                "obs_period": 3,
                "obs_prefix_name": "test",
                "obs_period_unit": "hour",
                "obs_transfer_path": "/obs-test2qwki/LogTanks/eu-de/dir-test",
                "obs_bucket_name": "obs-test2qwki",
                "obs_dir_pre_fix_name": "dir-test"
              },
              "log_transfer_mode": "cycle",
              "log_transfer_status": "DISABLE",
              "log_transfer_type": "OBS"
            }
          },
          {
            "log_group_id": "e3043ed5-07fb-4e65-8c9d-1fa6abd6276b",
            "log_group_name": "test-group-I5f",
            "log_streams": [
              {
                "log_stream_id": "ffd8ee09-f72d-42be-8f4a-13d97e32e287",
                "log_stream_name": "test-stream-4j5"
              }
            ],
            "log_transfer_id": "0e2079cf-d70b-4bf9-8a00-ae32c5bfb0bd",
            "log_transfer_info": {
              "log_agency_transfer": {
                "agency_domain_id": "",
                "agency_domain_name": "",
                "agency_name": "",
                "agency_project_id": "",
                "be_agency_domain_id": "",
                "be_agency_project_id": ""
              },
              "log_create_time": 1685103556319,
              "log_storage_format": "RAW",
              "log_transfer_detail": {
                "obs_period": 3,
                "obs_prefix_name": "test",
                "obs_period_unit": "hour",
                "obs_transfer_path": "/obs-testwapuc/LogTanks/eu-de/dir-test",
                "obs_bucket_name": "obs-testwapuc",
                "obs_dir_pre_fix_name": "dir-test"
              },
              "log_transfer_mode": "cycle",
              "log_transfer_status": "DISABLE",
              "log_transfer_type": "OBS"
            }
          },
          {
            "log_group_id": "b26b441a-df2c-4e77-ab14-6299aa95c381",
            "log_group_name": "test-group-YGf",
            "log_streams": [
              {
                "log_stream_id": "4e3965e4-39a7-4c32-ad59-3596552b6ad1",
                "log_stream_name": "test-stream-jRW"
              }
            ],
            "log_transfer_id": "63343b97-a6f1-4ce2-a053-9e395a527e0b",
            "log_transfer_info": {
              "log_agency_transfer": {
                "agency_domain_id": "",
                "agency_domain_name": "",
                "agency_name": "",
                "agency_project_id": "",
                "be_agency_domain_id": "",
                "be_agency_project_id": ""
              },
              "log_create_time": 1685103693690,
              "log_storage_format": "RAW",
              "log_transfer_detail": {
                "obs_period": 3,
                "obs_prefix_name": "test",
                "obs_period_unit": "hour",
                "obs_transfer_path": "/obs-testhjlh6/LogTanks/eu-de/dir-test",
                "obs_bucket_name": "obs-testhjlh6",
                "obs_dir_pre_fix_name": "dir-test"
              },
              "log_transfer_mode": "cycle",
              "log_transfer_status": "DISABLE",
              "log_transfer_type": "OBS"
            }
          }
        ]
--- PASS: TestLtsTransferLifecycle (4.77s)
PASS

Process finished with the exit code 0
```