### PR TITLE
[OBS]: Custom domain name

### DIFF
--- a/acceptance/openstack/obs/v1/obs_test.go
+++ b/acceptance/openstack/obs/v1/obs_test.go
@@ -271,3 +271,41 @@ func TestOBSObjectLock(t *testing.T) {
 	_, err = client.SetWORMPolicy(&wormOpts)
 	th.AssertNoErr(t, err)
 }
+
+func TestOBSCustomDomain(t *testing.T) {
+	client, err := clients.NewOBSClient()
+	th.AssertNoErr(t, err)
+
+	bucketName := strings.ToLower(tools.RandomString("obs-sdk-test-", 5))
+
+	_, err = client.CreateBucket(&obs.CreateBucketInput{
+		Bucket: bucketName,
+	})
+	t.Cleanup(func() {
+		_, err = client.DeleteBucket(bucketName)
+		th.AssertNoErr(t, err)
+	})
+	th.AssertNoErr(t, err)
+
+	domainName := "www.test.com"
+
+	input := &obs.SetBucketCustomDomainInput{
+		Bucket:       bucketName,
+		CustomDomain: domainName,
+	}
+	_, err = client.SetBucketCustomDomain(input)
+	th.AssertNoErr(t, err)
+
+	output, err := client.GetBucketCustomDomain(bucketName)
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, output)
+
+	inputDelete := &obs.DeleteBucketCustomDomainInput{
+		Bucket:       bucketName,
+		CustomDomain: domainName,
+	}
+
+	_, err = client.DeleteBucketCustomDomain(inputDelete)
+	th.AssertNoErr(t, err)
+}

--- a/openstack/obs/client_bucket.go
+++ b/openstack/obs/client_bucket.go
@@ -669,3 +669,38 @@ func (obsClient ObsClient) GetWORMPolicy(bucketName string) (output *GetBucketWO
 	}
 	return
 }
+
+func (obsClient ObsClient) DeleteBucketCustomDomain(input *DeleteBucketCustomDomainInput) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("DeleteBucketCustomDomainInput is nil")
+	}
+
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("DeleteBucketCustomDomain", HTTP_DELETE, input.Bucket, newSubResourceSerialV2(SubResourceCustomDomain, input.CustomDomain), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetBucketCustomDomain(input *SetBucketCustomDomainInput) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("SetBucketCustomDomainInput is nil")
+	}
+
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("SetBucketCustomDomain", HTTP_PUT, input.Bucket, newSubResourceSerialV2(SubResourceCustomDomain, input.CustomDomain), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetBucketCustomDomain(bucketName string) (output *GetBucketCustomDomainOuput, err error) {
+	output = &GetBucketCustomDomainOuput{}
+	err = obsClient.doActionWithBucket("GetBucketCustomDomain", HTTP_GET, bucketName, newSubResourceSerial(SubResourceCustomDomain), output)
+	if err != nil {
+		output = nil
+	}
+	return
+}

--- a/openstack/obs/const.go
+++ b/openstack/obs/const.go
@@ -666,6 +666,7 @@ const (
 	SubResourceNotification  SubResourceType  = "notification"
 	SubResourceEncryption    SubResourceType  = "encryption"
 	SubResourceObjectLock    SubResourceType  = "object-lock"
+	SubResourceCustomDomain  SubResourceType  = "customdomain"
 	SubResourceTagging       SubResourceType  = "tagging"
 	SubResourceDelete        SubResourceType  = "delete"
 	SubResourceVersions      SubResourceType  = "versions"

--- a/openstack/obs/model_bucket.go
+++ b/openstack/obs/model_bucket.go
@@ -301,3 +301,27 @@ type GetBucketWORMPolicyOutput struct {
 	BaseModel
 	BucketWormPolicy
 }
+
+// DeleteBucketCustomDomainInput is the input parameter of DeleteBucketCustomDomain function
+type DeleteBucketCustomDomainInput struct {
+	Bucket       string
+	CustomDomain string
+}
+
+// GetBucketCustomDomainOuput is the result of GetBucketCustomdomain function
+type GetBucketCustomDomainOuput struct {
+	BaseModel
+	Domains []Domain `xml:"Domains"`
+}
+
+// SetBucketCustomDomainInput is the input parameter of SetBucketCustomDomain function
+type SetBucketCustomDomainInput struct {
+	Bucket       string
+	CustomDomain string
+}
+
+// Domain defines the object content properties
+type Domain struct {
+	DomainName string `xml:"DomainName"`
+	CreateTime string `xml:"CreateTime"`
+}

--- a/openstack/obs/trait.go
+++ b/openstack/obs/trait.go
@@ -66,6 +66,10 @@ func newSubResourceSerial(subResource SubResourceType) *DefaultSerializable {
 	return &DefaultSerializable{map[string]string{string(subResource): ""}, nil, nil}
 }
 
+func newSubResourceSerialV2(subResource SubResourceType, value string) *DefaultSerializable {
+	return &DefaultSerializable{map[string]string{string(subResource): value}, nil, nil}
+}
+
 func trans(subResource SubResourceType, input interface{}) (params map[string]string, headers map[string][]string, data interface{}, err error) {
 	params = map[string]string{string(subResource): ""}
 	data, err = ConvertRequestToIoReader(input)


### PR DESCRIPTION
### What this PR does / why we need it
Implements a custom domain names management for bucket
### Acceptance tests
=== RUN   TestOBSCustomDomain
    tools.go:72: {
          "StatusCode": 200,
          "request_id": "0000018E09811A114DD2FE2EB18B82B4",
          "ResponseHeaders": {
            "content-length": [
              "276"
            ],
            "content-type": [
              "application/xml"
            ],
            "date": [
              "Mon, 04 Mar 2024 12:47:19 GMT"
            ],
            "id-2": [
              "32AAAQAAEAABAAAQAAEAABAAAQAAEAABCSbOIzpo69/JsSvx5xuJp/fs4BekbfSJ"
            ],
            "request-id": [
              "0000018E09811A114DD2FE2EB18B82B4"
            ],
            "server": [
              "OBS"
            ],
            "x-reserved-indicator": [
              "9902"
            ]
          },
          "Domains": [
            {
              "DomainName": "www.test.com",
              "CreateTime": "2024-03-04T12:47:19.517Z"
            }
          ]
        }
--- PASS: TestOBSCustomDomain (1.62s)
PASS

Process finished with the exit code 0