### PR TITLE
css api was updated

### DIFF
--- a/acceptance/openstack/css/v1/snapshots_test.go
+++ b/acceptance/openstack/css/v1/snapshots_test.go
@@ -28,8 +28,9 @@ func TestSnapshotWorkflow(t *testing.T) {
 	defer deleteBucket(t, bucketName)
 
 	basicOpts := snapshots.UpdateConfigurationOpts{
-		Bucket: bucketName,
-		Agency: agencyID,
+		Bucket:   bucketName,
+		Agency:   agencyID,
+		BasePath: "css_repository/css-test",
 	}
 	err = snapshots.UpdateConfiguration(client, clusterID, basicOpts)
 	th.AssertNoErr(t, err)
@@ -111,11 +112,15 @@ func createCluster(t *testing.T, client *golangsdk.ServiceClient) string {
 				SubnetID:        subnetID,
 				SecurityGroupID: sgID,
 			},
-			AvailabilityZone: "eu-de-02",
+			AvailabilityZone: "eu-de-01",
 		},
 		InstanceNum: 1,
 		DiskEncryption: &clusters.DiskEncryption{
 			Encrypted: "0",
+		},
+		Datastore: &clusters.Datastore{
+			Version: "Opensearch_1.3.6",
+			Type:    "elasticsearch",
 		},
 	}
 	created, err := clusters.Create(client, opts)

--- a/openstack/css/v1/clusters/results.go
+++ b/openstack/css/v1/clusters/results.go
@@ -37,8 +37,8 @@ type Datastore struct {
 	// The default value is 7.6.2.
 	Version string `json:"version" required:"true"`
 	// Type - Engine type.
-	// The default value is `elasticsearch`.
-	Type string `json:"type,omitempty"`
+	// The value is `elasticsearch` or 'opensearch'.
+	Type string `json:"type" required:"true"`
 }
 
 type Instance struct {

--- a/openstack/css/v1/snapshots/UpdateConfiguration.go
+++ b/openstack/css/v1/snapshots/UpdateConfiguration.go
@@ -1,6 +1,9 @@
 package snapshots
 
-import "github.com/opentelekomcloud/gophertelekomcloud"
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
 
 type UpdateConfigurationOpts struct {
 	// OBS bucket used for index data backup.
@@ -8,12 +11,14 @@ type UpdateConfigurationOpts struct {
 	Bucket string `json:"bucket" required:"true"`
 	// IAM agency used to access OBS.
 	Agency string `json:"agency" required:"true"`
+	// IAM agency used to access OBS.
+	BasePath string `json:"basePath" required:"true"`
 	// Key ID used for snapshot encryption.
 	SnapshotCmkID string `json:"snapshotCmkId,omitempty"`
 }
 
 func UpdateConfiguration(client *golangsdk.ServiceClient, clusterID string, opts UpdateConfigurationOpts) (err error) {
-	b, err := golangsdk.BuildRequestBody(opts, "")
+	b, err := build.RequestBody(opts, "")
 	if err != nil {
 		return
 	}

--- a/openstack/css/v1/snapshots/UpdateConfiguration.go
+++ b/openstack/css/v1/snapshots/UpdateConfiguration.go
@@ -11,7 +11,7 @@ type UpdateConfigurationOpts struct {
 	Bucket string `json:"bucket" required:"true"`
 	// IAM agency used to access OBS.
 	Agency string `json:"agency" required:"true"`
-	// IAM agency used to access OBS.
+	// Storage path of the snapshot in the OBS bucket.
 	BasePath string `json:"basePath" required:"true"`
 	// Key ID used for snapshot encryption.
 	SnapshotCmkID string `json:"snapshotCmkId,omitempty"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
Datastore type now required for cluster,
BasePath attribute added for snapshot configuration and required


```
=== RUN   TestSnapshotWorkflow
    tools.go:72: {
          "keepday": 1,
          "period": "00:00 GMT+03:00",
          "prefix": "snap",
          "bucket": "snapshot-sdk-test-bucket",
          "basePath": "css_repository/css-test",
          "agency": "css_obs_agency",
          "enable": "true",
          "snapshotCmkId": ""
        }
--- PASS: TestSnapshotWorkflow (752.81s)
PASS

Debugger finished with the exit code 0
```