### PR TITLE
WAFD: update resource creation

### DIFF
--- a/acceptance/openstack/waf-premium/v1/instance_test.go
+++ b/acceptance/openstack/waf-premium/v1/instance_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/waf-premium/v1/instances"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
@@ -41,6 +42,7 @@ func TestWafPremiumInstanceWorkflow(t *testing.T) {
 		Flavor:           "s3.2xlarge.2",
 		VpcId:            vpcID,
 		SubnetId:         subnetID,
+		ResTenant:        pointerto.Bool(true),
 		SecurityGroupsId: []string{openstack.DefaultSecurityGroup(t)},
 	}
 

--- a/openstack/waf-premium/v1/instances/Create.go
+++ b/openstack/waf-premium/v1/instances/Create.go
@@ -46,6 +46,9 @@ type CreateOpts struct {
 	SecurityGroupsId []string `json:"security_group" required:"true"`
 	// Number of dedicated engines to be provisioned
 	Count int `json:"count" required:"true"`
+	// Whether to create a dedicated engine instance of the network interface type.
+	// Its value has to be true.
+	ResTenant *bool `json:"res_tenant" required:"true"`
 }
 
 // Create will create a new instance on the values in CreateOpts.


### PR DESCRIPTION
### What this PR does / why we need it
New required parameter was introduced which now blocks TF resource creation.
Refers to: [#2375](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/2375)

### Acceptance tests
=== RUN   TestWafPremiumInstanceWorkflow
    instance_test.go:49: Attempting to create WAF premium instance
    instance_test.go:52: Created WAF instance: 2f2b3a60d4f54586beba24a0fa80dfcf
    instance_test.go:58: Attempting to delete WAF Premium instance: 2f2b3a60d4f54586beba24a0fa80dfcf
    instance_test.go:61: Deleted WAF Premium instance: 2f2b3a60d4f54586beba24a0fa80dfcf
--- PASS: TestWafPremiumInstanceWorkflow (297.82s)
PASS

Process finished with the exit code 0