### PR TITLE
[CLIENT] move BackOff retry parameters to provider client level

### DIFF
--- a/acceptance/openstack/networking/v2/sgs/sg_test.go
+++ b/acceptance/openstack/networking/v2/sgs/sg_test.go
@@ -128,10 +128,10 @@ func TestThrottlingSgs(t *testing.T) {
 	sg, err := secgroups.Create(clientCompute, createSGOpts).Extract()
 	th.AssertNoErr(t, err)
 
-	size := 15
+	size := 20
 	q := make(chan []string, size)
 	for i := 0; i < size; i++ {
-		go CreateMultipleSgsRules(clientNetworking, sg.ID, 47, i, q) // nolint
+		go CreateMultipleSgsRules(clientNetworking, sg.ID, 70, i, q) // nolint
 	}
 	for i := 0; i < size; i++ {
 		sgs := <-q

--- a/provider_client.go
+++ b/provider_client.go
@@ -280,7 +280,7 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 	}
 
 	if client.MaxBackoffRetries == nil {
-		defaultMaxBackoffRetryLimit := 5
+		defaultMaxBackoffRetryLimit := 20
 		client.MaxBackoffRetries = &defaultMaxBackoffRetryLimit
 	}
 

--- a/provider_client.go
+++ b/provider_client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -81,6 +80,10 @@ type ProviderClient struct {
 	// UserAgent represents the User-Agent header in the HTTP request.
 	UserAgent UserAgent
 
+	// MaxBackoffRetries set the maximum number of backoffs. When not set, defaults to defaultMaxBackoffRetryLimit
+	MaxBackoffRetries *int
+	// BackoffRetryTimeout specifies time before next retry on 429. When not set, defaults to defaultBackoffTimeout
+	BackoffRetryTimeout *time.Duration
 	// ReauthFunc is the function used to re-authenticate the user if the request
 	// fails with a 401 HTTP response code. This a needed because there may be multiple
 	// authentication functions for different Identity service versions.
@@ -173,10 +176,6 @@ type RequestOpts struct {
 	RetryCount *int
 	// RetryTimeout specifies time before next retry
 	RetryTimeout *time.Duration
-	// MaxBackoffRetries set the maximum number of backoffs. When not set, defaults to defaultMaxBackoffRetryLimit
-	MaxBackoffRetries *int
-	// BackoffRetryTimeout specifies time before next retry on 429. When not set, defaults to defaultBackoffTimeout
-	BackoffRetryTimeout *time.Duration
 }
 
 var applicationJSON = "application/json"
@@ -280,14 +279,14 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 		options.RetryTimeout = &defaultRetryTimeout
 	}
 
-	if options.MaxBackoffRetries == nil {
+	if client.MaxBackoffRetries == nil {
 		defaultMaxBackoffRetryLimit := 5
-		options.MaxBackoffRetries = &defaultMaxBackoffRetryLimit
+		client.MaxBackoffRetries = &defaultMaxBackoffRetryLimit
 	}
 
-	if options.BackoffRetryTimeout == nil {
-		defaultBackoffTimeout := 120 * time.Second
-		options.BackoffRetryTimeout = &defaultBackoffTimeout
+	if client.BackoffRetryTimeout == nil {
+		defaultBackoffTimeout := 60 * time.Second
+		client.BackoffRetryTimeout = &defaultBackoffTimeout
 	}
 
 	// Validate the HTTP response status.
@@ -300,7 +299,7 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 	}
 
 	if !ok {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
 		respErr := ErrUnexpectedResponseCode{
 			URL:      url,
@@ -389,9 +388,9 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 			if error429er, ok := errType.(Err429er); ok {
 				err = error429er.Error429(respErr)
 			}
-			if *options.MaxBackoffRetries > 0 {
-				*options.MaxBackoffRetries -= 1
-				time.Sleep(*options.BackoffRetryTimeout)
+			if *client.MaxBackoffRetries > 0 {
+				*client.MaxBackoffRetries -= 1
+				time.Sleep(*client.BackoffRetryTimeout)
 				return client.Request(method, url, options)
 			}
 		case http.StatusInternalServerError:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
Move BackOff parameters to client level to make it more configurable for terraform provider.

=== RUN   TestThrottlingSgs
--- PASS: TestThrottlingSgs (122.57s)
PASS

=== RUN   TestTooManyRequestsRetry
--- PASS: TestTooManyRequestsRetry (20.01s)
=== RUN   TestTooManyRequestsRetry/429
    --- PASS: TestTooManyRequestsRetry/429 (20.01s)
PASS


Process finished with the exit code 0