### PR TITLE
[FGS]: version/alias management

### DIFF
--- a/acceptance/openstack/fgs/v2/alias_test.go
+++ b/acceptance/openstack/fgs/v2/alias_test.go
@@ -1,0 +1,77 @@
+package v2
+
+import (
+	"strings"
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/fgs/v2/alias"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/fgs/v2/function"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestFunctionGraphListAliases(t *testing.T) {
+	client, err := clients.NewFuncGraphClient()
+	th.AssertNoErr(t, err)
+
+	createResp, _ := createFunctionGraph(t, client)
+	funcUrn := strings.TrimSuffix(createResp.FuncURN, ":latest")
+
+	defer func(client *golangsdk.ServiceClient, id string) {
+		err = function.Delete(client, id)
+		th.AssertNoErr(t, err)
+	}(client, funcUrn)
+
+	publishOpts := alias.PublishOpts{
+		FuncUrn:     funcUrn,
+		Version:     "new-version",
+		Description: "terraform",
+	}
+
+	publishOptsResp, err := alias.PublishVersion(client, publishOpts)
+	th.AssertNoErr(t, err)
+
+	createAliasOpts := alias.CreateAliasOpts{
+		Name:        "test-alias",
+		Version:     "new-version",
+		Description: "terraform alias",
+		FuncUrn:     publishOptsResp.FuncURN,
+	}
+
+	listVersion, err := alias.ListVersion(client, alias.ListVersionOpts{
+		FuncUrn: publishOptsResp.FuncURN,
+	})
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, listVersion)
+
+	createAliasResp, err := alias.CreateAlias(client, createAliasOpts)
+	th.AssertNoErr(t, err)
+
+	listAliasResp, err := alias.ListAlias(client, publishOptsResp.FuncURN)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, listAliasResp[0].Name, createAliasResp.Name)
+	th.AssertEquals(t, listAliasResp[0].Version, createAliasResp.Version)
+
+	updateAliasResp, err := alias.UpdateAlias(client, alias.UpdateAliasOpts{
+		FuncUrn:     funcUrn,
+		AliasName:   "test-alias",
+		Version:     "new-version",
+		Description: "new description",
+	})
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, listAliasResp[0].Name, updateAliasResp.Name)
+	th.AssertEquals(t, updateAliasResp.Description, "new description")
+
+	getAliasResp, err := alias.GetAlias(client, publishOptsResp.FuncURN, "test-alias")
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, listAliasResp[0].Name, getAliasResp.Name)
+	th.AssertEquals(t, getAliasResp.Description, updateAliasResp.Description)
+	th.AssertEquals(t, listAliasResp[0].AliasUrn, getAliasResp.AliasUrn)
+
+	th.AssertNoErr(t, alias.Delete(client, publishOptsResp.FuncURN, "test-alias"))
+}

--- a/openstack/fgs/v2/alias/CreateAlias.go
+++ b/openstack/fgs/v2/alias/CreateAlias.go
@@ -1,0 +1,55 @@
+package alias
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateAliasOpts struct {
+	FuncUrn                   string                    `json:"-"`
+	Name                      string                    `json:"name" required:"true"`
+	Version                   string                    `json:"version" required:"true"`
+	Description               string                    `json:"description,omitempty"`
+	AdditionalVersionWeights  map[string]int            `json:"additional_version_weights,omitempty"`
+	AdditionalVersionStrategy map[string]VectorStrategy `json:"additional_version_strategy,omitempty"`
+}
+
+type VectorStrategy struct {
+	CombineType string                `json:"combine_type"`
+	Rules       *VersionStrategyRules `json:"rules"`
+}
+
+type VersionStrategyRules struct {
+	RuleType string `json:"rule_type"`
+	Param    string `json:"param"`
+	Op       string `json:"op"`
+	Value    string `json:"value"`
+}
+
+func CreateAlias(client *golangsdk.ServiceClient, opts CreateAliasOpts) (*FuncAliasesResp, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Post(client.ServiceURL("fgs", "functions", opts.FuncUrn, "aliases"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res FuncAliasesResp
+	return &res, extract.Into(raw.Body, &res)
+}
+
+type FuncAliasesResp struct {
+	Name                      string                    `json:"name"`
+	Version                   string                    `json:"version"`
+	Description               string                    `json:"description"`
+	LastModified              string                    `json:"last_modified"`
+	AliasUrn                  string                    `json:"alias_urn"`
+	AdditionalVersionWeights  map[string]int            `json:"additional_version_weights"`
+	AdditionalVersionStrategy map[string]VectorStrategy `json:"additional_version_strategy"`
+}

--- a/openstack/fgs/v2/alias/DeleteAlias.go
+++ b/openstack/fgs/v2/alias/DeleteAlias.go
@@ -1,0 +1,8 @@
+package alias
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+func Delete(client *golangsdk.ServiceClient, funcURN, aliasName string) (err error) {
+	_, err = client.Delete(client.ServiceURL("fgs", "functions", funcURN, "aliases", aliasName), nil)
+	return
+}

--- a/openstack/fgs/v2/alias/GetAlias.go
+++ b/openstack/fgs/v2/alias/GetAlias.go
@@ -1,0 +1,17 @@
+package alias
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func GetAlias(client *golangsdk.ServiceClient, funcURN, aliasName string) (*FuncAliases, error) {
+	raw, err := client.Get(client.ServiceURL("fgs", "functions", funcURN, "aliases", aliasName), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res *FuncAliases
+	err = extract.Into(raw.Body, &res)
+	return res, err
+}

--- a/openstack/fgs/v2/alias/ListAlias.go
+++ b/openstack/fgs/v2/alias/ListAlias.go
@@ -1,0 +1,26 @@
+package alias
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func ListAlias(client *golangsdk.ServiceClient, funcURN string) ([]FuncAliases, error) {
+	raw, err := client.Get(client.ServiceURL("fgs", "functions", funcURN, "aliases"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res []FuncAliases
+	err = extract.IntoSlicePtr(raw.Body, &res, "")
+	return res, err
+}
+
+type FuncAliases struct {
+	Name                     string         `json:"name"`
+	Version                  string         `json:"version"`
+	Description              string         `json:"description"`
+	LastModified             string         `json:"last_modified"`
+	AliasUrn                 string         `json:"alias_urn"`
+	AdditionalVersionWeights map[string]int `json:"additional_version_weights"`
+}

--- a/openstack/fgs/v2/alias/ListVersion.go
+++ b/openstack/fgs/v2/alias/ListVersion.go
@@ -1,0 +1,35 @@
+package alias
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/fgs/v2/function"
+)
+
+type ListVersionOpts struct {
+	FuncUrn  string `q:"-"`
+	Marker   string `q:"marker,omitempty"`
+	Maxitems string `q:"maxitems,omitempty"`
+}
+
+func ListVersion(client *golangsdk.ServiceClient, opts ListVersionOpts) (*ListVersionResponse, error) {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints("fgs", "functions", opts.FuncUrn, "versions").WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListVersionResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListVersionResponse struct {
+	Functions  []function.FuncGraph `json:"versions"`
+	NextMarker int                  `json:"next_marker"`
+	Count      int                  `json:"count"`
+}

--- a/openstack/fgs/v2/alias/PublishVersion.go
+++ b/openstack/fgs/v2/alias/PublishVersion.go
@@ -1,0 +1,32 @@
+package alias
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/fgs/v2/function"
+)
+
+type PublishOpts struct {
+	FuncUrn     string `json:"-"`
+	Digest      string `json:"digest,omitempty"`
+	Version     string `json:"version,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+func PublishVersion(client *golangsdk.ServiceClient, opts PublishOpts) (*function.FuncGraph, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Post(client.ServiceURL("fgs", "functions", opts.FuncUrn, "versions"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res function.FuncGraph
+	return &res, extract.Into(raw.Body, &res)
+}

--- a/openstack/fgs/v2/alias/UpdateAlias.go
+++ b/openstack/fgs/v2/alias/UpdateAlias.go
@@ -1,0 +1,33 @@
+package alias
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type UpdateAliasOpts struct {
+	FuncUrn                   string                    `json:"-"`
+	AliasName                 string                    `json:"-"`
+	Version                   string                    `json:"version" required:"true"`
+	Description               string                    `json:"description,omitempty"`
+	AdditionalVersionWeights  map[string]int            `json:"additional_version_weights,omitempty"`
+	AdditionalVersionStrategy map[string]VectorStrategy `json:"additional_version_strategy,omitempty"`
+}
+
+func UpdateAlias(client *golangsdk.ServiceClient, opts UpdateAliasOpts) (*FuncAliasesResp, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Put(client.ServiceURL("fgs", "functions", opts.FuncUrn, "aliases", opts.AliasName), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res FuncAliasesResp
+	return &res, extract.Into(raw.Body, &res)
+}


### PR DESCRIPTION
### What this PR does / why we need it
Implement versions and aliases management.

### Acceptance tests
=== RUN   TestFunctionGraphListAliases
    tools.go:72: {
          "versions": [
            {
              "func_id": "",
              "func_urn": "urn:fss:eu-de:a720688fb87f4575a4c000d818061eae:function:default:funcgraph-acctestgn7D:latest",
              "func_name": "funcgraph-acctestgn7D",
              "domain_id": "698f9bf85ca9437a9b2f41132ab3aa0e",
              "namespace": "a720688fb87f4575a4c000d818061eae",
              "project_name": "eu-de",
              "package": "default",
              "runtime": "Python3.9",
              "timeout": 200,
              "handler": "index.py",
              "memory_size": 512,
              "gpu_memory": 0,
              "cpu": 600,
              "code_type": "zip",
              "code_url": "",
              "code_filename": "funcgraph-acctestgn7D.zip",
              "code_size": 286,
              "domain_names": "",
              "user_data": "",
              "encrypted_user_data": "",
              "digest": "f233be6d5b0f84a14012fa6f33d42c0044bc457e45890fcf1feb8b1b9ba27abb840d86c58799ad8c5b97bb839faf2d7afb97d8cee7d40ca487da112095d5c0e4",
              "version": "latest",
              "image_name": "latest-240417123114@nihpn",
              "xrole": "",
              "app_xrole": "",
              "description": "",
              "last_modified": "2024-04-17T12:31:14+02:00",
              "func_vpc": {
                "security_groups": null
              },
              "mount_config": {
                "mount_user": {
                  "user_id": "",
                  "user_group_id": ""
                },
                "func_mounts": null
              },
              "reserved_instance_count": 0,
              "depend_version_list": null,
              "strategy_config": {
                "concurrency": 400,
                "concurrent_num": 1
              },
              "extend_config": "",
              "dependencies": null,
              "initializer_handler": "",
              "initializer_timeout": 0,
              "pre_stop_handler": "",
              "pre_stop_timeout": "",
              "long_time": false,
              "log_group_id": "",
              "log_stream_id": "",
              "type": "",
              "enable_dynamic_memory": false,
              "is_stateful_function": false,
              "custom_image": {},
              "is_bridge_function": false,
              "apig_route_enable": false,
              "heartbeat_handler": "",
              "enable_class_isolation": false,
              "gpu_type": "",
              "allow_ephemeral_storage": false,
              "ephemeral_storage": 512,
              "network_controller": {},
              "resource_id": "",
              "enable_auth_in_header": false,
              "reserved_instance_idle_mode": false
            },
            {
              "func_id": "",
              "func_urn": "urn:fss:eu-de:a720688fb87f4575a4c000d818061eae:function:default:funcgraph-acctestgn7D:new-version",
              "func_name": "funcgraph-acctestgn7D",
              "domain_id": "698f9bf85ca9437a9b2f41132ab3aa0e",
              "namespace": "a720688fb87f4575a4c000d818061eae",
              "project_name": "eu-de",
              "package": "default",
              "runtime": "Python3.9",
              "timeout": 200,
              "handler": "index.py",
              "memory_size": 512,
              "gpu_memory": 0,
              "cpu": 600,
              "code_type": "zip",
              "code_url": "",
              "code_filename": "funcgraph-acctestgn7D.zip",
              "code_size": 286,
              "domain_names": "",
              "user_data": "",
              "encrypted_user_data": "",
              "digest": "f233be6d5b0f84a14012fa6f33d42c0044bc457e45890fcf1feb8b1b9ba27abb840d86c58799ad8c5b97bb839faf2d7afb97d8cee7d40ca487da112095d5c0e4",
              "version": "new-version",
              "image_name": "new-version-240417123115@cbtc3",
              "xrole": "",
              "app_xrole": "",
              "description": "",
              "last_modified": "2024-04-17T12:31:15+02:00",
              "func_vpc": {
                "security_groups": null
              },
              "mount_config": {
                "mount_user": {
                  "user_id": "",
                  "user_group_id": ""
                },
                "func_mounts": null
              },
              "reserved_instance_count": 0,
              "depend_version_list": null,
              "strategy_config": {
                "concurrency": 400,
                "concurrent_num": 1
              },
              "extend_config": "",
              "dependencies": null,
              "initializer_handler": "",
              "initializer_timeout": 0,
              "pre_stop_handler": "",
              "pre_stop_timeout": "",
              "long_time": false,
              "log_group_id": "",
              "log_stream_id": "",
              "type": "",
              "enable_dynamic_memory": false,
              "is_stateful_function": false,
              "custom_image": {},
              "is_bridge_function": false,
              "apig_route_enable": false,
              "heartbeat_handler": "",
              "enable_class_isolation": false,
              "gpu_type": "",
              "allow_ephemeral_storage": false,
              "ephemeral_storage": 512,
              "network_controller": {},
              "resource_id": "",
              "enable_auth_in_header": false,
              "reserved_instance_idle_mode": false
            }
          ],
          "next_marker": 2,
          "count": 2
        }
--- PASS: TestFunctionGraphListAliases (3.89s)
PASS

Process finished with the exit code 0