### PR TITLE
[VPC] security group rule port range nil value in response

### DIFF
--- a/acceptance/openstack/networking/v2/sgs/sg_test.go
+++ b/acceptance/openstack/networking/v2/sgs/sg_test.go
@@ -64,7 +64,7 @@ func TestICMPSecurityGroupRules(t *testing.T) {
 
 	getAll, err := rules.Get(clientNetworking, all.ID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, getAll.PortRangeMin, (*int)(nil))
+	th.AssertEquals(t, getAll.PortRangeMin)
 	th.AssertEquals(t, getAll.PortRangeMax, (*int)(nil))
 
 	optsEcho := rules.CreateOpts{

--- a/acceptance/openstack/networking/v2/sgs/sg_test.go
+++ b/acceptance/openstack/networking/v2/sgs/sg_test.go
@@ -6,10 +6,103 @@ import (
 
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/secgroups"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/security/rules"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
+
+func TestICMPSecurityGroupRules(t *testing.T) {
+	clientNetworking, err := clients.NewNetworkV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a networking client: %v", err)
+	}
+	clientCompute, err := clients.NewComputeV2Client()
+	if err != nil {
+		t.Fatalf("Unable to create a networking client: %v", err)
+	}
+
+	createSGOpts := secgroups.CreateOpts{
+		Name:        "sg-test-01",
+		Description: "desc",
+	}
+	t.Logf("Attempting to create sg: %s", createSGOpts.Name)
+
+	sg, err := secgroups.Create(clientCompute, createSGOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	optsEchoReply := rules.CreateOpts{
+		Description:  "ICMP echo reply",
+		SecGroupID:   sg.ID,
+		PortRangeMin: pointerto.Int(0),
+		PortRangeMax: pointerto.Int(0),
+		Direction:    "ingress",
+		EtherType:    "IPv4",
+		Protocol:     "ICMP",
+	}
+	log.Print("[DEBUG] Create OpenTelekomCloud Neutron ICMP echo reply Security Group Rule")
+	echoReply, err := rules.Create(clientNetworking, optsEchoReply).Extract()
+
+	getEchoReply, err := rules.Get(clientNetworking, echoReply.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, *getEchoReply.PortRangeMin, 0)
+	th.AssertEquals(t, *getEchoReply.PortRangeMax, 0)
+
+	optsAll := rules.CreateOpts{
+		Description:  "ICMP all",
+		SecGroupID:   sg.ID,
+		PortRangeMin: nil,
+		PortRangeMax: nil,
+		Direction:    "ingress",
+		EtherType:    "IPv4",
+		Protocol:     "ICMP",
+	}
+	log.Print("[DEBUG] Create OpenTelekomCloud Neutron ICMP All Security Group Rule")
+	all, err := rules.Create(clientNetworking, optsAll).Extract()
+
+	getAll, err := rules.Get(clientNetworking, all.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, getAll.PortRangeMin, (*int)(nil))
+	th.AssertEquals(t, getAll.PortRangeMax, (*int)(nil))
+
+	optsEcho := rules.CreateOpts{
+		Description:  "ICMP echo",
+		SecGroupID:   sg.ID,
+		PortRangeMin: pointerto.Int(8),
+		PortRangeMax: pointerto.Int(0),
+		Direction:    "ingress",
+		EtherType:    "IPv4",
+		Protocol:     "ICMP",
+	}
+	log.Print("[DEBUG] Create OpenTelekomCloud Neutron ICMP Echo Security Group Rule")
+	echo, err := rules.Create(clientNetworking, optsEcho).Extract()
+
+	getEcho, err := rules.Get(clientNetworking, echo.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, *getEcho.PortRangeMin, 8)
+	th.AssertEquals(t, *getEcho.PortRangeMax, 0)
+
+	optsFragment := rules.CreateOpts{
+		Description:  "ICMP Fragment need DF set",
+		SecGroupID:   sg.ID,
+		PortRangeMin: pointerto.Int(3),
+		PortRangeMax: pointerto.Int(4),
+		Direction:    "ingress",
+		EtherType:    "IPv4",
+		Protocol:     "ICMP",
+	}
+	log.Print("[DEBUG] Create OpenTelekomCloud Neutron ICMP Fragment need DF set Security Group Rule")
+	fragment, err := rules.Create(clientNetworking, optsFragment).Extract()
+
+	getFragment, err := rules.Get(clientNetworking, fragment.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, *getFragment.PortRangeMin, 3)
+	th.AssertEquals(t, *getFragment.PortRangeMax, 4)
+
+	t.Cleanup(func() {
+		secgroups.Delete(clientCompute, sg.ID)
+	})
+}
 
 func TestThrottlingSgs(t *testing.T) {
 	t.Skip("please run only manually, long test")

--- a/acceptance/openstack/networking/v2/sgs/sg_test.go
+++ b/acceptance/openstack/networking/v2/sgs/sg_test.go
@@ -42,6 +42,7 @@ func TestICMPSecurityGroupRules(t *testing.T) {
 	}
 	log.Print("[DEBUG] Create OpenTelekomCloud Neutron ICMP echo reply Security Group Rule")
 	echoReply, err := rules.Create(clientNetworking, optsEchoReply).Extract()
+	th.AssertNoErr(t, err)
 
 	getEchoReply, err := rules.Get(clientNetworking, echoReply.ID).Extract()
 	th.AssertNoErr(t, err)
@@ -59,6 +60,7 @@ func TestICMPSecurityGroupRules(t *testing.T) {
 	}
 	log.Print("[DEBUG] Create OpenTelekomCloud Neutron ICMP All Security Group Rule")
 	all, err := rules.Create(clientNetworking, optsAll).Extract()
+	th.AssertNoErr(t, err)
 
 	getAll, err := rules.Get(clientNetworking, all.ID).Extract()
 	th.AssertNoErr(t, err)
@@ -76,6 +78,7 @@ func TestICMPSecurityGroupRules(t *testing.T) {
 	}
 	log.Print("[DEBUG] Create OpenTelekomCloud Neutron ICMP Echo Security Group Rule")
 	echo, err := rules.Create(clientNetworking, optsEcho).Extract()
+	th.AssertNoErr(t, err)
 
 	getEcho, err := rules.Get(clientNetworking, echo.ID).Extract()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/networking/v2/sgs/sg_test.go
+++ b/acceptance/openstack/networking/v2/sgs/sg_test.go
@@ -64,7 +64,7 @@ func TestICMPSecurityGroupRules(t *testing.T) {
 
 	getAll, err := rules.Get(clientNetworking, all.ID).Extract()
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, getAll.PortRangeMin)
+	th.AssertEquals(t, getAll.PortRangeMin, (*int)(nil))
 	th.AssertEquals(t, getAll.PortRangeMax, (*int)(nil))
 
 	optsEcho := rules.CreateOpts{
@@ -96,6 +96,7 @@ func TestICMPSecurityGroupRules(t *testing.T) {
 	}
 	log.Print("[DEBUG] Create OpenTelekomCloud Neutron ICMP Fragment need DF set Security Group Rule")
 	fragment, err := rules.Create(clientNetworking, optsFragment).Extract()
+	th.AssertNoErr(t, err)
 
 	getFragment, err := rules.Get(clientNetworking, fragment.ID).Extract()
 	th.AssertNoErr(t, err)

--- a/openstack/networking/v2/extensions/security/rules/results.go
+++ b/openstack/networking/v2/extensions/security/rules/results.go
@@ -31,12 +31,12 @@ type SecGroupRule struct {
 	// rule. If the protocol is TCP or UDP, this value must be less than or equal
 	// to the value of the PortRangeMax attribute. If the protocol is ICMP, this
 	// value must be an ICMP type.
-	PortRangeMin int `json:"port_range_min"`
+	PortRangeMin *int `json:"port_range_min"`
 
 	// The maximum port number in the range that is matched by the security group
 	// rule. The PortRangeMin attribute constrains the PortRangeMax attribute. If
 	// the protocol is ICMP, this value must be an ICMP type.
-	PortRangeMax int `json:"port_range_max"`
+	PortRangeMax *int `json:"port_range_max"`
 
 	// The protocol that is matched by the security group rule. Valid values are
 	// "tcp", "udp", "icmp" or an empty string.

--- a/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/security/rules/testing/requests_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
 	fake "github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/common"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/security/rules"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
@@ -29,8 +30,8 @@ func TestList(t *testing.T) {
             "direction": "egress",
             "ethertype": "IPv6",
             "id": "3c0e45ff-adaf-4124-b083-bf390e5482ff",
-            "port_range_max": null,
-            "port_range_min": null,
+            "port_range_max": 0,
+            "port_range_min": 0,
             "protocol": null,
             "remote_group_id": null,
             "remote_ip_prefix": null,
@@ -69,8 +70,8 @@ func TestList(t *testing.T) {
 				Direction:      "egress",
 				EtherType:      "IPv6",
 				ID:             "3c0e45ff-adaf-4124-b083-bf390e5482ff",
-				PortRangeMax:   0,
-				PortRangeMin:   0,
+				PortRangeMax:   pointerto.Int(0),
+				PortRangeMin:   pointerto.Int(0),
 				Protocol:       "",
 				RemoteGroupID:  "",
 				RemoteIPPrefix: "",
@@ -81,8 +82,8 @@ func TestList(t *testing.T) {
 				Direction:      "egress",
 				EtherType:      "IPv4",
 				ID:             "93aa42e5-80db-4581-9391-3a608bd0e448",
-				PortRangeMax:   0,
-				PortRangeMin:   0,
+				PortRangeMax:   (*int)(nil),
+				PortRangeMin:   (*int)(nil),
 				Protocol:       "",
 				RemoteGroupID:  "",
 				RemoteIPPrefix: "",
@@ -214,8 +215,8 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, "egress", sr.Direction)
 	th.AssertEquals(t, "IPv6", sr.EtherType)
 	th.AssertEquals(t, "3c0e45ff-adaf-4124-b083-bf390e5482ff", sr.ID)
-	th.AssertEquals(t, 0, sr.PortRangeMax)
-	th.AssertEquals(t, 0, sr.PortRangeMin)
+	th.AssertEquals(t, (*int)(nil), sr.PortRangeMax)
+	th.AssertEquals(t, (*int)(nil), sr.PortRangeMin)
 	th.AssertEquals(t, "", sr.Protocol)
 	th.AssertEquals(t, "", sr.RemoteGroupID)
 	th.AssertEquals(t, "", sr.RemoteIPPrefix)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
Need to get proper values also for null from API response for proper handling of ICMP ranges

### What this PR does / why we need it

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
