### PR TITLE
[CTS]: tracker v3 implementation for SWISS

### DIFF
--- a/acceptance/openstack/cts/helpers.go
+++ b/acceptance/openstack/cts/helpers.go
@@ -40,17 +40,19 @@ func DeleteOBSBucket(t *testing.T, bucketName string) {
 	objectsList, err := client.ListObjects(input)
 	th.AssertNoErr(t, err)
 
-	objects := make([]obs.ObjectToDelete, len(objectsList.Contents))
-	for i, content := range objectsList.Contents {
-		objects[i].Key = content.Key
+	if len(objectsList.Contents) > 0 {
+		objects := make([]obs.ObjectToDelete, len(objectsList.Contents))
+		for i, content := range objectsList.Contents {
+			objects[i].Key = content.Key
+		}
+		deleteOpts := &obs.DeleteObjectsInput{
+			Bucket:  bucketName,
+			Objects: objects,
+		}
+		_, err = client.DeleteObjects(deleteOpts)
+		th.AssertNoErr(t, err)
+		t.Logf("Deleted OBS Bucket objects: %s", objects)
 	}
-	deleteOpts := &obs.DeleteObjectsInput{
-		Bucket:  bucketName,
-		Objects: objects,
-	}
-	_, err = client.DeleteObjects(deleteOpts)
-	th.AssertNoErr(t, err)
-	t.Logf("Deleted OBS Bucket objects: %s", objects)
 
 	_, err = client.DeleteBucket(bucketName)
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/cts/v3/keyevents_test.go
+++ b/acceptance/openstack/cts/v3/keyevents_test.go
@@ -1,0 +1,58 @@
+package v3
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cts/v3/keyevent"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestKeyEventLifecycle(t *testing.T) {
+	client, err := clients.NewCTSV3Client()
+	th.AssertNoErr(t, err)
+
+	event, err := keyevent.Create(client, keyevent.CreateNotificationOpts{
+		NotificationName: tools.RandomString("keyevent_test_", 3),
+		OperationType:    "customized",
+		Operations: []keyevent.Operations{
+			{
+				ServiceType:  "OBS",
+				ResourceType: "bucket",
+				TraceNames:   []string{"createBucket"},
+			},
+		},
+	})
+	th.AssertNoErr(t, err)
+
+	t.Cleanup(func() {
+		err = keyevent.Delete(client, keyevent.DeleteOpts{
+			NotificationId: []string{event.NotificationId},
+		})
+		th.AssertNoErr(t, err)
+	})
+
+	list, err := keyevent.List(client, keyevent.ListNotificationsOpts{
+		NotificationType: "smn",
+		NotificationName: event.NotificationName,
+	})
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, list)
+
+	update, err := keyevent.Update(client, keyevent.UpdateNotificationOpts{
+		NotificationName: "keyevent_test_update",
+		Status:           "disabled",
+		OperationType:    "customized",
+		NotificationId:   event.NotificationId,
+		Operations: []keyevent.Operations{
+			{
+				ServiceType:  "OBS",
+				ResourceType: "bucket",
+				TraceNames:   []string{"deleteBucket"},
+			},
+		},
+	})
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, update)
+}

--- a/acceptance/openstack/cts/v3/trackers_test.go
+++ b/acceptance/openstack/cts/v3/trackers_test.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"os"
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
@@ -10,9 +11,9 @@ import (
 )
 
 func TestTrackersLifecycle(t *testing.T) {
-	// if os.Getenv("RUN_CTS_TRACKER") == "" {
-	// 	t.Skip("unstable test")
-	// }
+	if os.Getenv("RUN_CTS_TRACKER") == "" {
+		t.Skip("unstable test")
+	}
 	client, err := clients.NewCTSV3Client()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/cts/v3/trackers_test.go
+++ b/acceptance/openstack/cts/v3/trackers_test.go
@@ -4,55 +4,69 @@ import (
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
-	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cts/v3/keyevent"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack/cts"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cts/v3/tracker"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
 
-func TestKeyEventLifecycle(t *testing.T) {
+func TestTrackersLifecycle(t *testing.T) {
+	// if os.Getenv("RUN_CTS_TRACKER") == "" {
+	// 	t.Skip("unstable test")
+	// }
 	client, err := clients.NewCTSV3Client()
 	th.AssertNoErr(t, err)
 
-	event, err := keyevent.Create(client, keyevent.CreateNotificationOpts{
-		NotificationName: tools.RandomString("keyevent_test_", 3),
-		OperationType:    "customized",
-		Operations: []keyevent.Operations{
-			{
-				ServiceType:  "OBS",
-				ResourceType: "bucket",
-				TraceNames:   []string{"createBucket"},
-			},
+	bucketName := cts.CreateOBSBucket(t)
+	t.Cleanup(func() {
+		cts.DeleteOBSBucket(t, bucketName)
+	})
+
+	t.Logf("Attempting to create CTSv3 Tracker")
+	ctsTracker, err := tracker.Create(client, tracker.CreateOpts{
+		TrackerType:  "system",
+		TrackerName:  "system",
+		IsLtsEnabled: true,
+		ObsInfo: tracker.ObsInfo{
+			BucketName:     bucketName,
+			FilePrefixName: "test-prefix",
 		},
 	})
-	th.AssertNoErr(t, err)
 
 	t.Cleanup(func() {
-		err = keyevent.Delete(client, keyevent.DeleteOpts{
-			NotificationId: []string{event.NotificationId},
-		})
+		t.Logf("Attempting to delete CTSv3 Tracker: %s", ctsTracker.TrackerName)
+		err := tracker.Delete(client, ctsTracker.TrackerName)
 		th.AssertNoErr(t, err)
+		t.Logf("Deleted CTSv3 Tracker: %s", ctsTracker.TrackerName)
 	})
 
-	list, err := keyevent.List(client, keyevent.ListNotificationsOpts{
-		NotificationType: "smn",
-		NotificationName: event.NotificationName,
-	})
 	th.AssertNoErr(t, err)
-	tools.PrintResource(t, list)
+	t.Logf("Created CTSv3 Tracker: %s", ctsTracker.TrackerName)
+	th.AssertEquals(t, true, ctsTracker.Lts.IsLtsEnabled)
+	th.AssertEquals(t, "enabled", ctsTracker.Status)
+	th.AssertEquals(t, false, *ctsTracker.ObsInfo.IsObsCreated)
+	th.AssertEquals(t, bucketName, ctsTracker.ObsInfo.BucketName)
 
-	update, err := keyevent.Update(client, keyevent.UpdateNotificationOpts{
-		NotificationName: "keyevent_test_update",
-		Status:           "disabled",
-		OperationType:    "customized",
-		NotificationId:   event.NotificationId,
-		Operations: []keyevent.Operations{
-			{
-				ServiceType:  "OBS",
-				ResourceType: "bucket",
-				TraceNames:   []string{"deleteBucket"},
-			},
+	t.Logf("Attempting to update CTSv3 Tracker: %s", ctsTracker.TrackerName)
+	ltsEnable := false
+	_, err = tracker.Update(client, tracker.UpdateOpts{
+		TrackerName:  "system",
+		TrackerType:  "system",
+		Status:       "enabled",
+		IsLtsEnabled: &ltsEnable,
+		ObsInfo: tracker.ObsInfo{
+			FilePrefixName: "test-2-",
 		},
 	})
 	th.AssertNoErr(t, err)
-	tools.PrintResource(t, update)
+	t.Logf("Updated CTSv1 Tracker: %s", ctsTracker.TrackerName)
+
+	trackerList, err := tracker.List(client, ctsTracker.TrackerName)
+	trackerGet := trackerList[0]
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, trackerGet.TrackerType, "system")
+	th.AssertEquals(t, trackerGet.TrackerName, "system")
+	th.AssertEquals(t, trackerGet.Status, "enabled")
+	// if tracker is disabled LTS status can't be changed
+	th.AssertEquals(t, trackerGet.Lts.IsLtsEnabled, false)
+	th.AssertEquals(t, trackerGet.ObsInfo.FilePrefixName, "test-2-")
 }

--- a/openstack/cts/v3/tracker/Create.go
+++ b/openstack/cts/v3/tracker/Create.go
@@ -1,0 +1,42 @@
+package tracker
+
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type CreateOpts struct {
+	// Tracker type. The value can be system (management tracker).
+	TrackerType string `json:"tracker_type" required:"true"`
+	// Tracker name. When tracker_type is set to system, the default value system is used.
+	TrackerName string `json:"tracker_name" required:"true"`
+	// Configurations of an OBS bucket to which traces will be transferred.
+	ObsInfo ObsInfo `json:"obs_info,omitempty"`
+	// Indicates whether to enable trace analysis.
+	IsLtsEnabled bool `json:"is_lts_enabled,omitempty"`
+}
+
+type ObsInfo struct {
+	// OBS bucket name. The value contains 3 to 63 characters and must start with a digit or lowercase letter.
+	// Only lowercase letters, digits, hyphens (-), and periods (.) are allowed.
+	BucketName string `json:"bucket_name,omitempty"`
+	// Prefix of trace files that need to be stored in OBS buckets.
+	// The value can contain 0 to 64 characters, including letters, digits, hyphens (-), underscores (_), and periods (.).
+	FilePrefixName string `json:"file_prefix_name,omitempty"`
+	// Whether the OBS bucket is automatically created by the tracker.
+	IsObsCreated *bool `json:"is_obs_created,omitempty"`
+	// Duration that traces are stored in the OBS bucket. When tracker_type is set to system,
+	// the default value is 0, indicating permanent storage.
+	BucketLifecycle *int `json:"bucket_lifecycle,omitempty"`
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*Tracker, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST /3/{project_id}/tracker
+	raw, err := client.Post(client.ServiceURL("tracker"), b, nil, nil)
+	return extra(err, raw)
+}

--- a/openstack/cts/v3/tracker/Delete.go
+++ b/openstack/cts/v3/tracker/Delete.go
@@ -1,0 +1,10 @@
+package tracker
+
+import "github.com/opentelekomcloud/gophertelekomcloud"
+
+// Delete will permanently delete a particular tracker.
+func Delete(client *golangsdk.ServiceClient, trackerName string) (err error) {
+	// DELETE /v3/{project_id}/trackers?tracker_name=system
+	_, err = client.Delete(client.ServiceURL("trackers")+"?tracker_name="+trackerName, nil)
+	return
+}

--- a/openstack/cts/v3/tracker/List.go
+++ b/openstack/cts/v3/tracker/List.go
@@ -1,0 +1,11 @@
+package tracker
+
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+func List(client *golangsdk.ServiceClient, trackerName string) ([]Tracker, error) {
+	// GET /v3/{project_id}/trackers
+	raw, err := client.Get(client.ServiceURL("trackers")+"?tracker_name="+trackerName, nil, nil)
+	return extraStruct(err, raw)
+}

--- a/openstack/cts/v3/tracker/Update.go
+++ b/openstack/cts/v3/tracker/Update.go
@@ -1,0 +1,33 @@
+package tracker
+
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type UpdateOpts struct {
+	// Tracker type. The value can be system (management tracker).
+	TrackerType string `json:"tracker_type" required:"true"`
+	// Tracker name. When tracker_type is set to system, the default value system is used.
+	TrackerName string `json:"tracker_name" required:"true"`
+	// Configurations of an OBS bucket to which traces will be transferred.
+	ObsInfo ObsInfo `json:"obs_info,omitempty"`
+	// Indicates whether to enable trace analysis.
+	IsLtsEnabled *bool `json:"is_lts_enabled,omitempty"`
+	// Status of a tracker. The value can be enabled or disabled.
+	// If you change the value to disabled, the tracker stops recording traces.
+	Status string `json:"status,omitempty"`
+}
+
+func Update(client *golangsdk.ServiceClient, opts UpdateOpts) (*Tracker, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// PUT /3/{project_id}/tracker
+	raw, err := client.Put(client.ServiceURL("tracker"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return extra(err, raw)
+}

--- a/openstack/cts/v3/tracker/results.go
+++ b/openstack/cts/v3/tracker/results.go
@@ -1,0 +1,59 @@
+package tracker
+
+import (
+	"net/http"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type Tracker struct {
+	// Unique tracker ID.
+	Id string `json:"id"`
+	// Timestamp when the tracker was created.
+	CreateTime int64 `json:"create_time"`
+	// Trace analysis
+	Lts Lts `json:"lts"`
+	// Tracker type
+	TrackerType string `json:"tracker_type"`
+	// Account ID
+	DomainId string `json:"domain_id"`
+	// Project id
+	ProjectId string `json:"project_id"`
+	// Tracker name
+	TrackerName string `json:"tracker_name"`
+	// Tracker status
+	Status string `json:"status"`
+	// This parameter is returned only when the tracker status is error.
+	Detail string `json:"detail"`
+	// Tracker type
+	ObsInfo ObsInfo `json:"obs_info"`
+}
+
+type Lts struct {
+	// Whether trace analysis is enabled.
+	IsLtsEnabled bool `json:"is_lts_enabled"`
+	// Name of the Log Tank Service (LTS) log group.
+	LogGroupName string `json:"log_group_name"`
+	// Name of the LTS log stream.
+	LogTopicName string `json:"log_topic_name"`
+}
+
+func extra(err error, raw *http.Response) (*Tracker, error) {
+	if err != nil {
+		return nil, err
+	}
+
+	var res Tracker
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+func extraStruct(err error, raw *http.Response) ([]Tracker, error) {
+	if err != nil {
+		return nil, err
+	}
+	var res []Tracker
+
+	err = extract.IntoSlicePtr(raw.Body, &res, "trackers")
+	return res, err
+}


### PR DESCRIPTION
### What this PR does / why we need it
Implementation for cts tracker for SWISSCLOUD.

### Acceptance tests
=== RUN   TestTrackersLifecycle
    helpers.go:14: Attempting to create OBS bucket
    helpers.go:27: Created OBS Bucket: obs-cts-test3h5rs
    trackers_test.go:24: Attempting to create CTSv3 Tracker
    trackers_test.go:43: Created CTSv3 Tracker: system
    trackers_test.go:49: Attempting to update CTSv3 Tracker: system
    trackers_test.go:61: Updated CTSv1 Tracker: system
    trackers_test.go:36: Attempting to delete CTSv3 Tracker: system
    trackers_test.go:39: Deleted CTSv3 Tracker: system
    helpers.go:33: Attempting to delete OBS bucket: obs-cts-test3h5rs
    helpers.go:54: Deleted OBS Bucket objects: [{{ } CloudTraces/ } {{ } CloudTraces/eu-ch2/2023/06/20/system/LTS/test-prefix_CloudTrace_eu-ch2_2023-06-20T13-32-51Z_9b09a506c43264ef.json.gz }]
    helpers.go:59: Deleted OBS Bucket: obs-cts-test3h5rs
--- PASS: TestTrackersLifecycle (4.82s)
PASS

Process finished with the exit code 0