### PR TITLE
[DCaaS] Implementing Direct Connect as a Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/*.swp
 .idea
+.DS_Store

--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -145,6 +145,20 @@ func NewCTSV3Client() (*golangsdk.ServiceClient, error) {
 	})
 }
 
+// NewDCaaSV2Client returns a *ServiceClient for making calls
+// to the OpenStack v2 API. An error will be returned
+// if authentication or client creation was not possible.
+func NewDCaaSV2Client() (*golangsdk.ServiceClient, error) {
+	cc, err := CloudAndClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return openstack.NewDCaaSV2(cc.ProviderClient, golangsdk.EndpointOpts{
+		Region: cc.RegionName,
+	})
+}
+
 // NewDNSV2Client returns a *ServiceClient for making calls
 // to the OpenStack Compute v2 API. An error will be returned
 // if authentication or client creation was not possible.

--- a/acceptance/openstack/dcaas/v2/dcaas_acc_test.go
+++ b/acceptance/openstack/dcaas/v2/dcaas_acc_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -14,6 +15,10 @@ import (
 )
 
 func TestDCAASLifecycle(t *testing.T) {
+	if os.Getenv("RUN_DCAAS_VIRTUAL_INTERFACE") == "" {
+		t.Skip("unstable test")
+	}
+
 	// Create client
 	client, err := clients.NewDCaaSV2Client()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/dcaas/v2/dcaas_acc_test.go
+++ b/acceptance/openstack/dcaas/v2/dcaas_acc_test.go
@@ -1,0 +1,104 @@
+package v2
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	dc_endpoint_group "github.com/opentelekomcloud/gophertelekomcloud/openstack/dcaas/v2/dc-endpoint-group"
+	direct_connect "github.com/opentelekomcloud/gophertelekomcloud/openstack/dcaas/v2/direct-connect"
+	virtual_gateway "github.com/opentelekomcloud/gophertelekomcloud/openstack/dcaas/v2/virtual-gateway"
+	virtual_interface "github.com/opentelekomcloud/gophertelekomcloud/openstack/dcaas/v2/virtual-interface"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestDCAASLifecycle(t *testing.T) {
+	// Create client
+	client, err := clients.NewDCaaSV2Client()
+	th.AssertNoErr(t, err)
+
+	// Create a direct connect
+	name := strings.ToLower(tools.RandomString("test-direct-connect-", 5))
+	createOpts := direct_connect.CreateOpts{
+		Name:      name,
+		PortType:  "1G",
+		Bandwidth: 100,
+		Location:  "Biere",
+		Provider:  "OTC",
+	}
+
+	dc, err := direct_connect.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+
+	// Get a direct connect
+	_, err = direct_connect.Get(client, dc.ID)
+	th.AssertNoErr(t, err)
+
+	// List direct connects
+	_, err = direct_connect.List(client, dc.ID)
+	th.AssertNoErr(t, err)
+
+	// Update a direct connect
+	updateOpts := direct_connect.UpdateOpts{
+		Name:        tools.RandomString(name, 3),
+		Description: "Updated description",
+	}
+	_ = direct_connect.Update(client, dc.ID, updateOpts)
+	th.AssertNoErr(t, err)
+
+	// Create a direct connect endpoint group
+	DCegName := strings.ToLower(tools.RandomString("test-direct-connect-endpoint-group-", 5))
+
+	TenantId := clients.EnvOS.GetEnv("TENANT_ID")
+
+	DCEGCreateOpts := dc_endpoint_group.CreateOpts{
+		TenantId:  TenantId,
+		Name:      DCegName,
+		Endpoints: []string{"10.2.0.0/24", "10.3.0.0/24"},
+		Type:      "cidr",
+	}
+
+	dceg, err := dc_endpoint_group.Create(client, DCEGCreateOpts)
+	th.AssertNoErr(t, err)
+
+	// Create a virtual gateway
+	VgName := strings.ToLower(tools.RandomString("test-virtual-gateway-", 5))
+	VgCreateOpts := virtual_gateway.CreateOpts{
+		Name:                 VgName,
+		VpcId:                clients.EnvOS.GetEnv("VPC_ID"),
+		LocalEndpointGroupId: dceg.ID,
+		Type:                 "default",
+	}
+
+	VG, err := virtual_gateway.Create(client, VgCreateOpts)
+	th.AssertNoErr(t, err)
+
+	// Create a virtual interface fails with error
+	ViName := strings.ToLower(tools.RandomString("test-virtual-interface-", 5))
+	ViCreateOpts := virtual_interface.CreateOpts{
+		Name:              ViName,
+		DirectConnectID:   dc.ID,
+		VgwID:             VG.ID,
+		Type:              "private",
+		ServiceType:       "vpc",
+		VLAN:              2511,
+		Bandwidth:         50,
+		LocalGatewayV4IP:  "16.16.16.1/30",
+		RemoteGatewayV4IP: "16.16.16.2/30",
+		RouteMode:         "static",
+		RemoteEPGroupID:   "a2b81f07-826f-40b0-9e8d-17d1af5230cf",
+	}
+
+	Vi, err := virtual_interface.Create(client, ViCreateOpts)
+	th.AssertNoErr(t, err)
+
+	// Cleanup
+	t.Cleanup(func() {
+		err = virtual_interface.Delete(client, Vi.ID)
+		err = virtual_gateway.Delete(client, VG.ID)
+		err = dc_endpoint_group.Delete(client, dceg.ID)
+		err = direct_connect.Delete(client, dc.ID)
+		th.AssertNoErr(t, err)
+	})
+}

--- a/acceptance/openstack/dcaas/v2/direct_connect_endpoint_group_test.go
+++ b/acceptance/openstack/dcaas/v2/direct_connect_endpoint_group_test.go
@@ -18,7 +18,7 @@ func TestDirectConnectEndpointGroupLifecycle(t *testing.T) {
 	name := strings.ToLower(tools.RandomString("test-direct-connect-endpoint-group", 5))
 
 	createOpts := dc_endpoint_group.CreateOpts{
-		TenantId:  "6fbe9263116a4b68818cf1edce16bc4f",
+		TenantId:  clients.EnvOS.GetEnv("OS_TENANT_ID"),
 		Name:      name,
 		Endpoints: []string{"10.2.0.0/24", "10.3.0.0/24"},
 		Type:      "cidr",

--- a/acceptance/openstack/dcaas/v2/direct_connect_endpoint_group_test.go
+++ b/acceptance/openstack/dcaas/v2/direct_connect_endpoint_group_test.go
@@ -39,10 +39,7 @@ func TestDirectConnectEndpointGroupLifecycle(t *testing.T) {
 	_ = dc_endpoint_group.Update(client, created.ID, updateOpts)
 
 	// List direct connect endpoint groups
-	listOpts := dc_endpoint_group.ListOpts{
-		ID: created.ID,
-	}
-	_, err = dc_endpoint_group.List(client, listOpts)
+	_, err = dc_endpoint_group.List(client, created.ID)
 	th.AssertNoErr(t, err)
 
 	// Cleanup

--- a/acceptance/openstack/dcaas/v2/direct_connect_endpoint_group_test.go
+++ b/acceptance/openstack/dcaas/v2/direct_connect_endpoint_group_test.go
@@ -1,0 +1,41 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	dc_endpoint_group "github.com/opentelekomcloud/gophertelekomcloud/openstack/dcaas/v2/dc-endpoint-group"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestDirectConnectEndpointGroupLifecycle(t *testing.T) {
+	// Create a direct connect endpoint group
+	client, err := clients.NewDCaaSV2Client()
+	th.AssertNoErr(t, err)
+
+	createOpts := dc_endpoint_group.CreateOpts{
+		Name:      "test-direct-connect-endpoint-group",
+		Endpoints: []string{"10.2.0.0/24", "10.3.0.0/24"},
+		Type:      "cidr",
+	}
+
+	created, err := dc_endpoint_group.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+
+	// Get a direct connect endpoint group
+	_, err = dc_endpoint_group.Get(client, created.ID)
+	th.AssertNoErr(t, err)
+
+	// List direct connect endpoint groups
+	listOpts := dc_endpoint_group.ListOpts{
+		ID: created.ID,
+	}
+	_, err = dc_endpoint_group.List(client, listOpts)
+	th.AssertNoErr(t, err)
+
+	// Cleanup
+	t.Cleanup(func() {
+		err = dc_endpoint_group.Delete(client, created.ID)
+		th.AssertNoErr(t, err)
+	})
+}

--- a/acceptance/openstack/dcaas/v2/direct_connect_endpoint_group_test.go
+++ b/acceptance/openstack/dcaas/v2/direct_connect_endpoint_group_test.go
@@ -14,6 +14,7 @@ func TestDirectConnectEndpointGroupLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	createOpts := dc_endpoint_group.CreateOpts{
+		TenantId:  "6fbe9263116a4b68818cf1edce16bc4f",
 		Name:      "test-direct-connect-endpoint-group",
 		Endpoints: []string{"10.2.0.0/24", "10.3.0.0/24"},
 		Type:      "cidr",
@@ -25,6 +26,13 @@ func TestDirectConnectEndpointGroupLifecycle(t *testing.T) {
 	// Get a direct connect endpoint group
 	_, err = dc_endpoint_group.Get(client, created.ID)
 	th.AssertNoErr(t, err)
+
+	// Update a direct connect endpoint group
+	updateOpts := dc_endpoint_group.UpdateOpts{
+		Name:        "test-direct-connect-endpoint-group-updated",
+		Description: "test-direct-connect-endpoint-group-updated",
+	}
+	_ = dc_endpoint_group.Update(client, created.ID, updateOpts)
 
 	// List direct connect endpoint groups
 	listOpts := dc_endpoint_group.ListOpts{

--- a/acceptance/openstack/dcaas/v2/direct_connect_endpoint_group_test.go
+++ b/acceptance/openstack/dcaas/v2/direct_connect_endpoint_group_test.go
@@ -16,9 +16,10 @@ func TestDirectConnectEndpointGroupLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	name := strings.ToLower(tools.RandomString("test-direct-connect-endpoint-group", 5))
+	TenantId := clients.EnvOS.GetEnv("TENANT_ID")
 
 	createOpts := dc_endpoint_group.CreateOpts{
-		TenantId:  clients.EnvOS.GetEnv("OS_TENANT_ID"),
+		TenantId:  TenantId,
 		Name:      name,
 		Endpoints: []string{"10.2.0.0/24", "10.3.0.0/24"},
 		Type:      "cidr",

--- a/acceptance/openstack/dcaas/v2/direct_connect_endpoint_group_test.go
+++ b/acceptance/openstack/dcaas/v2/direct_connect_endpoint_group_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -11,6 +12,10 @@ import (
 )
 
 func TestDirectConnectEndpointGroupLifecycle(t *testing.T) {
+	if os.Getenv("RUN_DCAAS_DIRECT_CONNECT_ENDPOINT_GROUP") == "" {
+		t.Skip("unstable test")
+	}
+
 	// Create a direct connect endpoint group
 	client, err := clients.NewDCaaSV2Client()
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/dcaas/v2/direct_connect_endpoint_group_test.go
+++ b/acceptance/openstack/dcaas/v2/direct_connect_endpoint_group_test.go
@@ -1,9 +1,11 @@
 package v2
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	dc_endpoint_group "github.com/opentelekomcloud/gophertelekomcloud/openstack/dcaas/v2/dc-endpoint-group"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
@@ -13,9 +15,11 @@ func TestDirectConnectEndpointGroupLifecycle(t *testing.T) {
 	client, err := clients.NewDCaaSV2Client()
 	th.AssertNoErr(t, err)
 
+	name := strings.ToLower(tools.RandomString("test-direct-connect-endpoint-group", 5))
+
 	createOpts := dc_endpoint_group.CreateOpts{
 		TenantId:  "6fbe9263116a4b68818cf1edce16bc4f",
-		Name:      "test-direct-connect-endpoint-group",
+		Name:      name,
 		Endpoints: []string{"10.2.0.0/24", "10.3.0.0/24"},
 		Type:      "cidr",
 	}
@@ -29,7 +33,7 @@ func TestDirectConnectEndpointGroupLifecycle(t *testing.T) {
 
 	// Update a direct connect endpoint group
 	updateOpts := dc_endpoint_group.UpdateOpts{
-		Name:        "test-direct-connect-endpoint-group-updated",
+		Name:        tools.RandomString(name, 3),
 		Description: "test-direct-connect-endpoint-group-updated",
 	}
 	_ = dc_endpoint_group.Update(client, created.ID, updateOpts)

--- a/acceptance/openstack/dcaas/v2/direct_connect_test.go
+++ b/acceptance/openstack/dcaas/v2/direct_connect_test.go
@@ -1,0 +1,34 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	direct_connect "github.com/opentelekomcloud/gophertelekomcloud/openstack/dcaas/v2/direct-connect"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestDirectConnectLifecycle(t *testing.T) {
+	client, err := clients.NewDCaaSV2Client()
+	th.AssertNoErr(t, err)
+
+	// Create a direct connect
+	createOpts := direct_connect.CreateOpts{
+		Name:      "test-direct-connect",
+		PortType:  "1G",
+		Bandwidth: 1000,
+		Location:  "Biere",
+		Provider:  "OTC",
+	}
+
+	created, err := direct_connect.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+
+	_, err = direct_connect.Get(client, created.ID)
+	th.AssertNoErr(t, err)
+
+	t.Cleanup(func() {
+		err = direct_connect.Delete(client, created.ID)
+		th.AssertNoErr(t, err)
+	})
+}

--- a/acceptance/openstack/dcaas/v2/direct_connect_test.go
+++ b/acceptance/openstack/dcaas/v2/direct_connect_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestDirectConnectLifecycle(t *testing.T) {
 	createOpts := direct_connect.CreateOpts{
 		Name:      name,
 		PortType:  "1G",
-		Bandwidth: 1000,
+		Bandwidth: 100,
 		Location:  "Biere",
 		Provider:  "OTC",
 	}
@@ -28,20 +29,25 @@ func TestDirectConnectLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	// Get a direct connect
-	_, err = direct_connect.Get(client, created.ID)
+	get, err := direct_connect.Get(client, created.ID)
+	fmt.Println(get)
 	th.AssertNoErr(t, err)
 
 	// List direct connects
-	_, err = direct_connect.List(client, created.ID)
+	listed, err := direct_connect.List(client, created.ID)
+	fmt.Println(listed)
+
 	th.AssertNoErr(t, err)
 
 	// Update a direct connect
 	updateOpts := direct_connect.UpdateOpts{
 		Name:        tools.RandomString(name, 3),
 		Description: "Updated description",
+		Bandwidth:   200,
 	}
 
-	_ = direct_connect.Update(client, created.ID, updateOpts)
+	updated := direct_connect.Update(client, created.ID, updateOpts)
+	fmt.Println(updated)
 
 	// Cleanup
 	t.Cleanup(func() {

--- a/acceptance/openstack/dcaas/v2/direct_connect_test.go
+++ b/acceptance/openstack/dcaas/v2/direct_connect_test.go
@@ -24,9 +24,18 @@ func TestDirectConnectLifecycle(t *testing.T) {
 	created, err := direct_connect.Create(client, createOpts)
 	th.AssertNoErr(t, err)
 
+	// Get a direct connect
 	_, err = direct_connect.Get(client, created.ID)
 	th.AssertNoErr(t, err)
 
+	// List direct connects
+	listOpts := direct_connect.ListOpts{
+		ID: created.ID,
+	}
+	_, err = direct_connect.List(client, listOpts)
+	th.AssertNoErr(t, err)
+
+	// Cleanup
 	t.Cleanup(func() {
 		err = direct_connect.Delete(client, created.ID)
 		th.AssertNoErr(t, err)

--- a/acceptance/openstack/dcaas/v2/direct_connect_test.go
+++ b/acceptance/openstack/dcaas/v2/direct_connect_test.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -12,6 +13,10 @@ import (
 )
 
 func TestDirectConnectLifecycle(t *testing.T) {
+	if os.Getenv("RUN_DCAAS_DIRECT_CONNECT") == "" {
+		t.Skip("unstable test")
+	}
+
 	client, err := clients.NewDCaaSV2Client()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/dcaas/v2/direct_connect_test.go
+++ b/acceptance/openstack/dcaas/v2/direct_connect_test.go
@@ -1,9 +1,11 @@
 package v2
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	direct_connect "github.com/opentelekomcloud/gophertelekomcloud/openstack/dcaas/v2/direct-connect"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
@@ -13,8 +15,9 @@ func TestDirectConnectLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	// Create a direct connect
+	name := strings.ToLower(tools.RandomString("test-direct-connect", 5))
 	createOpts := direct_connect.CreateOpts{
-		Name:      "test-direct-connect",
+		Name:      name,
 		PortType:  "1G",
 		Bandwidth: 1000,
 		Location:  "Biere",
@@ -34,6 +37,14 @@ func TestDirectConnectLifecycle(t *testing.T) {
 	}
 	_, err = direct_connect.List(client, listOpts)
 	th.AssertNoErr(t, err)
+
+	// Update a direct connect
+	updateOpts := direct_connect.UpdateOpts{
+		Name:        tools.RandomString(name, 3),
+		Description: "Updated description",
+	}
+
+	_ = direct_connect.Update(client, created.ID, updateOpts)
 
 	// Cleanup
 	t.Cleanup(func() {

--- a/acceptance/openstack/dcaas/v2/direct_connect_test.go
+++ b/acceptance/openstack/dcaas/v2/direct_connect_test.go
@@ -32,10 +32,7 @@ func TestDirectConnectLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	// List direct connects
-	listOpts := direct_connect.ListOpts{
-		ID: created.ID,
-	}
-	_, err = direct_connect.List(client, listOpts)
+	_, err = direct_connect.List(client, created.ID)
 	th.AssertNoErr(t, err)
 
 	// Update a direct connect

--- a/acceptance/openstack/dcaas/v2/virtual_gateway_test.go
+++ b/acceptance/openstack/dcaas/v2/virtual_gateway_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -11,6 +12,10 @@ import (
 )
 
 func TestVirtualGatewayLifecycle(t *testing.T) {
+	if os.Getenv("RUN_DCAAS_VIRTUAL_GATEWAY") == "" {
+		t.Skip("unstable test")
+	}
+
 	client, err := clients.NewDCaaSV2Client()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/dcaas/v2/virtual_gateway_test.go
+++ b/acceptance/openstack/dcaas/v2/virtual_gateway_test.go
@@ -37,6 +37,9 @@ func TestVirtualGatewayLifecycle(t *testing.T) {
 	_ = virtual_gateway.Update(client, created.ID, updateOpts)
 	th.AssertNoErr(t, err)
 
+	_, err = virtual_gateway.List(client, created.ID)
+	th.AssertNoErr(t, err)
+
 	t.Cleanup(func() {
 		err = virtual_gateway.Delete(client, created.ID)
 		th.AssertNoErr(t, err)

--- a/acceptance/openstack/dcaas/v2/virtual_gateway_test.go
+++ b/acceptance/openstack/dcaas/v2/virtual_gateway_test.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
@@ -25,19 +24,15 @@ func TestVirtualGatewayLifecycle(t *testing.T) {
 	created, err := virtual_gateway.Create(client, createOpts)
 	th.AssertNoErr(t, err)
 
-	get, err := virtual_gateway.Get(client, created.ID)
+	_, err = virtual_gateway.Get(client, created.ID)
 	th.AssertNoErr(t, err)
-
-	fmt.Print(get)
 
 	updateOpts := virtual_gateway.UpdateOpts{
 		Name:        "test-virtual-interface-updated",
 		Description: "test-virtual-interface-updated",
 	}
-	updated := virtual_gateway.Update(client, created.ID, updateOpts)
+	_ = virtual_gateway.Update(client, created.ID, updateOpts)
 	th.AssertNoErr(t, err)
-
-	fmt.Print(updated)
 
 	t.Cleanup(func() {
 		err = virtual_gateway.Delete(client, created.ID)

--- a/acceptance/openstack/dcaas/v2/virtual_gateway_test.go
+++ b/acceptance/openstack/dcaas/v2/virtual_gateway_test.go
@@ -1,9 +1,11 @@
 package v2
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dcaas/v2/virtual-gateway"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
@@ -13,8 +15,9 @@ func TestVirtualGatewayLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	// Create a virtual gateway
+	name := strings.ToLower(tools.RandomString("test-virtual-gateway", 5))
 	createOpts := virtual_gateway.CreateOpts{
-		Name:                 "test-virtual-interface",
+		Name:                 name,
 		Type:                 "default",
 		VpcId:                "0bd45fdf-bf78-41e5-bd08-99f1c65e0147",
 		Description:          "test-virtual-interface",
@@ -28,7 +31,7 @@ func TestVirtualGatewayLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	updateOpts := virtual_gateway.UpdateOpts{
-		Name:        "test-virtual-interface-updated",
+		Name:        tools.RandomString(name, 3),
 		Description: "test-virtual-interface-updated",
 	}
 	_ = virtual_gateway.Update(client, created.ID, updateOpts)

--- a/acceptance/openstack/dcaas/v2/virtual_gateway_test.go
+++ b/acceptance/openstack/dcaas/v2/virtual_gateway_test.go
@@ -1,0 +1,46 @@
+package v2
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dcaas/v2/virtual-gateway"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestVirtualGatewayLifecycle(t *testing.T) {
+	client, err := clients.NewDCaaSV2Client()
+	th.AssertNoErr(t, err)
+
+	// Create a virtual gateway
+	createOpts := virtual_gateway.CreateOpts{
+		Name:                 "test-virtual-interface",
+		Type:                 "default",
+		VpcId:                "0bd45fdf-bf78-41e5-bd08-99f1c65e0147",
+		Description:          "test-virtual-interface",
+		LocalEndpointGroupId: "719dd2a3-34a7-401b-935f-16d9a217ff8b",
+	}
+
+	created, err := virtual_gateway.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+
+	get, err := virtual_gateway.Get(client, created.ID)
+	th.AssertNoErr(t, err)
+
+	fmt.Print(get)
+
+	updateOpts := virtual_gateway.UpdateOpts{
+		Name:        "test-virtual-interface-updated",
+		Description: "test-virtual-interface-updated",
+	}
+	updated := virtual_gateway.Update(client, created.ID, updateOpts)
+	th.AssertNoErr(t, err)
+
+	fmt.Print(updated)
+
+	t.Cleanup(func() {
+		err = virtual_gateway.Delete(client, created.ID)
+		th.AssertNoErr(t, err)
+	})
+}

--- a/acceptance/openstack/dcaas/v2/virtual_gateway_test.go
+++ b/acceptance/openstack/dcaas/v2/virtual_gateway_test.go
@@ -19,9 +19,9 @@ func TestVirtualGatewayLifecycle(t *testing.T) {
 	createOpts := virtual_gateway.CreateOpts{
 		Name:                 name,
 		Type:                 "default",
-		VpcId:                "0bd45fdf-bf78-41e5-bd08-99f1c65e0147",
+		VpcId:                clients.EnvOS.GetEnv("VPC_ID"),
 		Description:          "test-virtual-interface",
-		LocalEndpointGroupId: "719dd2a3-34a7-401b-935f-16d9a217ff8b",
+		LocalEndpointGroupId: clients.EnvOS.GetEnv("LOCAL_ENDPOINT_GROUP_ID"),
 	}
 
 	created, err := virtual_gateway.Create(client, createOpts)

--- a/acceptance/openstack/dcaas/v2/virtual_interface_test.go
+++ b/acceptance/openstack/dcaas/v2/virtual_interface_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"os"
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
@@ -10,6 +11,9 @@ import (
 )
 
 func TestVirtualInterfaceLifecycle(t *testing.T) {
+	if os.Getenv("RUN_DCAAS_VIRTUAL_INTERFACE") == "" {
+		t.Skip("unstable test")
+	}
 	client, err := clients.NewDCaaSV2Client()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/dcaas/v2/virtual_interface_test.go
+++ b/acceptance/openstack/dcaas/v2/virtual_interface_test.go
@@ -17,8 +17,8 @@ func TestVirtualInterfaceLifecycle(t *testing.T) {
 	name := tools.RandomString("test-virtual-interface", 5)
 	createOpts := virtual_interface.CreateOpts{
 		Name:              name,
-		DirectConnectID:   "b07d42dc-6137-4af3-a93b-853d879ae268",
-		VgwID:             "d27d5bd2-97b3-4bd8-b7e5-189a71c14846",
+		DirectConnectID:   clients.EnvOS.GetEnv("DIRECT_CONNECT_ID"),
+		VgwID:             clients.EnvOS.GetEnv("VIRTUAL_GATEWAY_ID"),
 		Type:              "private",
 		ServiceType:       "vpc",
 		VLAN:              100,
@@ -26,7 +26,7 @@ func TestVirtualInterfaceLifecycle(t *testing.T) {
 		LocalGatewayV4IP:  "16.16.16.1/30",
 		RemoteGatewayV4IP: "16.16.16.2/30",
 		RouteMode:         "static",
-		RemoteEPGroupID:   "31dd8536-1ac7-4a38-b2fc-178a69f11b11",
+		RemoteEPGroupID:   clients.EnvOS.GetEnv("REMOTE_ENDPOINT_GROUP_ID"),
 	}
 
 	created, err := virtual_interface.Create(client, createOpts)

--- a/acceptance/openstack/dcaas/v2/virtual_interface_test.go
+++ b/acceptance/openstack/dcaas/v2/virtual_interface_test.go
@@ -1,0 +1,37 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dcaas/v2/virtual-interface"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestVirtualInterfaceLifecycle(t *testing.T) {
+	client, err := clients.NewDCaaSV2Client()
+	th.AssertNoErr(t, err)
+
+	// Create a virtual interface
+	createOpts := virtual_interface.CreateOpts{
+		Name:              "test-virtual-interface",
+		DirectConnectID:   "test-direct-connect-id",
+		VgwID:             "test-vgw-id",
+		Type:              "private",
+		ServiceType:       "vpc",
+		VLAN:              100,
+		Bandwidth:         100,
+		LocalGatewayV4IP:  "192.168.0.1",
+		RemoteGatewayV4IP: "192.168.1.1",
+		RouteMode:         "static",
+		RemoteEPGroupID:   "test-remote-ep-group-id",
+	}
+
+	created, err := virtual_interface.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+	
+	t.Cleanup(func() {
+		err = virtual_interface.Delete(client, created.ID)
+		th.AssertNoErr(t, err)
+	})
+}

--- a/acceptance/openstack/dcaas/v2/virtual_interface_test.go
+++ b/acceptance/openstack/dcaas/v2/virtual_interface_test.go
@@ -15,7 +15,7 @@ func TestVirtualInterfaceLifecycle(t *testing.T) {
 	// Create a virtual interface
 	createOpts := virtual_interface.CreateOpts{
 		Name:              "test-virtual-interface",
-		DirectConnectID:   "test-direct-connect-id",
+		DirectConnectID:   "test-direct-connect-uuid",
 		VgwID:             "test-vgw-id",
 		Type:              "private",
 		ServiceType:       "vpc",
@@ -29,7 +29,7 @@ func TestVirtualInterfaceLifecycle(t *testing.T) {
 
 	created, err := virtual_interface.Create(client, createOpts)
 	th.AssertNoErr(t, err)
-	
+
 	t.Cleanup(func() {
 		err = virtual_interface.Delete(client, created.ID)
 		th.AssertNoErr(t, err)

--- a/acceptance/openstack/dcaas/v2/virtual_interface_test.go
+++ b/acceptance/openstack/dcaas/v2/virtual_interface_test.go
@@ -41,6 +41,11 @@ func TestVirtualInterfaceLifecycle(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 
+	// List virtual interfaces
+	_, err = virtual_interface.List(client, created.ID)
+	th.AssertNoErr(t, err)
+
+	// Cleanup
 	t.Cleanup(func() {
 		err = virtual_interface.Delete(client, created.ID)
 		th.AssertNoErr(t, err)

--- a/acceptance/openstack/dcaas/v2/virtual_interface_test.go
+++ b/acceptance/openstack/dcaas/v2/virtual_interface_test.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
@@ -31,10 +30,14 @@ func TestVirtualInterfaceLifecycle(t *testing.T) {
 	created, err := virtual_interface.Create(client, createOpts)
 	th.AssertNoErr(t, err)
 
-	got, err := virtual_interface.Get(client, created.ID)
+	_, err = virtual_interface.Get(client, created.ID)
 	th.AssertNoErr(t, err)
 
-	fmt.Print(got)
+	_ = virtual_interface.Update(client, created.ID, virtual_interface.UpdateOpts{
+		Name:        "test-virtual-interface-updated",
+		Description: "New description",
+	})
+	th.AssertNoErr(t, err)
 
 	t.Cleanup(func() {
 		err = virtual_interface.Delete(client, created.ID)

--- a/acceptance/openstack/dcaas/v2/virtual_interface_test.go
+++ b/acceptance/openstack/dcaas/v2/virtual_interface_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dcaas/v2/virtual-interface"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
@@ -13,8 +14,9 @@ func TestVirtualInterfaceLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	// Create a virtual interface
+	name := tools.RandomString("test-virtual-interface", 5)
 	createOpts := virtual_interface.CreateOpts{
-		Name:              "test-virtual-interface",
+		Name:              name,
 		DirectConnectID:   "b07d42dc-6137-4af3-a93b-853d879ae268",
 		VgwID:             "d27d5bd2-97b3-4bd8-b7e5-189a71c14846",
 		Type:              "private",
@@ -34,7 +36,7 @@ func TestVirtualInterfaceLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	_ = virtual_interface.Update(client, created.ID, virtual_interface.UpdateOpts{
-		Name:        "test-virtual-interface-updated",
+		Name:        tools.RandomString(name, 3),
 		Description: "New description",
 	})
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/dcaas/v2/virtual_interface_test.go
+++ b/acceptance/openstack/dcaas/v2/virtual_interface_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
@@ -15,20 +16,25 @@ func TestVirtualInterfaceLifecycle(t *testing.T) {
 	// Create a virtual interface
 	createOpts := virtual_interface.CreateOpts{
 		Name:              "test-virtual-interface",
-		DirectConnectID:   "test-direct-connect-uuid",
-		VgwID:             "test-vgw-id",
+		DirectConnectID:   "b07d42dc-6137-4af3-a93b-853d879ae268",
+		VgwID:             "d27d5bd2-97b3-4bd8-b7e5-189a71c14846",
 		Type:              "private",
 		ServiceType:       "vpc",
 		VLAN:              100,
 		Bandwidth:         100,
-		LocalGatewayV4IP:  "192.168.0.1",
-		RemoteGatewayV4IP: "192.168.1.1",
+		LocalGatewayV4IP:  "16.16.16.1/30",
+		RemoteGatewayV4IP: "16.16.16.2/30",
 		RouteMode:         "static",
-		RemoteEPGroupID:   "test-remote-ep-group-id",
+		RemoteEPGroupID:   "31dd8536-1ac7-4a38-b2fc-178a69f11b11",
 	}
 
 	created, err := virtual_interface.Create(client, createOpts)
 	th.AssertNoErr(t, err)
+
+	got, err := virtual_interface.Get(client, created.ID)
+	th.AssertNoErr(t, err)
+
+	fmt.Print(got)
 
 	t.Cleanup(func() {
 		err = virtual_interface.Delete(client, created.ID)

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -692,7 +692,7 @@ func NewAntiDDoSV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) 
 
 // NewDCaaSV2 creates a ServiceClient that may be used to access the v1 Distributed Message Service.
 func NewDCaaSV2(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
-	return initClientOpts(client, eo, "dcaasv2")
+	return initClientOpts(client, eo, "dcaas")
 }
 
 // NewDMSServiceV1 creates a ServiceClient that may be used to access the v1 Distributed Message Service.

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -690,6 +690,11 @@ func NewAntiDDoSV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) 
 	return initClientOpts(client, eo, "antiddos")
 }
 
+// NewDCaaSV2 creates a ServiceClient that may be used to access the v1 Distributed Message Service.
+func NewDCaaSV2(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	return initClientOpts(client, eo, "dcaasv2")
+}
+
 // NewDMSServiceV1 creates a ServiceClient that may be used to access the v1 Distributed Message Service.
 func NewDMSServiceV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
 	return initClientOpts(client, eo, "dmsv1")

--- a/openstack/dcaas/v2/dc-endpoint-group/Create.go
+++ b/openstack/dcaas/v2/dc-endpoint-group/Create.go
@@ -1,0 +1,31 @@
+package dc_endpoint_group
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateOpts struct {
+	Name        string   `json:"name,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Endpoints   []string `json:"endpoints" required:"true"`
+	Type        string   `json:"type" required:"true"`
+}
+
+func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*DCEndpointGroup, error) {
+	b, err := build.RequestBody(opts, "dc_endpoint_group")
+	if err != nil {
+		return nil, err
+	}
+	raw, err := c.Post(c.ServiceURL("dcaas", "dc-endpoint-groups"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{201},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res DCEndpointGroup
+	err = extract.IntoStructPtr(raw.Body, &res, "dc_endpoint_group")
+	return &res, err
+}

--- a/openstack/dcaas/v2/dc-endpoint-group/Create.go
+++ b/openstack/dcaas/v2/dc-endpoint-group/Create.go
@@ -7,10 +7,16 @@ import (
 )
 
 type CreateOpts struct {
-	Name        string   `json:"name,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Endpoints   []string `json:"endpoints" required:"true"`
-	Type        string   `json:"type" required:"true"`
+	// Specifies the project ID.
+	TenantId string `json:"tenant_id" required:"true"`
+	// Specifies the name of the Direct Connect endpoint group.
+	Name string `json:"name,omitempty"`
+	// Provides supplementary information about the Direct Connect endpoint group.
+	Description string `json:"description,omitempty"`
+	// Specifies the list of the endpoints in a Direct Connect endpoint group.
+	Endpoints []string `json:"endpoints" required:"true"`
+	// Specifies the type of the Direct Connect endpoints. The value can only be cidr.
+	Type string `json:"type,omitempty"`
 }
 
 func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*DCEndpointGroup, error) {

--- a/openstack/dcaas/v2/dc-endpoint-group/Delete.go
+++ b/openstack/dcaas/v2/dc-endpoint-group/Delete.go
@@ -4,6 +4,8 @@ import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 
 // Delete is used to delete a Direct Connect endpoint group
 func Delete(c *golangsdk.ServiceClient, id string) (err error) {
-	_, err = c.Delete(c.ServiceURL("dcaas", "dc-endpoint-groups", id), nil)
+	_, err = c.Delete(c.ServiceURL("dcaas", "dc-endpoint-groups", id), &golangsdk.RequestOpts{
+		OkCodes: []int{200, 201, 204},
+	})
 	return
 }

--- a/openstack/dcaas/v2/dc-endpoint-group/Delete.go
+++ b/openstack/dcaas/v2/dc-endpoint-group/Delete.go
@@ -1,0 +1,9 @@
+package dc_endpoint_group
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+// Delete is used to delete a Direct Connect endpoint group
+func Delete(c *golangsdk.ServiceClient, id string) (err error) {
+	_, err = c.Delete(c.ServiceURL("dcaas", "dc-endpoint-groups", id), nil)
+	return
+}

--- a/openstack/dcaas/v2/dc-endpoint-group/Get.go
+++ b/openstack/dcaas/v2/dc-endpoint-group/Get.go
@@ -1,0 +1,17 @@
+package dc_endpoint_group
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Get(c *golangsdk.ServiceClient, id string) (*DCEndpointGroup, error) {
+	raw, err := c.Get(c.ServiceURL("dcaas", "dc-endpoint-groups", id), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res DCEndpointGroup
+	err = extract.IntoStructPtr(raw.Body, &res, "dc_endpoint_group")
+	return &res, err
+}

--- a/openstack/dcaas/v2/dc-endpoint-group/List.go
+++ b/openstack/dcaas/v2/dc-endpoint-group/List.go
@@ -1,6 +1,8 @@
 package dc_endpoint_group
 
 import (
+	"fmt"
+
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack"
@@ -26,14 +28,10 @@ type ListOpts struct {
 }
 
 // List is used to obtain the DirectConnects list
-func List(c *golangsdk.ServiceClient, opts ListOpts) ([]DCEndpointGroup, error) {
-	q, err := golangsdk.BuildQueryString(opts)
-	if err != nil {
-		return nil, err
-	}
+func List(c *golangsdk.ServiceClient, id string) ([]DCEndpointGroup, error) {
 
 	// GET https://{Endpoint}/v2.0/dcaas/dc-endpoint-groups?id={id}
-	raw, err := c.Get(c.ServiceURL("dcaas", "dc-endpoint-groups")+q.String(), nil, openstack.StdRequestOpts())
+	raw, err := c.Get(c.ServiceURL(fmt.Sprintf("dcaas/dc-endpoint-groups?id=%s", id)), nil, openstack.StdRequestOpts())
 	if err != nil {
 		return nil, err
 	}

--- a/openstack/dcaas/v2/dc-endpoint-group/List.go
+++ b/openstack/dcaas/v2/dc-endpoint-group/List.go
@@ -1,0 +1,42 @@
+package dc_endpoint_group
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack"
+)
+
+type DCEndpointGroup struct {
+	// Specifies the ID of the Direct Connect endpoint group.
+	ID string `json:"id"`
+	// Specifies the name of the Direct Connect endpoint group.
+	Name string `json:"name"`
+	// Provides supplementary information about the Direct Connect endpoint group.
+	Description string `json:"description"`
+	// Specifies the list of the endpoints in a Direct Connect endpoint group.
+	Endpoints []string `json:"endpoints"`
+	// Specifies the type of the Direct Connect endpoints. The value can only be cidr.
+	Type string `json:"type"`
+}
+
+type ListOpts struct {
+	ID string `q:"id"`
+}
+
+// List is used to obtain the DirectConnects list
+func List(c *golangsdk.ServiceClient, opts ListOpts) ([]DCEndpointGroup, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// GET https://{Endpoint}/v2.0/dcaas/dc-endpoint-groups?id={id}
+	raw, err := c.Get(c.ServiceURL("dcaas", "dc-endpoint-groups")+q.String(), nil, openstack.StdRequestOpts())
+	if err != nil {
+		return nil, err
+	}
+
+	var res []DCEndpointGroup
+	err = extract.IntoSlicePtr(raw.Body, &res, "dc_endpoint_groups")
+	return res, err
+}

--- a/openstack/dcaas/v2/dc-endpoint-group/List.go
+++ b/openstack/dcaas/v2/dc-endpoint-group/List.go
@@ -7,6 +7,8 @@ import (
 )
 
 type DCEndpointGroup struct {
+	// Specifies the project ID.
+	TenantId string `json:"tenant_id"`
 	// Specifies the ID of the Direct Connect endpoint group.
 	ID string `json:"id"`
 	// Specifies the name of the Direct Connect endpoint group.

--- a/openstack/dcaas/v2/dc-endpoint-group/Update.go
+++ b/openstack/dcaas/v2/dc-endpoint-group/Update.go
@@ -1,0 +1,1 @@
+package dc_endpoint_group

--- a/openstack/dcaas/v2/dc-endpoint-group/Update.go
+++ b/openstack/dcaas/v2/dc-endpoint-group/Update.go
@@ -1,1 +1,27 @@
 package dc_endpoint_group
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type UpdateOpts struct {
+	// Provides supplementary information about the Direct Connect endpoint group.
+	Description string `json:"description,omitempty"`
+	// Specifies the name of the Direct Connect endpoint group.
+	Name string `json:"name,omitempty"`
+}
+
+// Update is an operation which modifies the attributes of the specified Direct Connect endpoint group
+func Update(c *golangsdk.ServiceClient, id string, opts UpdateOpts) (err error) {
+	b, err := build.RequestBody(opts, "dc_endpoint_group")
+	if err != nil {
+		return
+	}
+
+	_, err = c.Put(c.ServiceURL("dcaas", "dc-endpoint-groups", id), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+
+	return
+}

--- a/openstack/dcaas/v2/direct-connect/Create.go
+++ b/openstack/dcaas/v2/direct-connect/Create.go
@@ -1,0 +1,45 @@
+package direct_connect
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateOpts struct {
+	Name           string `json:"name,omitempty"`
+	Description    string `json:"description,omitempty"`
+	PortType       string `json:"port_type" required:"true"`
+	Bandwidth      int    `json:"bandwidth" required:"true"`
+	Location       string `json:"location" required:"true"`
+	PeerLocation   string `json:"peer_location,omitempty"`
+	DeviceID       string `json:"device_id,omitempty"`
+	InterfaceName  string `json:"interface_name,omitempty"`
+	RedundantID    string `json:"redundant_id,omitempty"`
+	Provider       string `json:"provider" required:"true"`
+	ProviderStatus string `json:"provider_status,omitempty"`
+	Type           string `json:"type,omitempty"`
+	HostingID      string `json:"hosting_id,omitempty"`
+	ChargeMode     string `json:"charge_mode,omitempty"`
+	OrderID        string `json:"order_id,omitempty"`
+	ProductID      string `json:"product_id,omitempty"`
+	Status         string `json:"status,omitempty"`
+	AdminStateUp   bool   `json:"admin_state_up,omitempty"`
+}
+
+func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*DirectConnect, error) {
+	b, err := build.RequestBody(opts, "direct_connect")
+	if err != nil {
+		return nil, err
+	}
+	raw, err := c.Post(c.ServiceURL("dcaas", "direct-connects"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{201},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res DirectConnect
+	err = extract.IntoStructPtr(raw.Body, &res, "direct_connect")
+	return &res, err
+}

--- a/openstack/dcaas/v2/direct-connect/Delete.go
+++ b/openstack/dcaas/v2/direct-connect/Delete.go
@@ -1,0 +1,11 @@
+package direct_connect
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+// Delete will permanently delete a particular DirectConnect based on its
+// unique ID.
+
+func Delete(c *golangsdk.ServiceClient, id string) (err error) {
+	_, err = c.Delete(c.ServiceURL("dcaas", "direct-connects", id), nil)
+	return
+}

--- a/openstack/dcaas/v2/direct-connect/Delete.go
+++ b/openstack/dcaas/v2/direct-connect/Delete.go
@@ -6,6 +6,8 @@ import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 // unique ID.
 
 func Delete(c *golangsdk.ServiceClient, id string) (err error) {
-	_, err = c.Delete(c.ServiceURL("dcaas", "direct-connects", id), nil)
+	_, err = c.Delete(c.ServiceURL("dcaas", "direct-connects", id), &golangsdk.RequestOpts{
+		OkCodes: []int{200, 201, 204},
+	})
 	return
 }

--- a/openstack/dcaas/v2/direct-connect/Get.go
+++ b/openstack/dcaas/v2/direct-connect/Get.go
@@ -1,0 +1,18 @@
+package direct_connect
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// Get retrieves a particular direct connect based on its unique ID.
+func Get(c *golangsdk.ServiceClient, id string) (*DirectConnect, error) {
+	raw, err := c.Get(c.ServiceURL("dcaas", "direct-connects", id), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res DirectConnect
+	err = extract.IntoStructPtr(raw.Body, &res, "direct_connect")
+	return &res, err
+}

--- a/openstack/dcaas/v2/direct-connect/List.go
+++ b/openstack/dcaas/v2/direct-connect/List.go
@@ -1,0 +1,51 @@
+package direct_connect
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack"
+)
+
+type DirectConnect struct {
+	TenantID       string `json:"tenant_id,omitempty"`
+	Name           string `json:"name,omitempty"`
+	Description    string `json:"description,omitempty"`
+	PortType       string `json:"port_type" required:"true"`
+	Bandwidth      int    `json:"bandwidth" required:"true"`
+	Location       string `json:"location" required:"true"`
+	PeerLocation   string `json:"peer_location,omitempty"`
+	DeviceID       string `json:"device_id,omitempty"`
+	InterfaceName  string `json:"interface_name,omitempty"`
+	RedundantID    string `json:"redundant_id,omitempty"`
+	Provider       string `json:"provider" required:"true"`
+	ProviderStatus string `json:"provider_status,omitempty"`
+	Type           string `json:"type,omitempty"`
+	HostingID      string `json:"hosting_id,omitempty"`
+	ChargeMode     string `json:"charge_mode,omitempty"`
+	OrderID        string `json:"order_id,omitempty"`
+	ProductID      string `json:"product_id,omitempty"`
+	Status         string `json:"status,omitempty"`
+	AdminStateUp   bool   `json:"admin_state_up,omitempty"`
+}
+
+type ListOpts struct {
+	ID string `q:"id"`
+}
+
+// List is used to obtain the DirectConnects list
+func List(c *golangsdk.ServiceClient, opts ListOpts) ([]DirectConnect, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// GET https://{Endpoint}/v2.0/{project_id}/virtual-gateways
+	raw, err := c.Get(c.ServiceURL("dcaas", "direct-connects")+q.String(), nil, openstack.StdRequestOpts())
+	if err != nil {
+		return nil, err
+	}
+
+	var res []DirectConnect
+	err = extract.IntoSlicePtr(raw.Body, &res, "direct_connects")
+	return res, err
+}

--- a/openstack/dcaas/v2/direct-connect/List.go
+++ b/openstack/dcaas/v2/direct-connect/List.go
@@ -9,26 +9,47 @@ import (
 )
 
 type DirectConnect struct {
-	TenantID       string `json:"tenant_id,omitempty"`
-	ID             string `json:"id,omitempty"`
-	Name           string `json:"name,omitempty"`
-	Description    string `json:"description,omitempty"`
-	PortType       string `json:"port_type" required:"true"`
-	Bandwidth      int    `json:"bandwidth" required:"true"`
-	Location       string `json:"location" required:"true"`
-	PeerLocation   string `json:"peer_location,omitempty"`
-	DeviceID       string `json:"device_id,omitempty"`
-	InterfaceName  string `json:"interface_name,omitempty"`
-	RedundantID    string `json:"redundant_id,omitempty"`
-	Provider       string `json:"provider" required:"true"`
-	ProviderStatus string `json:"provider_status,omitempty"`
-	Type           string `json:"type,omitempty"`
-	HostingID      string `json:"hosting_id,omitempty"`
-	ChargeMode     string `json:"charge_mode,omitempty"`
-	OrderID        string `json:"order_id,omitempty"`
-	ProductID      string `json:"product_id,omitempty"`
-	Status         string `json:"status,omitempty"`
-	AdminStateUp   bool   `json:"admin_state_up,omitempty"`
+	ID                    string `json:"id"`
+	TenantID              string `json:"tenant_id"`
+	Name                  string `json:"name"`
+	Description           string `json:"description"`
+	PortType              string `json:"port_type"`
+	Bandwidth             int    `json:"bandwidth"`
+	Location              string `json:"location"`
+	PeerLocation          string `json:"peer_location"`
+	DeviceID              string `json:"device_id"`
+	InterfaceName         string `json:"interface_name"`
+	RedundantID           string `json:"redundant_id"`
+	Provider              string `json:"provider"`
+	ProviderStatus        string `json:"provider_status"`
+	Type                  string `json:"type"`
+	HostingID             string `json:"hosting_id"`
+	VLAN                  int    `json:"vlan"`
+	ChargeMode            string `json:"charge_mode"`
+	ApplyTime             string `json:"apply_time"`
+	CreateTime            string `json:"create_time"`
+	DeleteTime            string `json:"delete_time"`
+	OrderID               string `json:"order_id"`
+	ProductID             string `json:"product_id"`
+	Status                string `json:"status"`
+	AdminStateUp          bool   `json:"admin_state_up"`
+	SpecCode              string `json:"spec_code"`
+	Applicant             string `json:"applicant"`
+	Mobile                string `json:"mobile"`
+	Email                 string `json:"email"`
+	RegionID              string `json:"region_id"`
+	ServiceKey            string `json:"service_key"`
+	CableLabel            string `json:"cable_label"`
+	PeerPortType          string `json:"peer_port_type"`
+	PeerProvider          string `json:"peer_provider"`
+	OnestopProductID      string `json:"onestop_product_id"`
+	BuildingLineProductID string `json:"building_line_product_id"`
+	LastOnestopProductID  string `json:"last_onestop_product_id"`
+	PeriodType            int    `json:"period_type"`
+	PeriodNum             int    `json:"period_num"`
+	Reason                string `json:"reason"`
+	VGWType               string `json:"vgw_type"`
+	LagID                 string `json:"lag_id"`
 }
 
 // List is used to obtain the DirectConnects list

--- a/openstack/dcaas/v2/direct-connect/List.go
+++ b/openstack/dcaas/v2/direct-connect/List.go
@@ -1,6 +1,8 @@
 package direct_connect
 
 import (
+	"fmt"
+
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack"
@@ -29,19 +31,11 @@ type DirectConnect struct {
 	AdminStateUp   bool   `json:"admin_state_up,omitempty"`
 }
 
-type ListOpts struct {
-	ID string `q:"id"`
-}
-
 // List is used to obtain the DirectConnects list
-func List(c *golangsdk.ServiceClient, opts ListOpts) ([]DirectConnect, error) {
-	q, err := golangsdk.BuildQueryString(opts)
-	if err != nil {
-		return nil, err
-	}
+func List(c *golangsdk.ServiceClient, id string) ([]DirectConnect, error) {
 
 	// GET https://{Endpoint}/v2.0/dcaas/direct-connects?id={id}
-	raw, err := c.Get(c.ServiceURL("dcaas", "direct-connects")+q.String(), nil, openstack.StdRequestOpts())
+	raw, err := c.Get(c.ServiceURL(fmt.Sprintf("dcaas/direct-connects?id=%s", id)), nil, openstack.StdRequestOpts())
 	if err != nil {
 		return nil, err
 	}

--- a/openstack/dcaas/v2/direct-connect/List.go
+++ b/openstack/dcaas/v2/direct-connect/List.go
@@ -40,7 +40,7 @@ func List(c *golangsdk.ServiceClient, opts ListOpts) ([]DirectConnect, error) {
 		return nil, err
 	}
 
-	// GET https://{Endpoint}/v2.0/{project_id}/virtual-gateways
+	// GET https://{Endpoint}/v2.0/dcaas/direct-connects?id={id}
 	raw, err := c.Get(c.ServiceURL("dcaas", "direct-connects")+q.String(), nil, openstack.StdRequestOpts())
 	if err != nil {
 		return nil, err

--- a/openstack/dcaas/v2/direct-connect/List.go
+++ b/openstack/dcaas/v2/direct-connect/List.go
@@ -8,6 +8,7 @@ import (
 
 type DirectConnect struct {
 	TenantID       string `json:"tenant_id,omitempty"`
+	ID             string `json:"id,omitempty"`
 	Name           string `json:"name,omitempty"`
 	Description    string `json:"description,omitempty"`
 	PortType       string `json:"port_type" required:"true"`

--- a/openstack/dcaas/v2/direct-connect/Update.go
+++ b/openstack/dcaas/v2/direct-connect/Update.go
@@ -1,0 +1,1 @@
+package direct_connect

--- a/openstack/dcaas/v2/direct-connect/Update.go
+++ b/openstack/dcaas/v2/direct-connect/Update.go
@@ -1,1 +1,32 @@
 package direct_connect
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type UpdateOpts struct {
+	// description of the direct connect
+	Description string `json:"description,omitempty"`
+	// name of the direct connect
+	Name string `json:"name,omitempty"`
+	// bandwidth of the direct connect in Mbps
+	Bandwidth int `json:"bandwidth,omitempty"`
+	// provider_status specifies the status of the carrier's leased line.
+	// The value can be ACTIVE or DOWN.
+	ProviderStatus string `json:"provider_status,omitempty"`
+}
+
+// Update is an operation which modifies the attributes of the specified direct connect
+func Update(c *golangsdk.ServiceClient, id string, opts UpdateOpts) (err error) {
+	b, err := build.RequestBody(opts, "direct_connect")
+	if err != nil {
+		return
+	}
+
+	_, err = c.Put(c.ServiceURL("dcaas", "direct-connects", id), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+
+	return
+}

--- a/openstack/dcaas/v2/virtual-gateway/Create.go
+++ b/openstack/dcaas/v2/virtual-gateway/Create.go
@@ -22,9 +22,9 @@ type CreateOpts struct {
 	// Specifies the ID of the redundant physical device used by the virtual gateway.
 	RedundantDeviceId string `json:"redundant_device_id,omitempty"`
 	// Specifies the virtual gateway type. The value can only be default.
-	Type string `json:"type" Default:"default"`
+	Type string `json:"type"`
 	// Specifies the administrative status of the virtual gateway.
-	AdminStateUp bool `json:"admin_state_up,omitempty"`
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 }
 
 func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*VirtualGateway, error) {

--- a/openstack/dcaas/v2/virtual-gateway/Create.go
+++ b/openstack/dcaas/v2/virtual-gateway/Create.go
@@ -1,0 +1,45 @@
+package virtual_gateway
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateOpts struct {
+	// Specifies the virtual gateway name.
+	Name string `json:"name,omitempty"`
+	// Provides supplementary information about the virtual gateway.
+	Description string `json:"description,omitempty"`
+	// Specifies the ID of the VPC to be accessed.
+	VpcId string `json:"vpc_id" required:"true"`
+	// Specifies the ID of the local endpoint group that records CIDR blocks of the VPC subnets.
+	LocalEndpointGroupId string `json:"local_ep_group_id" required:"true"`
+	// Specifies the BGP ASN of the virtual gateway.
+	BgpAsn int `json:"bgp_asn,omitempty"`
+	// Specifies the ID of the physical device used by the virtual gateway.
+	DeviceId string `json:"device_id,omitempty"`
+	// Specifies the ID of the redundant physical device used by the virtual gateway.
+	RedundantDeviceId string `json:"redundant_device_id,omitempty"`
+	// Specifies the virtual gateway type. The value can only be default.
+	Type string `json:"type" Default:"default"`
+	// Specifies the administrative status of the virtual gateway.
+	AdminStateUp bool `json:"admin_state_up,omitempty"`
+}
+
+func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*VirtualGateway, error) {
+	b, err := build.RequestBody(opts, "virtual-gateways")
+	if err != nil {
+		return nil, err
+	}
+	raw, err := c.Post(c.ServiceURL("virtual-gateways"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{201},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res VirtualGateway
+	err = extract.IntoStructPtr(raw.Body, &res, "virtual_gateway")
+	return &res, err
+}

--- a/openstack/dcaas/v2/virtual-gateway/Create.go
+++ b/openstack/dcaas/v2/virtual-gateway/Create.go
@@ -28,11 +28,11 @@ type CreateOpts struct {
 }
 
 func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*VirtualGateway, error) {
-	b, err := build.RequestBody(opts, "virtual-gateways")
+	b, err := build.RequestBody(opts, "virtual_gateway")
 	if err != nil {
 		return nil, err
 	}
-	raw, err := c.Post(c.ServiceURL("virtual-gateways"), b, nil, &golangsdk.RequestOpts{
+	raw, err := c.Post(c.ServiceURL("dcaas", "virtual-gateways"), b, nil, &golangsdk.RequestOpts{
 		OkCodes: []int{201},
 	})
 	if err != nil {

--- a/openstack/dcaas/v2/virtual-gateway/Delete.go
+++ b/openstack/dcaas/v2/virtual-gateway/Delete.go
@@ -6,6 +6,6 @@ import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 // unique ID.
 
 func Delete(c *golangsdk.ServiceClient, id string) (err error) {
-	_, err = c.Delete(c.ServiceURL("virtual-gateways", id), nil)
+	_, err = c.Delete(c.ServiceURL("dcaas", "virtual-gateways", id), nil)
 	return
 }

--- a/openstack/dcaas/v2/virtual-gateway/Delete.go
+++ b/openstack/dcaas/v2/virtual-gateway/Delete.go
@@ -6,6 +6,8 @@ import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 // unique ID.
 
 func Delete(c *golangsdk.ServiceClient, id string) (err error) {
-	_, err = c.Delete(c.ServiceURL("dcaas", "virtual-gateways", id), nil)
+	_, err = c.Delete(c.ServiceURL("dcaas", "virtual-gateways", id), &golangsdk.RequestOpts{
+		OkCodes: []int{200, 201, 204},
+	})
 	return
 }

--- a/openstack/dcaas/v2/virtual-gateway/Delete.go
+++ b/openstack/dcaas/v2/virtual-gateway/Delete.go
@@ -1,0 +1,11 @@
+package virtual_gateway
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+// Delete will permanently delete a particular VirtualGateway based on its
+// unique ID.
+
+func Delete(c *golangsdk.ServiceClient, id string) (err error) {
+	_, err = c.Delete(c.ServiceURL("virtual-gateways", id), nil)
+	return
+}

--- a/openstack/dcaas/v2/virtual-gateway/Get.go
+++ b/openstack/dcaas/v2/virtual-gateway/Get.go
@@ -7,7 +7,7 @@ import (
 
 // Get retrieves a particular virtual gateway based on its unique ID.
 func Get(c *golangsdk.ServiceClient, id string) (*VirtualGateway, error) {
-	raw, err := c.Get(c.ServiceURL("virtual-gateways", id), nil, nil)
+	raw, err := c.Get(c.ServiceURL("dcaas", "virtual-gateways", id), nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/openstack/dcaas/v2/virtual-gateway/Get.go
+++ b/openstack/dcaas/v2/virtual-gateway/Get.go
@@ -1,0 +1,18 @@
+package virtual_gateway
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// Get retrieves a particular virtual gateway based on its unique ID.
+func Get(c *golangsdk.ServiceClient, id string) (*VirtualGateway, error) {
+	raw, err := c.Get(c.ServiceURL("virtual-gateways", id), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res VirtualGateway
+	err = extract.IntoStructPtr(raw.Body, &res, "virtual_gateway")
+	return &res, err
+}

--- a/openstack/dcaas/v2/virtual-gateway/List.go
+++ b/openstack/dcaas/v2/virtual-gateway/List.go
@@ -1,24 +1,18 @@
 package virtual_gateway
 
 import (
+	"fmt"
+
 	"github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack"
 )
 
-type ListOpts struct {
-	ID string `q:"id"`
-}
-
 // List is used to obtain the virtual gateway list
-func List(c *golangsdk.ServiceClient, opts ListOpts) ([]VirtualGateway, error) {
-	q, err := golangsdk.BuildQueryString(opts)
-	if err != nil {
-		return nil, err
-	}
+func List(c *golangsdk.ServiceClient, id string) ([]VirtualGateway, error) {
 
 	// GET https://{Endpoint}/v2.0/{project_id}/virtual-gateways
-	raw, err := c.Get(c.ServiceURL("dcaas", "virtual-gateways")+q.String(), nil, openstack.StdRequestOpts())
+	raw, err := c.Get(c.ServiceURL(fmt.Sprintf("dcaas/virtual-gateways?id=%s", id)), nil, openstack.StdRequestOpts())
 	if err != nil {
 		return nil, err
 	}

--- a/openstack/dcaas/v2/virtual-gateway/List.go
+++ b/openstack/dcaas/v2/virtual-gateway/List.go
@@ -29,7 +29,7 @@ func List(client *golangsdk.ServiceClient, opts ListOpts) ([]VirtualGateway, err
 		return nil, err
 	}
 
-	// GET https://{Endpoint}/v1/{project_id}/virtual_gateways
+	// GET https://{Endpoint}/v2.0/{project_id}/virtual_gateways
 	raw, err := client.Get(client.ServiceURL("virtual-gateways")+q.String(), nil, openstack.StdRequestOpts())
 	if err != nil {
 		return nil, err

--- a/openstack/dcaas/v2/virtual-gateway/List.go
+++ b/openstack/dcaas/v2/virtual-gateway/List.go
@@ -23,14 +23,14 @@ type ListOpts struct {
 }
 
 // List is used to obtain the virtual gateway list
-func List(client *golangsdk.ServiceClient, opts ListOpts) ([]VirtualGateway, error) {
+func List(c *golangsdk.ServiceClient, opts ListOpts) ([]VirtualGateway, error) {
 	q, err := golangsdk.BuildQueryString(opts)
 	if err != nil {
 		return nil, err
 	}
 
 	// GET https://{Endpoint}/v2.0/{project_id}/virtual_gateways
-	raw, err := client.Get(client.ServiceURL("virtual-gateways")+q.String(), nil, openstack.StdRequestOpts())
+	raw, err := c.Get(c.ServiceURL("dcaas", "virtual-gateways")+q.String(), nil, openstack.StdRequestOpts())
 	if err != nil {
 		return nil, err
 	}

--- a/openstack/dcaas/v2/virtual-gateway/List.go
+++ b/openstack/dcaas/v2/virtual-gateway/List.go
@@ -7,19 +7,7 @@ import (
 )
 
 type ListOpts struct {
-	Limit        int      `q:"limit"`
-	Marker       string   `q:"marker"`
-	PageReverse  bool     `q:"page_reverse"`
-	ID           []string `q:"id"`
-	TenantID     []string `q:"tenant_id"`
-	Name         []string `q:"name"`
-	Description  []string `q:"description"`
-	VPCID        []string `q:"vpc_id"`
-	LocalEPGroup []string `q:"local_ep_group_id"`
-	DeviceID     []string `q:"device_id"`
-	Type         []string `q:"type"`
-	Status       []string `q:"status"`
-	AdminStateUp []string `q:"admin_state_up"`
+	ID string `q:"id"`
 }
 
 // List is used to obtain the virtual gateway list
@@ -29,7 +17,7 @@ func List(c *golangsdk.ServiceClient, opts ListOpts) ([]VirtualGateway, error) {
 		return nil, err
 	}
 
-	// GET https://{Endpoint}/v2.0/{project_id}/virtual_gateways
+	// GET https://{Endpoint}/v2.0/{project_id}/virtual-gateways
 	raw, err := c.Get(c.ServiceURL("dcaas", "virtual-gateways")+q.String(), nil, openstack.StdRequestOpts())
 	if err != nil {
 		return nil, err

--- a/openstack/dcaas/v2/virtual-gateway/List.go
+++ b/openstack/dcaas/v2/virtual-gateway/List.go
@@ -1,0 +1,59 @@
+package virtual_gateway
+
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack"
+)
+
+type ListOpts struct {
+	Limit        int      `q:"limit"`
+	Marker       string   `q:"marker"`
+	PageReverse  bool     `q:"page_reverse"`
+	ID           []string `q:"id"`
+	TenantID     []string `q:"tenant_id"`
+	Name         []string `q:"name"`
+	Description  []string `q:"description"`
+	VPCID        []string `q:"vpc_id"`
+	LocalEPGroup []string `q:"local_ep_group_id"`
+	DeviceID     []string `q:"device_id"`
+	Type         []string `q:"type"`
+	Status       []string `q:"status"`
+	AdminStateUp []string `q:"admin_state_up"`
+}
+
+// List is used to obtain the virtual gateway list
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]VirtualGateway, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// GET https://{Endpoint}/v1/{project_id}/virtual_gateways
+	raw, err := client.Get(client.ServiceURL("virtual-gateways")+q.String(), nil, openstack.StdRequestOpts())
+	if err != nil {
+		return nil, err
+	}
+
+	var res []VirtualGateway
+	err = extract.IntoSlicePtr(raw.Body, &res, "virtual_gateways")
+	return res, err
+}
+
+type VirtualGateway struct {
+	ID                 string `json:"id"`
+	TenantID           string `json:"tenant_id"`
+	Name               string `json:"name"`
+	Description        string `json:"description"`
+	VPCID              string `json:"vpc_id"`
+	LocalEPGroupID     string `json:"local_ep_group_id"`
+	DeviceID           string `json:"device_id"`
+	RedundantDeviceID  string `json:"redundant_device_id"`
+	Type               string `json:"type"`
+	IPSecBandwidth     int    `json:"ipsec_bandwidth"`
+	Status             string `json:"status"`
+	AdminStateUp       bool   `json:"admin_state_up"`
+	BGPASN             int    `json:"bgp_asn"`
+	RegionID           string `json:"region_id"`
+	LocalEPGroupIPv6ID string `json:"local_ep_group_ipv6_id"`
+}

--- a/openstack/dcaas/v2/virtual-gateway/Update.go
+++ b/openstack/dcaas/v2/virtual-gateway/Update.go
@@ -23,7 +23,7 @@ func Update(c *golangsdk.ServiceClient, id string, opts UpdateOpts) (err error) 
 		return
 	}
 
-	_, err = c.Put(c.ServiceURL("virtual-gateways", id), b, nil, &golangsdk.RequestOpts{
+	_, err = c.Put(c.ServiceURL("dcaas", "virtual-gateways", id), b, nil, &golangsdk.RequestOpts{
 		OkCodes: []int{200, 202},
 	})
 

--- a/openstack/dcaas/v2/virtual-gateway/Update.go
+++ b/openstack/dcaas/v2/virtual-gateway/Update.go
@@ -1,0 +1,31 @@
+package virtual_gateway
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+// UpdateOpts represents options for updating a VirtualGateway.
+type UpdateOpts struct {
+	// Provides supplementary information about the virtual gateway.
+	Description string `json:"description,omitempty"`
+	// Specifies the virtual gateway name.
+	Name string `json:"name,omitempty"`
+	// Specifies the ID of the local endpoint group that records CIDR blocks of the VPC subnets.
+	LocalEndpointGroupId string `json:"local_ep_group_id,omitempty"`
+}
+
+// Update is an operation which modifies the attributes of the specified
+// VirtualGateway.
+func Update(c *golangsdk.ServiceClient, id string, opts UpdateOpts) (err error) {
+	b, err := build.RequestBody(opts, "virtual_gateway")
+	if err != nil {
+		return
+	}
+
+	_, err = c.Put(c.ServiceURL("virtual-gateways", id), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+
+	return
+}

--- a/openstack/dcaas/v2/virtual-interface/Create.go
+++ b/openstack/dcaas/v2/virtual-interface/Create.go
@@ -29,7 +29,7 @@ func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*VirtualInterface, err
 	if err != nil {
 		return nil, err
 	}
-	raw, err := c.Post(c.ServiceURL("virtual-interfaces"), b, nil, &golangsdk.RequestOpts{
+	raw, err := c.Post(c.ServiceURL("dcaas", "virtual-interfaces"), b, nil, &golangsdk.RequestOpts{
 		OkCodes: []int{201},
 	})
 	if err != nil {

--- a/openstack/dcaas/v2/virtual-interface/Create.go
+++ b/openstack/dcaas/v2/virtual-interface/Create.go
@@ -7,6 +7,7 @@ import (
 )
 
 type CreateOpts struct {
+	TenantID          string `json:"tenant_id,omitempty"`
 	Name              string `json:"name,omitempty"`
 	Description       string `json:"description,omitempty"`
 	DirectConnectID   string `json:"direct_connect_id"  required:"true"`

--- a/openstack/dcaas/v2/virtual-interface/Create.go
+++ b/openstack/dcaas/v2/virtual-interface/Create.go
@@ -1,0 +1,42 @@
+package virtual_interface
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateOpts struct {
+	Name              string `json:"name,omitempty"`
+	Description       string `json:"description,omitempty"`
+	DirectConnectID   string `json:"direct_connect_id"  required:"true"`
+	VgwID             string `json:"vgw_id" required:"true"`
+	Type              string `json:"type" required:"true"`
+	ServiceType       string `json:"service_type" required:"true"`
+	VLAN              int    `json:"vlan" required:"true"`
+	Bandwidth         int    `json:"bandwidth" required:"true"`
+	LocalGatewayV4IP  string `json:"local_gateway_v4_ip" required:"true"`
+	RemoteGatewayV4IP string `json:"remote_gateway_v4_ip" required:"true"`
+	RouteMode         string `json:"route_mode" required:"true"`
+	BGPASN            int    `json:"bgp_asn,omitempty"`
+	BGPMD5            string `json:"bgp_md5,omitempty"`
+	RemoteEPGroupID   string `json:"remote_ep_group_id" required:"true"`
+	AdminStateUp      bool   `json:"admin_state_up,omitempty"`
+}
+
+func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*VirtualInterface, error) {
+	b, err := build.RequestBody(opts, "virtual_interface")
+	if err != nil {
+		return nil, err
+	}
+	raw, err := c.Post(c.ServiceURL("virtual-interfaces"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{201},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res VirtualInterface
+	err = extract.IntoStructPtr(raw.Body, &res, "virtual_interface")
+	return &res, err
+}

--- a/openstack/dcaas/v2/virtual-interface/Delete.go
+++ b/openstack/dcaas/v2/virtual-interface/Delete.go
@@ -1,0 +1,11 @@
+package virtual_interface
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+// Delete will permanently delete a particular VirtualInterface based on its
+// unique ID.
+
+func Delete(c *golangsdk.ServiceClient, id string) (err error) {
+	_, err = c.Delete(c.ServiceURL("virtual-virtual-interfaces", id), nil)
+	return
+}

--- a/openstack/dcaas/v2/virtual-interface/Delete.go
+++ b/openstack/dcaas/v2/virtual-interface/Delete.go
@@ -6,6 +6,6 @@ import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 // unique ID.
 
 func Delete(c *golangsdk.ServiceClient, id string) (err error) {
-	_, err = c.Delete(c.ServiceURL("virtual-virtual-interfaces", id), nil)
+	_, err = c.Delete(c.ServiceURL("dcaas", "virtual-interfaces", id), nil)
 	return
 }

--- a/openstack/dcaas/v2/virtual-interface/Delete.go
+++ b/openstack/dcaas/v2/virtual-interface/Delete.go
@@ -6,6 +6,8 @@ import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 // unique ID.
 
 func Delete(c *golangsdk.ServiceClient, id string) (err error) {
-	_, err = c.Delete(c.ServiceURL("dcaas", "virtual-interfaces", id), nil)
+	_, err = c.Delete(c.ServiceURL("dcaas", "virtual-interfaces", id), &golangsdk.RequestOpts{
+		OkCodes: []int{200, 201, 204},
+	})
 	return
 }

--- a/openstack/dcaas/v2/virtual-interface/Get.go
+++ b/openstack/dcaas/v2/virtual-interface/Get.go
@@ -7,7 +7,7 @@ import (
 
 // Get retrieves a particular virtual gateway based on its unique ID.
 func Get(c *golangsdk.ServiceClient, id string) (*VirtualInterface, error) {
-	raw, err := c.Get(c.ServiceURL("virtual-interfaces", id), nil, nil)
+	raw, err := c.Get(c.ServiceURL("dcaas", "virtual-interfaces", id), nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/openstack/dcaas/v2/virtual-interface/Get.go
+++ b/openstack/dcaas/v2/virtual-interface/Get.go
@@ -1,0 +1,18 @@
+package virtual_interface
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// Get retrieves a particular virtual gateway based on its unique ID.
+func Get(c *golangsdk.ServiceClient, id string) (*VirtualInterface, error) {
+	raw, err := c.Get(c.ServiceURL("virtual-interfaces", id), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res VirtualInterface
+	err = extract.IntoStructPtr(raw.Body, &res, "virtual_interfaces")
+	return &res, err
+}

--- a/openstack/dcaas/v2/virtual-interface/List.go
+++ b/openstack/dcaas/v2/virtual-interface/List.go
@@ -1,5 +1,15 @@
 package virtual_interface
 
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack"
+)
+
+type ListOpts struct {
+	ID string `q:"id"`
+}
+
 type VirtualInterface struct {
 	ID                  string `json:"id"`
 	TenantID            string `json:"tenant_id"`
@@ -34,4 +44,21 @@ type VirtualInterface struct {
 	LocalGRETunnelIP    string `json:"local_gre_tunnel_ip"`
 	RemoteGRETunnelIP   string `json:"remote_gre_tunnel_ip"`
 	LagID               string `json:"lag_id"`
+}
+
+func List(c *golangsdk.ServiceClient, opts ListOpts) ([]VirtualInterface, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// GET https://{Endpoint}/v2.0/{project_id}/virtual-interfaces
+	raw, err := c.Get(c.ServiceURL("dcaas", "virtual-interfaces")+q.String(), nil, openstack.StdRequestOpts())
+	if err != nil {
+		return nil, err
+	}
+
+	var res []VirtualInterface
+	err = extract.IntoSlicePtr(raw.Body, &res, "virtual_interfaces")
+	return res, err
 }

--- a/openstack/dcaas/v2/virtual-interface/List.go
+++ b/openstack/dcaas/v2/virtual-interface/List.go
@@ -1,0 +1,37 @@
+package virtual_interface
+
+type VirtualInterface struct {
+	ID                  string `json:"id"`
+	TenantID            string `json:"tenant_id"`
+	Name                string `json:"name"`
+	Description         string `json:"description"`
+	DirectConnectID     string `json:"direct_connect_id"`
+	VgwID               string `json:"vgw_id"`
+	Type                string `json:"type"`
+	ServiceType         string `json:"service_type"`
+	VLAN                int    `json:"vlan"`
+	Bandwidth           int    `json:"bandwidth"`
+	LocalGatewayV4IP    string `json:"local_gateway_v4_ip"`
+	RemoteGatewayV4IP   string `json:"remote_gateway_v4_ip"`
+	RouteMode           string `json:"route_mode"`
+	BGPASN              int    `json:"bgp_asn"`
+	BGPMD5              string `json:"bgp_md5"`
+	RemoteEPGroupID     string `json:"remote_ep_group_id"`
+	ServiceEPGroupID    string `json:"service_ep_group_id"`
+	CreateTime          string `json:"create_time"`
+	Status              string `json:"status"`
+	AdminStateUp        bool   `json:"admin_state_up"`
+	AddressFamily       string `json:"address_family"`
+	EnableBFD           bool   `json:"enable_bfd"`
+	HealthCheckSourceIP string `json:"health_check_source_ip"`
+	RateLimit           bool   `json:"rate_limit"`
+	RouteLimit          int    `json:"route_limit"`
+	RegionID            string `json:"region_id"`
+	EnableNQA           bool   `json:"enable_nqa"`
+	EnableGRE           bool   `json:"enable_gre"`
+	LocalGatewayV6IP    string `json:"local_gateway_v6_ip"`
+	RemoteGatewayV6IP   string `json:"remote_gateway_v6_ip"`
+	LocalGRETunnelIP    string `json:"local_gre_tunnel_ip"`
+	RemoteGRETunnelIP   string `json:"remote_gre_tunnel_ip"`
+	LagID               string `json:"lag_id"`
+}

--- a/openstack/dcaas/v2/virtual-interface/List.go
+++ b/openstack/dcaas/v2/virtual-interface/List.go
@@ -1,6 +1,8 @@
 package virtual_interface
 
 import (
+	"fmt"
+
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack"
@@ -46,14 +48,9 @@ type VirtualInterface struct {
 	LagID               string `json:"lag_id"`
 }
 
-func List(c *golangsdk.ServiceClient, opts ListOpts) ([]VirtualInterface, error) {
-	q, err := golangsdk.BuildQueryString(opts)
-	if err != nil {
-		return nil, err
-	}
-
-	// GET https://{Endpoint}/v2.0/{project_id}/virtual-interfaces
-	raw, err := c.Get(c.ServiceURL("dcaas", "virtual-interfaces")+q.String(), nil, openstack.StdRequestOpts())
+func List(c *golangsdk.ServiceClient, id string) ([]VirtualInterface, error) {
+	// GET https://{Endpoint}/v2.0/{project_id}/virtual-interfaces?id={id}
+	raw, err := c.Get(c.ServiceURL(fmt.Sprintf("dcaas/virtual-gateways?id=%s", id)), nil, openstack.StdRequestOpts())
 	if err != nil {
 		return nil, err
 	}

--- a/openstack/dcaas/v2/virtual-interface/Update.go
+++ b/openstack/dcaas/v2/virtual-interface/Update.go
@@ -1,1 +1,34 @@
 package virtual_interface
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+// UpdateOpts represents options for updating a Virtual Interface.
+type UpdateOpts struct {
+	// Specifies the virtual interface ID.
+	ID string `json:"virtual_interface_id" required:"true"`
+	// Provides supplementary information about the virtual interface.
+	Description string `json:"description,omitempty"`
+	// Specifies the virtual interface name.
+	Name string `json:"name,omitempty"`
+	// Specifies the virtual interface bandwidth.
+	Bandwidth int `json:"bandwidth,omitempty"`
+	// Specifies the ID of the remote endpoint group that records the CIDR blocks used by the on-premises network.
+	RemoteEndpointGroupId string `json:"remote_ep_group_id,omitempty"`
+}
+
+// Update is an operation which modifies the attributes of the specified
+func Update(c *golangsdk.ServiceClient, id string, opts UpdateOpts) (err error) {
+	b, err := build.RequestBody(opts, "virtual_interface")
+	if err != nil {
+		return
+	}
+
+	_, err = c.Put(c.ServiceURL("dcaas", "virtual-interfaces", id), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+
+	return
+}

--- a/openstack/dcaas/v2/virtual-interface/Update.go
+++ b/openstack/dcaas/v2/virtual-interface/Update.go
@@ -1,0 +1,1 @@
+package virtual_interface


### PR DESCRIPTION
### What this PR does / why we need it

- Implements support for Direct Connect as a Service (DCaaS) in the Golang SDK.
- Introduces new structs, methods, and API calls for managing DCaaS resources.
- Provides users with the ability to configure and manage connections, virtual gateways, virtual interfaces, and DC endpoint groups

### Related Issue
SDK for https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/2215

### Acceptance tests passed:
```
=== RUN   TestDirectConnectLifecycle
--- PASS: TestDirectConnectLifecycle (3.91s)
PASS

Process finished with the exit code 0

=== RUN   TestVirtualGatewayLifecycle
--- PASS: TestVirtualGatewayLifecycle (1.75s)
PASS

Process finished with the exit code 0

=== RUN   TestDirectConnectEndpointGroupLifecycle
--- PASS: TestDirectConnectEndpointGroupLifecycle (2.02s)
PASS

Process finished with the exit code 0

=== RUN   TestVirtualInterfaceLifecycle
    virtual_interface_test.go:32: Failure in virtual_interface_test.go, line 32: unexpected error "Resource not found: [POST https://dcaas.eu-de.otc.t-systems.com/v2.0/dcaas/virtual-interfaces], error message: {\"requestId\":\"49c10809b215e9fa039f27aa33fe3ea8\",\"error_msg\":\"DirectConnection b07d42dc-6137-4af3-a93b-853d879ae268 could not be found.\",\"error_code\":\"DC.1012\"}"
--- FAIL: TestVirtualInterfaceLifecycle (1.12s)

FAIL
```