### PR TITLE
[WAF]: alarm page implementation

### DIFF
--- a/openstack/waf/v1/domains/requests.go
+++ b/openstack/waf/v1/domains/requests.go
@@ -81,6 +81,20 @@ type UpdateOpts struct {
 	SipHeaderName string `json:"sip_header_name,omitempty"`
 	// The HTTP request header for identifying the real source IP.
 	SipHeaderList []string `json:"sip_header_list,omitempty"`
+	// Alarm page configuration
+	BlockPage *BlockPage `json:"block_page,omitempty"`
+}
+
+type BlockPage struct {
+	Template    string      `json:"template" required:"true"`
+	CustomPage  *CustomPage `json:"custom_page,omitempty"`
+	RedirectUrl string      `json:"redirect_url,omitempty"`
+}
+
+type CustomPage struct {
+	StatusCode  string `json:"status_code" required:"true"`
+	ContentType string `json:"content_type" required:"true"`
+	Content     string `json:"content" required:"true"`
 }
 
 // ToDomainUpdateMap builds a update request body from UpdateOpts.

--- a/openstack/waf/v1/domains/results.go
+++ b/openstack/waf/v1/domains/results.go
@@ -39,6 +39,8 @@ type Domain struct {
 	SipHeaderName string `json:"sip_header_name"`
 	// The HTTP request header for identifying the real source IP.
 	SipHeaderList []string `json:"sip_header_list"`
+	// Alarm page configuration
+	BlockPage BlockPage `json:"block_page"`
 }
 
 type Server struct {


### PR DESCRIPTION
### What this PR does / why we need it
Implement possibility to change alarm block page to custom.

### Acceptance tests
=== RUN   TestDomainLifecycle
--- PASS: TestDomainLifecycle (10.48s)
PASS

Process finished with the exit code 0
