### PR TITLE
RDS: table names case sensitivity

### DIFF
--- a/acceptance/openstack/rds/v3/helpers.go
+++ b/acceptance/openstack/rds/v3/helpers.go
@@ -49,6 +49,9 @@ func CreateRDS(t *testing.T, client *golangsdk.ServiceClient, region string) *in
 			Type:    "PostgreSQL",
 			Version: "11",
 		},
+		UnchangeableParam: &instances.Param{
+			LowerCaseTableNames: "0",
+		},
 	}
 
 	rds, err := instances.Create(client, createRdsOpts)

--- a/openstack/rds/v3/instances/Create.go
+++ b/openstack/rds/v3/instances/Create.go
@@ -64,7 +64,8 @@ type CreateRdsOpts struct {
 	// Specifies the billing information, which is pay-per-use. By default, pay-per-use is used.
 	ChargeInfo *ChargeInfo `json:"charge_info,omitempty"`
 	// This parameter applies only to Microsoft SQL Server DB instances.
-	Collation string `json:"collation,omitempty"`
+	Collation         string `json:"collation,omitempty"`
+	UnchangeableParam *Param `json:"unchangeable_param,omitempty"`
 }
 
 type Datastore struct {
@@ -112,6 +113,10 @@ type BackupStrategy struct {
 	// NOTICE
 	// Primary/standby DB instances and Cluster DB instances of Microsoft SQL Server do not support disabling the automated backup policy.
 	KeepDays int `json:"keep_days,omitempty"`
+}
+
+type Param struct {
+	LowerCaseTableNames string `json:"lower_case_table_names"`
 }
 
 func Create(client *golangsdk.ServiceClient, opts CreateRdsOpts) (*CreateRds, error) {


### PR DESCRIPTION
### What this PR does / why we need it
Additional DB parameter to set case sensitivity for table names.