### PR TITLE
[APIGW]: throttling policy management

### DIFF
--- a/acceptance/openstack/apigw/v2/throttling_policy_test.go
+++ b/acceptance/openstack/apigw/v2/throttling_policy_test.go
@@ -1,0 +1,80 @@
+package v2
+
+import (
+	"os"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	policy "github.com/opentelekomcloud/gophertelekomcloud/openstack/apigw/v2/tr_policy"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestThrottlingPolicyLifecycle(t *testing.T) {
+	gatewayID := os.Getenv("GATEWAY_ID")
+
+	if gatewayID == "" {
+		t.Skip("`GATEWAY_ID` needs to be defined")
+	}
+
+	client, err := clients.NewAPIGWClient()
+	th.AssertNoErr(t, err)
+
+	name := tools.RandomString("test_policy_", 5)
+
+	createOpts := policy.CreateOpts{
+		GatewayID:      gatewayID,
+		Name:           name,
+		ApiCallLimits:  pointerto.Int(200),
+		TimeInterval:   pointerto.Int(10000),
+		TimeUnit:       "SECOND",
+		Description:    "test throttling policy",
+		AppCallLimits:  pointerto.Int(100),
+		UserCallLimits: pointerto.Int(100),
+	}
+
+	createResp, err := policy.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+
+	t.Cleanup(func() {
+		th.AssertNoErr(t, policy.Delete(client, gatewayID, createResp.ID))
+	})
+
+	updateOpts := policy.UpdateOpts{
+		GatewayID:      gatewayID,
+		ThrottleID:     createResp.ID,
+		Name:           name + "_updated",
+		ApiCallLimits:  pointerto.Int(199),
+		TimeInterval:   pointerto.Int(999),
+		TimeUnit:       "MINUTE",
+		Description:    "test throttling policy updated",
+		AppCallLimits:  pointerto.Int(50),
+		UserCallLimits: pointerto.Int(50),
+	}
+	updateResp, err := policy.Update(client, updateOpts)
+	th.AssertNoErr(t, err)
+
+	getResp, err := policy.Get(client, gatewayID, updateResp.ID)
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, getResp)
+}
+
+func TestThrottlingPolicyList(t *testing.T) {
+	gatewayID := os.Getenv("GATEWAY_ID")
+
+	if gatewayID == "" {
+		t.Skip("`GATEWAY_ID` needs to be defined")
+	}
+
+	client, err := clients.NewAPIGWClient()
+	th.AssertNoErr(t, err)
+
+	listResp, err := policy.List(client, policy.ListOpts{
+		GatewayID: gatewayID,
+	})
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, listResp)
+}

--- a/openstack/apigw/v2/tr_policy/Create.go
+++ b/openstack/apigw/v2/tr_policy/Create.go
@@ -1,0 +1,57 @@
+package throttling_policy
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateOpts struct {
+	GatewayID             string `json:"-"`
+	Name                  string `json:"name" required:"true"`
+	AppCallLimits         *int   `json:"app_call_limits,omitempty"`
+	ApiCallLimits         *int   `json:"api_call_limits" required:"true"`
+	TimeInterval          *int   `json:"time_interval" required:"true"`
+	TimeUnit              string `json:"time_unit" required:"true"`
+	Description           string `json:"remark,omitempty"`
+	Type                  *int   `json:"type,omitempty"`
+	IpCallLimits          *int   `json:"ip_call_limits,omitempty"`
+	UserCallLimits        *int   `json:"user_call_limits,omitempty"`
+	EnableAdaptiveControl string `json:"enable_adaptive_control,omitempty"`
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*ThrottlingResp, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Post(client.ServiceURL("apigw", "instances", opts.GatewayID, "throttles"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{201},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res ThrottlingResp
+
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ThrottlingResp struct {
+	AppCallLimits          int    `json:"app_call_limits"`
+	Name                   string `json:"name"`
+	TimeUnit               string `json:"time_unit"`
+	Description            string `json:"remark"`
+	ApiCallLimits          int    `json:"api_call_limits"`
+	Type                   int    `json:"type"`
+	EnableAdaptiveControl  string `json:"enable_adaptive_control"`
+	UserCallLimits         int    `json:"user_call_limits"`
+	TimeInterval           int    `json:"time_interval"`
+	IpCallLimits           int    `json:"ip_call_limits"`
+	ID                     string `json:"id"`
+	BindNum                int    `json:"bind_num"`
+	IsIncluSpecialThrottle int    `json:"is_inclu_special_throttle"`
+	CreateTime             string `json:"create_time"`
+}

--- a/openstack/apigw/v2/tr_policy/Delete.go
+++ b/openstack/apigw/v2/tr_policy/Delete.go
@@ -1,0 +1,8 @@
+package throttling_policy
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+func Delete(client *golangsdk.ServiceClient, gatewayID, throttleID string) (err error) {
+	_, err = client.Delete(client.ServiceURL("apigw", "instances", gatewayID, "throttles", throttleID), nil)
+	return
+}

--- a/openstack/apigw/v2/tr_policy/Get.go
+++ b/openstack/apigw/v2/tr_policy/Get.go
@@ -1,0 +1,17 @@
+package throttling_policy
+
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Get(client *golangsdk.ServiceClient, gatewayID, throttleID string) (*ThrottlingResp, error) {
+	raw, err := client.Get(client.ServiceURL("apigw", "instances", gatewayID, "throttles", throttleID), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ThrottlingResp
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/apigw/v2/tr_policy/List.go
+++ b/openstack/apigw/v2/tr_policy/List.go
@@ -1,0 +1,47 @@
+package throttling_policy
+
+import (
+	"bytes"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+)
+
+type ListOpts struct {
+	GatewayID     string `json:"-"`
+	ThrottleID    string `q:"id"`
+	PolicyName    string `q:"name"`
+	PreciseSearch string `q:"precise_search"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]ThrottlingResp, error) {
+	q, err := golangsdk.BuildQueryString(&opts)
+	if err != nil {
+		return nil, err
+	}
+	pages, err := pagination.Pager{
+		Client:     client,
+		InitialURL: client.ServiceURL("apigw", "instances", opts.GatewayID, "throttles") + q.String(),
+		CreatePage: func(r pagination.NewPageResult) pagination.NewPage {
+			return ThrottlingPage{NewSinglePageBase: pagination.NewSinglePageBase{NewPageResult: r}}
+		},
+	}.NewAllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return ExtractTrPolicy(pages)
+}
+
+type ThrottlingPage struct {
+	pagination.NewSinglePageBase
+}
+
+func ExtractTrPolicy(r pagination.NewPage) ([]ThrottlingResp, error) {
+	var s struct {
+		ThrottlingPolicies []ThrottlingResp `json:"throttles"`
+	}
+	err := extract.Into(bytes.NewReader((r.(ThrottlingPage)).Body), &s)
+	return s.ThrottlingPolicies, err
+}

--- a/openstack/apigw/v2/tr_policy/Update.go
+++ b/openstack/apigw/v2/tr_policy/Update.go
@@ -1,0 +1,42 @@
+package throttling_policy
+
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type UpdateOpts struct {
+	GatewayID             string `json:"-"`
+	ThrottleID            string `json:"-"`
+	Name                  string `json:"name" required:"true"`
+	AppCallLimits         *int   `json:"app_call_limits,omitempty"`
+	ApiCallLimits         *int   `json:"api_call_limits" required:"true"`
+	TimeInterval          *int   `json:"time_interval" required:"true"`
+	TimeUnit              string `json:"time_unit" required:"true"`
+	Description           string `json:"remark,omitempty"`
+	Type                  *int   `json:"type,omitempty"`
+	IpCallLimits          *int   `json:"ip_call_limits,omitempty"`
+	UserCallLimits        *int   `json:"user_call_limits,omitempty"`
+	EnableAdaptiveControl string `json:"enable_adaptive_control,omitempty"`
+}
+
+func Update(client *golangsdk.ServiceClient, opts UpdateOpts) (*ThrottlingResp, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Put(client.ServiceURL("apigw", "instances", opts.GatewayID, "throttles", opts.ThrottleID),
+		b, nil, &golangsdk.RequestOpts{
+			OkCodes: []int{200},
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	var res ThrottlingResp
+
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}


### PR DESCRIPTION
### What this PR does / why we need it
Package to manage throttling policies
Refers to: [#2403](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/2403).

### Acceptance tests
=== RUN   TestThrottlingPolicyLifecycle
    tools.go:72: {
          "app_call_limits": 50,
          "name": "test_policy_1QYv2_updated",
          "time_unit": "MINUTE",
          "remark": "test throttling policy updated",
          "api_call_limits": 199,
          "type": 1,
          "enable_adaptive_control": "FALSE",
          "user_call_limits": 50,
          "time_interval": 999,
          "ip_call_limits": 0,
          "id": "7d1bf038797d454f8013c395bf0bc12f",
          "bind_num": 0,
          "is_inclu_special_throttle": 2,
          "create_time": "2024-01-11T02:08:44Z"
        }
--- PASS: TestThrottlingPolicyLifecycle (1.67s)
=== RUN   TestThrottlingPolicyList
    tools.go:72: [
          {
            "app_call_limits": 0,
            "name": "Throttling_ozcf",
            "time_unit": "MINUTE",
            "remark": "",
            "api_call_limits": 200,
            "type": 1,
            "enable_adaptive_control": "FALSE",
            "user_call_limits": 0,
            "time_interval": 2,
            "ip_call_limits": 0,
            "id": "7782f5327cf54bf1ac9fe804faf64ab3",
            "bind_num": 0,
            "is_inclu_special_throttle": 2,
            "create_time": "2024-01-11T02:05:25Z"
          }
        ]
--- PASS: TestThrottlingPolicyList (0.54s)
PASS

Process finished with the exit code 0

