### PR TITLE
[VPC] Networking v1 subnet ipv6 support

### DIFF
--- a/acceptance/openstack/networking/v1/subnet_test.go
+++ b/acceptance/openstack/networking/v1/subnet_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/subnets"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
@@ -46,6 +47,7 @@ func TestSubnetsLifecycle(t *testing.T) {
 	updateOpts := &subnets.UpdateOpts{
 		Name:        tools.RandomString("acc-subnet-", 3),
 		Description: &emptyDescription,
+		EnableIpv6:  pointerto.Bool(true),
 	}
 	t.Logf("Attempting to update name of subnet to %s", updateOpts.Name)
 	_, err = subnets.Update(client, subnet.VpcID, subnet.ID, updateOpts).Extract()
@@ -56,4 +58,5 @@ func TestSubnetsLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, updateOpts.Name, newSubnet.Name)
 	th.AssertEquals(t, emptyDescription, newSubnet.Description)
+	th.AssertEquals(t, true, newSubnet.EnableIpv6)
 }

--- a/openstack/networking/v1/subnets/requests.go
+++ b/openstack/networking/v1/subnets/requests.go
@@ -118,6 +118,7 @@ type CreateOpts struct {
 	Description      string         `json:"description,omitempty"`
 	CIDR             string         `json:"cidr" required:"true"`
 	DNSList          []string       `json:"dnsList,omitempty"`
+	EnableIpv6       *bool          `json:"ipv6_enable,omitempty"`
 	GatewayIP        string         `json:"gateway_ip" required:"true"`
 	EnableDHCP       *bool          `json:"dhcp_enable,omitempty"`
 	PrimaryDNS       string         `json:"primary_dns,omitempty"`
@@ -169,6 +170,7 @@ type UpdateOpts struct {
 	Name          string         `json:"name,omitempty"`
 	Description   *string        `json:"description,omitempty"`
 	EnableDHCP    *bool          `json:"dhcp_enable,omitempty"`
+	EnableIpv6    *bool          `json:"ipv6_enable,omitempty"`
 	PrimaryDNS    string         `json:"primary_dns,omitempty"`
 	SecondaryDNS  string         `json:"secondary_dns,omitempty"`
 	DNSList       []string       `json:"dnsList,omitempty"`

--- a/openstack/networking/v1/subnets/results.go
+++ b/openstack/networking/v1/subnets/results.go
@@ -31,6 +31,9 @@ type Subnet struct {
 	// Specifies whether the DHCP function is enabled for the subnet.
 	EnableDHCP bool `json:"dhcp_enable"`
 
+	// Specifies whether an IPv6 subnet can be created.
+	EnableIpv6 bool `json:"ipv6_enable"`
+
 	// Specifies the IP address of DNS server 1 on the subnet.
 	PrimaryDNS string `json:"primary_dns"`
 


### PR DESCRIPTION
=== RUN   TestSubnetsLifecycle
    helpers.go:208: Attempting to create vpc: acc-vpc-ecJ
    helpers.go:212: Created vpc: 289d066e-9652-4f13-b046-417e78eec939
    helpers.go:140: Attempting to create subnet: acc-subnet-0Qc
    helpers.go:147: Waitting for subnet ec968efb-623c-4f28-8fa5-4e51d4428c47 to be active
    helpers.go:150: Created subnet: ec968efb-623c-4f28-8fa5-4e51d4428c47
    tools.go:72: {
          "id": "ec968efb-623c-4f28-8fa5-4e51d4428c47",
          "name": "acc-subnet-0Qc",
          "description": "some description",
          "cidr": "192.168.20.0/24",
          "dnsList": [],
          "status": "UNKNOWN",
          "gateway_ip": "192.168.20.1",
          "dhcp_enable": true,
          "ipv6_enable": false,
          "primary_dns": "",
          "secondary_dns": "",
          "availability_zone": "",
          "vpc_id": "289d066e-9652-4f13-b046-417e78eec939",
          "neutron_subnet_id": "f2263634-51c8-4560-b14a-5aa6890b1c95",
          "neutron_network_id": "ec968efb-623c-4f28-8fa5-4e51d4428c47",
          "extra_dhcp_opts": null
        }
    subnet_test.go:52: Attempting to update name of subnet to acc-subnet-pVq
    helpers.go:156: Attempting to delete subnet: ec968efb-623c-4f28-8fa5-4e51d4428c47
    helpers.go:161: Waiting for subnet ec968efb-623c-4f28-8fa5-4e51d4428c47 to be deleted
    helpers.go:165: Deleted subnet: ec968efb-623c-4f28-8fa5-4e51d4428c47
    helpers.go:218: Attempting to delete vpc: 289d066e-9652-4f13-b046-417e78eec939
    helpers.go:223: Deleted vpc: 289d066e-9652-4f13-b046-417e78eec939
--- PASS: TestSubnetsLifecycle (20.16s)
PASS

Process finished with the exit code 0
