### PR TITLE
RDS: auto-scaling APIs implementation

### DIFF
--- a/acceptance/openstack/rds/v3/rds_test.go
+++ b/acceptance/openstack/rds/v3/rds_test.go
@@ -486,3 +486,33 @@ func TestBackupRestorePointInTime(t *testing.T) {
 	th.AssertNoErr(t, err)
 	_ = instances.WaitForJobCompleted(client, 600, pitr)
 }
+
+func TestRdsAutoScaling(t *testing.T) {
+	if os.Getenv("RUN_RDS_LIFECYCLE") == "" {
+		t.Skip("too slow to run in zuul")
+	}
+
+	client, err := clients.NewRdsV3()
+	th.AssertNoErr(t, err)
+
+	cc, err := clients.CloudAndClient()
+	th.AssertNoErr(t, err)
+
+	t.Log("Creating instance")
+
+	// Create MySql RDSv3 instance
+	rds := CreateMySqlRDS(t, client, cc.RegionName)
+	t.Cleanup(func() { DeleteRDS(t, client, rds.Id) })
+	th.AssertEquals(t, rds.Volume.Size, 100)
+
+	err = instances.ManageAutoScaling(client, rds.Id, instances.ScalingOpts{
+		SwitchOption:     true,
+		LimitSize:        pointerto.Int(40),
+		TriggerThreshold: pointerto.Int(20),
+	})
+	th.AssertNoErr(t, err)
+
+	scaling, err := instances.GetAutoScaling(client, rds.Id)
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, scaling)
+}

--- a/acceptance/openstack/rds/v3/rds_test.go
+++ b/acceptance/openstack/rds/v3/rds_test.go
@@ -507,7 +507,7 @@ func TestRdsAutoScaling(t *testing.T) {
 
 	err = instances.ManageAutoScaling(client, rds.Id, instances.ScalingOpts{
 		SwitchOption:     true,
-		LimitSize:        pointerto.Int(40),
+		LimitSize:        pointerto.Int(200),
 		TriggerThreshold: pointerto.Int(20),
 	})
 	th.AssertNoErr(t, err)

--- a/openstack/rds/v3/instances/GetAutoScaling.go
+++ b/openstack/rds/v3/instances/GetAutoScaling.go
@@ -12,6 +12,6 @@ func GetAutoScaling(client *golangsdk.ServiceClient, id string) (*ScalingOpts, e
 		return nil, err
 	}
 	var res ScalingOpts
-	err = extract.IntoStructPtr(raw.Body, &res, "backup")
+	err = extract.Into(raw.Body, &res)
 	return &res, err
 }

--- a/openstack/rds/v3/instances/GetAutoScaling.go
+++ b/openstack/rds/v3/instances/GetAutoScaling.go
@@ -1,0 +1,17 @@
+package instances
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func GetAutoScaling(client *golangsdk.ServiceClient, id string) (*ScalingOpts, error) {
+	// PUT https://{Endpoint}/v3/{project_id}/instances/{instance_id}/disk-auto-expansion
+	raw, err := client.Get(client.ServiceURL("instances", id, "disk-auto-expansion"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	var res ScalingOpts
+	err = extract.IntoStructPtr(raw.Body, &res, "backup")
+	return &res, err
+}

--- a/openstack/rds/v3/instances/ManageAutoScaling.go
+++ b/openstack/rds/v3/instances/ManageAutoScaling.go
@@ -1,0 +1,25 @@
+package instances
+
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type ScalingOpts struct {
+	SwitchOption     bool `json:"switch_option" required:"true"`
+	LimitSize        *int `json:"limit_size,omitempty"`
+	TriggerThreshold *int `json:"trigger_threshold,omitempty"`
+}
+
+func ManageAutoScaling(client *golangsdk.ServiceClient, id string, opts ScalingOpts) error {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+	// PUT https://{Endpoint}/v3/{project_id}/instances/{instance_id}/disk-auto-expansion
+	_, err = client.Put(client.ServiceURL("instances", id, "disk-auto-expansion"), b, nil, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/openstack/rds/v3/instances/ManageAutoScaling.go
+++ b/openstack/rds/v3/instances/ManageAutoScaling.go
@@ -17,7 +17,9 @@ func ManageAutoScaling(client *golangsdk.ServiceClient, id string, opts ScalingO
 		return err
 	}
 	// PUT https://{Endpoint}/v3/{project_id}/instances/{instance_id}/disk-auto-expansion
-	_, err = client.Put(client.ServiceURL("instances", id, "disk-auto-expansion"), b, nil, nil)
+	_, err = client.Put(client.ServiceURL("instances", id, "disk-auto-expansion"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What this PR does / why we need it
PR implements 2 API for RDS auto-scaling management.

Documentation available here: https://artifacts.eco.tsi-dev.otc-service.com/zuul_gl_logs/a41/39/3d0c2583cb4ee6ca7e9f96a7f4bec2d6a6b5464d/check/build-otc-api-ref/a413c1b/docs/api-ref/api_v3_recommended/db_instance_management/querying_an_autoscaling_policy.html

### Acceptance tests
=== RUN   TestRdsAutoScaling
    rds_test.go:501: Creating instance
    helpers.go:67: Attempting to create RDSv3
    helpers.go:107: Created RDSv3: ab96e14ad9ee41b9affcf2fbc144c910in01
    tools.go:72: {
          "switch_option": false
        }
    helpers.go:113: Attempting to delete RDSv3: ab96e14ad9ee41b9affcf2fbc144c910in01
    helpers.go:124: RDSv3 instance deleted: ab96e14ad9ee41b9affcf2fbc144c910in01
--- PASS: TestRdsAutoScaling (369.93s)
PASS

Process finished with the exit code 0