### PR TITLE
[APIGW]: Group implementation

### DIFF
--- a/acceptance/openstack/apigw/v2/group_test.go
+++ b/acceptance/openstack/apigw/v2/group_test.go
@@ -60,7 +60,7 @@ func TestGroupList(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	listResp, err := group.List(client, group.ListOpts{
-		InstanceID: gatewayId,
+		GatewayID: gatewayId,
 	})
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, listResp)

--- a/acceptance/openstack/apigw/v2/group_test.go
+++ b/acceptance/openstack/apigw/v2/group_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"os"
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
@@ -10,7 +11,7 @@ import (
 )
 
 func TestGroupLifecycle(t *testing.T) {
-	gatewayId := clients.EnvOS.GetEnv("GATEWAY_ID")
+	gatewayId := os.Getenv("GATEWAY_ID")
 
 	if gatewayId == "" {
 		t.Skip("`GATEWAY_ID` need to be defined")
@@ -50,7 +51,7 @@ func TestGroupLifecycle(t *testing.T) {
 }
 
 func TestGroupList(t *testing.T) {
-	gatewayId := clients.EnvOS.GetEnv("GATEWAY_ID")
+	gatewayId := os.Getenv("GATEWAY_ID")
 
 	if gatewayId == "" {
 		t.Skip("`GATEWAY_ID` need to be defined")

--- a/acceptance/openstack/apigw/v2/group_test.go
+++ b/acceptance/openstack/apigw/v2/group_test.go
@@ -1,0 +1,67 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/apigw/v2/group"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestGroupLifecycle(t *testing.T) {
+	gatewayId := clients.EnvOS.GetEnv("GATEWAY_ID")
+
+	if gatewayId == "" {
+		t.Skip("`GATEWAY_ID` need to be defined")
+	}
+	client, err := clients.NewAPIGWClient()
+	th.AssertNoErr(t, err)
+
+	name := tools.RandomString("apigw_group-", 3)
+
+	createOpts := group.CreateOpts{
+		Name:        name,
+		Description: "test",
+		GatewayID:   gatewayId,
+	}
+
+	createResp, err := group.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+
+	t.Cleanup(func() {
+		th.AssertNoErr(t, group.Delete(client, gatewayId, createResp.ID))
+	})
+
+	updateOpts := group.UpdateOpts{
+		GroupID:     createResp.ID,
+		Name:        name + "-updated",
+		Description: "test updated",
+		GatewayID:   gatewayId,
+	}
+
+	_, err = group.Update(client, updateOpts)
+	th.AssertNoErr(t, err)
+
+	getResp, err := group.Get(client, gatewayId, createResp.ID)
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, getResp)
+}
+
+func TestGroupList(t *testing.T) {
+	gatewayId := clients.EnvOS.GetEnv("GATEWAY_ID")
+
+	if gatewayId == "" {
+		t.Skip("`GATEWAY_ID` need to be defined")
+	}
+
+	client, err := clients.NewAPIGWClient()
+	th.AssertNoErr(t, err)
+
+	listResp, err := group.List(client, group.ListOpts{
+		InstanceID: gatewayId,
+	})
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, listResp)
+}

--- a/openstack/apigw/v2/group/Create.go
+++ b/openstack/apigw/v2/group/Create.go
@@ -1,0 +1,57 @@
+package group
+
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateOpts struct {
+	GatewayID   string `json:"-"`
+	Name        string `json:"name" required:"true"`
+	Description string `json:"remark,omitempty"`
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*GroupResp, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Post(client.ServiceURL("apigw", "instances", opts.GatewayID, "api-groups"), b,
+		nil, &golangsdk.RequestOpts{
+			OkCodes: []int{201},
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	var res GroupResp
+
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type GroupResp struct {
+	ID           string       `json:"id"`
+	Name         string       `json:"name"`
+	Status       int          `json:"status"`
+	SlDomain     string       `json:"sl_domain"`
+	RegisterTime string       `json:"register_time"`
+	UpdateTime   string       `json:"update_time"`
+	OnSellStatus int          `json:"on_sell_status"`
+	UrlDomains   []UrlDomains `json:"url_domains"`
+	SlDomains    []string     `json:"sl_domains"`
+	Description  string       `json:"remark"`
+}
+
+type UrlDomains struct {
+	DomainId            string `json:"id"`
+	DomainName          string `json:"name"`
+	CnameStatus         int    `json:"cname_status"`
+	SslID               string `json:"ssl_id"`
+	SslName             string `json:"ssl_name"`
+	MinSslVersion       string `json:"min_ssl_version"`
+	VfClientCertEnabled bool   `json:"verified_client_certificate_enabled"`
+	HasTrustedCa        bool   `json:"is_has_trusted_root_ca"`
+}

--- a/openstack/apigw/v2/group/Delete.go
+++ b/openstack/apigw/v2/group/Delete.go
@@ -1,0 +1,8 @@
+package group
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+func Delete(client *golangsdk.ServiceClient, gatewayID, groupID string) (err error) {
+	_, err = client.Delete(client.ServiceURL("apigw", "instances", gatewayID, "api-groups", groupID), nil)
+	return
+}

--- a/openstack/apigw/v2/group/Get.go
+++ b/openstack/apigw/v2/group/Get.go
@@ -1,0 +1,18 @@
+package group
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Get(client *golangsdk.ServiceClient, gatewayID, groupID string) (*GroupResp, error) {
+	raw, err := client.Get(client.ServiceURL("apigw", "instances", gatewayID, "api-groups", groupID),
+		nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res GroupResp
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/apigw/v2/group/List.go
+++ b/openstack/apigw/v2/group/List.go
@@ -10,7 +10,7 @@ import (
 
 type ListOpts struct {
 	Limit        int    `q:"limit"`
-	InstanceID   string `json:"-"`
+	GatewayID    string `json:"-"`
 	InstanceName string `q:"instance_name"`
 	Status       string `q:"status"`
 }
@@ -22,7 +22,7 @@ func List(client *golangsdk.ServiceClient, opts ListOpts) ([]GroupResp, error) {
 	}
 	pages, err := pagination.Pager{
 		Client:     client,
-		InitialURL: client.ServiceURL("apigw", "instances", opts.InstanceID, "api-groups") + q.String(),
+		InitialURL: client.ServiceURL("apigw", "instances", opts.GatewayID, "api-groups") + q.String(),
 		CreatePage: func(r pagination.NewPageResult) pagination.NewPage {
 			return GroupPage{NewSinglePageBase: pagination.NewSinglePageBase{NewPageResult: r}}
 		},

--- a/openstack/apigw/v2/group/List.go
+++ b/openstack/apigw/v2/group/List.go
@@ -1,0 +1,47 @@
+package group
+
+import (
+	"bytes"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+)
+
+type ListOpts struct {
+	Limit        int    `q:"limit"`
+	InstanceID   string `json:"-"`
+	InstanceName string `q:"instance_name"`
+	Status       string `q:"status"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]GroupResp, error) {
+	q, err := golangsdk.BuildQueryString(&opts)
+	if err != nil {
+		return nil, err
+	}
+	pages, err := pagination.Pager{
+		Client:     client,
+		InitialURL: client.ServiceURL("apigw", "instances", opts.InstanceID, "api-groups") + q.String(),
+		CreatePage: func(r pagination.NewPageResult) pagination.NewPage {
+			return GroupPage{NewSinglePageBase: pagination.NewSinglePageBase{NewPageResult: r}}
+		},
+	}.NewAllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return ExtractGateways(pages)
+}
+
+type GroupPage struct {
+	pagination.NewSinglePageBase
+}
+
+func ExtractGateways(r pagination.NewPage) ([]GroupResp, error) {
+	var s struct {
+		Gateways []GroupResp `json:"groups"`
+	}
+	err := extract.Into(bytes.NewReader((r.(GroupPage)).Body), &s)
+	return s.Gateways, err
+}

--- a/openstack/apigw/v2/group/Update.go
+++ b/openstack/apigw/v2/group/Update.go
@@ -1,0 +1,34 @@
+package group
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type UpdateOpts struct {
+	GatewayID   string `json:"-"`
+	GroupID     string `json:"-"`
+	Name        string `json:"name" required:"true"`
+	Description string `json:"remark,omitempty"`
+}
+
+func Update(client *golangsdk.ServiceClient, opts UpdateOpts) (*GroupResp, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Put(client.ServiceURL("apigw", "instances", opts.GatewayID, "api-groups", opts.GroupID),
+		b, nil, &golangsdk.RequestOpts{
+			OkCodes: []int{200},
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	var res GroupResp
+
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}


### PR DESCRIPTION
### What this PR does / why we need it
APIGW group management implementation
Refers to: [#2403](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/2403).

### Acceptance tests
=== RUN   TestGroupLifecycle
    tools.go:72: {
          "id": "33675baafeca42a49d242242d5469858",
          "name": "apigw_group-lqY-updated",
          "status": 1,
          "sl_domain": "33675baafeca42a49d242242d5469858.apic.eu-de.otc.t-systems.com",
          "register_time": "2024-01-10T05:23:13Z",
          "update_time": "2024-01-10T05:23:14.009794Z",
          "on_sell_status": 2,
          "url_domains": [],
          "sl_domains": [
            "33675baafeca42a49d242242d5469858.apic.eu-de.otc.t-systems.com"
          ],
          "remark": "test updated"
        }
--- PASS: TestGroupLifecycle (1.49s)
=== RUN   TestGroupList
    tools.go:72: [
          {
            "id": "31f160699d66429aa9a292036c8479a7",
            "name": "DEFAULT",
            "status": 1,
            "sl_domain": "31f160699d66429aa9a292036c8479a7.apic.eu-de.otc.t-systems.com",
            "register_time": "2024-01-10T04:21:45Z",
            "update_time": "2024-01-10T04:21:45Z",
            "on_sell_status": 2,
            "url_domains": [],
            "sl_domains": [
              "31f160699d66429aa9a292036c8479a7.apic.eu-de.otc.t-systems.com"
            ],
            "remark": "This is an automatically generated group. APIs in this group can be accessed with an EIP or a private IP address."
          }
        ]
--- PASS: TestGroupList (0.51s)
PASS

Process finished with the exit code 0
