### PR TITLE
[FWAAS]: remove `omitempty` from souce/destination ports

### DIFF
--- a/acceptance/openstack/networking/v2/fw_rule_test.go
+++ b/acceptance/openstack/networking/v2/fw_rule_test.go
@@ -1,0 +1,47 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/fwaas_v2/rules"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestFwRuleLifecycle(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to create BandwidthV2")
+	ruleName := tools.RandomString("band-create", 3)
+	createOpts := rules.CreateOpts{
+		Name:            ruleName,
+		Protocol:        "tcp",
+		Action:          "deny",
+		DestinationPort: "23",
+		Enabled:         pointerto.Bool(true),
+	}
+
+	rule, err := rules.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		t.Logf("Attempting to delete FwaasV2: %s", rule.ID)
+		err := rules.Delete(client, rule.ID).ExtractErr()
+		th.AssertNoErr(t, err)
+		t.Logf("Deleted FwaasV2: %s", rule.ID)
+	})
+	th.AssertEquals(t, createOpts.Name, rule.Name)
+	th.AssertEquals(t, createOpts.DestinationPort, rule.DestinationPort)
+	t.Logf("Created FwaasV2: %s", rule.ID)
+
+	t.Logf("Attempting to update FwaasV2: %s", rule.ID)
+	updateOpts := rules.UpdateOpts{
+		Protocol: pointerto.String("icmp"),
+	}
+	updatedRule, err := rules.Update(client, rule.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Updated FwaasV2: %s", rule.ID)
+	th.AssertEquals(t, updatedRule.Protocol, *updateOpts.Protocol)
+}

--- a/openstack/networking/v2/extensions/fwaas_v2/rules/requests.go
+++ b/openstack/networking/v2/extensions/fwaas_v2/rules/requests.go
@@ -157,8 +157,8 @@ type UpdateOpts struct {
 	IPVersion            *golangsdk.IPVersion `json:"ip_version,omitempty"`
 	SourceIPAddress      *string              `json:"source_ip_address,omitempty"`
 	DestinationIPAddress *string              `json:"destination_ip_address,omitempty"`
-	SourcePort           *string              `json:"source_port,omitempty"`
-	DestinationPort      *string              `json:"destination_port,omitempty"`
+	SourcePort           *string              `json:"source_port"`
+	DestinationPort      *string              `json:"destination_port"`
 	Shared               *bool                `json:"shared,omitempty"`
 	Enabled              *bool                `json:"enabled,omitempty"`
 }


### PR DESCRIPTION
### What this PR does / why we need it
Remove `omitempty` so `source` and `destination` ports could assign `nil` value.
Test added.