### PR TITLE
[DCS]: v2 other APIs

### DIFF
--- a/acceptance/openstack/dcs/v2/configs_test.go
+++ b/acceptance/openstack/dcs/v2/configs_test.go
@@ -1,0 +1,37 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dcs/v2/configs"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestDcsV2ConfigLifeCycle(t *testing.T) {
+	client, err := clients.NewDcsV2Client()
+	th.AssertNoErr(t, err)
+
+	dcsInstance := createDCSInstance(t, client)
+
+	updateOpts := configs.ModifyConfigOpt{
+		InstanceId: dcsInstance.InstanceID,
+		RedisConfig: []configs.RedisConfigs{
+			{
+				ParamID:    "1",
+				ParamName:  "timeout",
+				ParamValue: "100",
+			},
+		},
+	}
+	t.Logf("Attempting to update DCSv2 configuration")
+	err = configs.Update(client, updateOpts)
+	th.AssertNoErr(t, err)
+	t.Logf("Updated DCSv2 configuration")
+
+	configList, err := configs.Get(client, dcsInstance.InstanceID)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, updateOpts.RedisConfig[0].ParamID, configList.RedisConfigs[0].ParamID)
+	th.AssertDeepEquals(t, updateOpts.RedisConfig[0].ParamValue, configList.RedisConfigs[0].ParamValue)
+	th.AssertDeepEquals(t, updateOpts.RedisConfig[0].ParamName, configList.RedisConfigs[0].ParamName)
+}

--- a/acceptance/openstack/dcs/v2/ssl_test.go
+++ b/acceptance/openstack/dcs/v2/ssl_test.go
@@ -1,0 +1,54 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dcs/v2/ssl"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestDcsInstanceSSLV2LifeCycle(t *testing.T) {
+	client, err := clients.NewDcsV2Client()
+	th.AssertNoErr(t, err)
+
+	dcsInstance := createDCSInstance(t, client)
+
+	sslOpts := ssl.SslOpts{
+		InstanceId: dcsInstance.InstanceID,
+		Enabled:    pointerto.Bool(true),
+	}
+
+	t.Logf("Attempting to enable SSL for DCSv2 instance")
+
+	_, err = ssl.Update(client, sslOpts)
+	th.AssertNoErr(t, err)
+
+	err = waitForInstanceAvailable(client, 100, dcsInstance.InstanceID)
+	th.AssertNoErr(t, err)
+
+	t.Logf("SSL enabled")
+
+	t.Logf("Attempting to retrieve SSL settings for DCSv2 instance")
+
+	getSsl, err := ssl.Get(client, dcsInstance.InstanceID)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, getSsl.Enabled, true)
+	th.AssertEquals(t, getSsl.SslValidated, true)
+
+	t.Logf("SSL settings retrieved")
+
+	t.Logf("Attempting to disable SSL for DCSv2 instance")
+
+	sslOpts.Enabled = pointerto.Bool(false)
+
+	_, err = ssl.Update(client, sslOpts)
+	th.AssertNoErr(t, err)
+
+	err = waitForInstanceAvailable(client, 100, dcsInstance.InstanceID)
+	th.AssertNoErr(t, err)
+
+	t.Logf("SSL disabled for DCSv2 instance")
+}

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -721,23 +721,16 @@ func NewDMSServiceV2(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts
 
 // NewDCSServiceV1 creates a ServiceClient that may be used to access the v1 Distributed Cache Service.
 func NewDCSServiceV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
-	sc, err := initClientOpts(client, eo, "network")
-	if err != nil {
-		return nil, err
-	}
-	sc.Endpoint = strings.Replace(sc.Endpoint, "vpc", "dcs", 1)
-	sc.ResourceBase = sc.Endpoint + "v1.0/" + client.ProjectID + "/"
-	return sc, err
+	return initClientOpts(client, eo, "dcsv1")
 }
 
 // NewDCSServiceV2 creates a ServiceClient that may be used to access the v2 Distributed Cache Service.
 func NewDCSServiceV2(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
-	sc, err := initClientOpts(client, eo, "network")
+	sc, err := initClientOpts(client, eo, "dcsv1")
 	if err != nil {
 		return nil, err
 	}
-	sc.Endpoint = strings.Replace(sc.Endpoint, "vpc", "dcs", 1)
-	sc.ResourceBase = sc.Endpoint + "v2/" + client.ProjectID + "/"
+	sc.Endpoint = strings.Replace(sc.Endpoint, "v1.0", "v2", 1)
 	return sc, err
 }
 

--- a/openstack/dcs/v2/configs/Get.go
+++ b/openstack/dcs/v2/configs/Get.go
@@ -1,0 +1,35 @@
+package configs
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Get(client *golangsdk.ServiceClient, id string) (*ConfigParam, error) {
+	raw, err := client.Get(client.ServiceURL("instances", id, "configs"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ConfigParam
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ConfigParam struct {
+	ConfigTime   string              `json:"config_time"`
+	InstanceID   string              `json:"instance_id"`
+	RedisConfigs []RedisConfigResult `json:"redis_config"`
+	ConfigStatus string              `json:"config_status"`
+	Status       string              `json:"status"`
+}
+
+type RedisConfigResult struct {
+	ParamValue   string `json:"param_value"`
+	Description  string `json:"description"`
+	ValueType    string `json:"value_type"`
+	ValueRange   string `json:"value_range"`
+	DefaultValue string `json:"default_value"`
+	ParamID      string `json:"param_id"`
+	ParamName    string `json:"param_name"`
+}

--- a/openstack/dcs/v2/configs/Update.go
+++ b/openstack/dcs/v2/configs/Update.go
@@ -1,0 +1,29 @@
+package configs
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type ModifyConfigOpt struct {
+	InstanceId  string         `json:"-"`
+	RedisConfig []RedisConfigs `json:"redis_config"`
+}
+
+type RedisConfigs struct {
+	ParamID    string `json:"param_id" required:"true"`
+	ParamName  string `json:"param_name" required:"true"`
+	ParamValue string `json:"param_value" required:"true"`
+}
+
+func Update(client *golangsdk.ServiceClient, opts ModifyConfigOpt) (err error) {
+	body, err := build.RequestBody(opts, "")
+	if err != nil {
+		return
+	}
+
+	_, err = client.Put(client.ServiceURL("instances", opts.InstanceId, "configs"), body, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}

--- a/openstack/dcs/v2/instance/Restart.go
+++ b/openstack/dcs/v2/instance/Restart.go
@@ -1,0 +1,35 @@
+package instance
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ChangeInstanceStatusOpts struct {
+	Instances []string `json:"instances,omitempty"`
+	Action    string   `json:"action,omitempty"`
+}
+
+func Restart(client *golangsdk.ServiceClient, opts ChangeInstanceStatusOpts) ([]BatchOpsResult, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Put(client.ServiceURL("instances", "status"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res []BatchOpsResult
+	err = extract.IntoSlicePtr(raw.Body, &res, "results")
+	return res, err
+}
+
+type BatchOpsResult struct {
+	Result   string `json:"result"`
+	Instance string `json:"instance"`
+}

--- a/openstack/dcs/v2/instance/UpdatePassword.go
+++ b/openstack/dcs/v2/instance/UpdatePassword.go
@@ -1,0 +1,39 @@
+package instance
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type UpdatePasswordOpts struct {
+	InstanceId  string `json:"-"`
+	OldPassword string `json:"old_password" required:"true"`
+	NewPassword string `json:"new_password" required:"true"`
+}
+
+func UpdatePassword(client *golangsdk.ServiceClient, opts UpdatePasswordOpts) (*UpdatePasswordResponse, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Put(client.ServiceURL("instances", opts.InstanceId, "password"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res UpdatePasswordResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type UpdatePasswordResponse struct {
+	LockTime       string `json:"lock_time"`
+	Result         string `json:"result"`
+	LockTimeLeft   string `json:"lock_time_left"`
+	RetryTimesLeft string `json:"retry_times_left"`
+	Message        string `json:"message"`
+}

--- a/openstack/dcs/v2/ssl/Get.go
+++ b/openstack/dcs/v2/ssl/Get.go
@@ -1,0 +1,26 @@
+package ssl
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Get(client *golangsdk.ServiceClient, id string) (*SslInfo, error) {
+	raw, err := client.Get(client.ServiceURL("instances", id, "ssl"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res SslInfo
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type SslInfo struct {
+	Enabled      bool   `json:"enabled"`
+	Ip           string `json:"ip"`
+	Port         string `json:"port"`
+	DomainName   string `json:"domain_name"`
+	SslExpiredAt string `json:"ssl_expired_at"`
+	SslValidated bool   `json:"ssl_validated"`
+}

--- a/openstack/dcs/v2/ssl/Update.go
+++ b/openstack/dcs/v2/ssl/Update.go
@@ -1,0 +1,39 @@
+package ssl
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type SslOpts struct {
+	InstanceId string `json:"-"`
+	Enabled    *bool  `json:"enabled" required:"true"`
+}
+
+func Update(client *golangsdk.ServiceClient, opts SslOpts) (*SslUpdateResp, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	url := client.ServiceURL("instances", opts.InstanceId, "ssl")
+	raw, err := client.Put(url, b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	var res SslUpdateResp
+
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type SslUpdateResp struct {
+	// Actual output parameters of API in which `result` is always `null`
+	JobId      string `json:"jobId"`
+	InstanceId string `json:"instanceId"`
+	Result     string `json:"result"`
+}


### PR DESCRIPTION
### What this PR does / why we need it
APIs needed for TF resource

### Acceptance tests
```
=== RUN   TestDcsV2ConfigLifeCycle
    helpers.go:20: Attempting to create DCSv2 instance
    helpers.go:97: DCSv2 instance successfully created: ca82f9bb-e533-42fe-9fd8-4d4bd1b390ab
    configs_test.go:27: Attempting to update DCSv2 configuration
    configs_test.go:30: Updated DCSv2 configuration
    helpers.go:110: Attempting to delete DCSv2 instance: ca82f9bb-e533-42fe-9fd8-4d4bd1b390ab
    helpers.go:119: Deleted DCSv2 instance: ca82f9bb-e533-42fe-9fd8-4d4bd1b390ab
--- PASS: TestDcsV2ConfigLifeCycle (53.46s)
=== RUN   TestDcsInstanceV2LifeCycle
    helpers.go:20: Attempting to create DCSv2 instance
    helpers.go:97: DCSv2 instance successfully created: e75417ec-057c-479b-b11e-b52a9bd129e2
    instance_test.go:42: Attempting to update whitelist configuration
    instance_test.go:56: Attempting to update DCSv2 instance
    instance_test.go:59: Updated DCSv2 instance
    instance_test.go:82: Attempting to resize DCSv2 instance
    instance_test.go:96: Resized DCSv2 instance
    instance_test.go:107: Retrieving whitelist configuration
    instance_test.go:116: Retrieving instance tags
    instance_test.go:123: Updating instance tags
    instance_test.go:132: Retrieving updated instance tags
    helpers.go:110: Attempting to delete DCSv2 instance: e75417ec-057c-479b-b11e-b52a9bd129e2
    helpers.go:119: Deleted DCSv2 instance: e75417ec-057c-479b-b11e-b52a9bd129e2
--- PASS: TestDcsInstanceV2LifeCycle (148.31s)
=== RUN   TestDcsInstanceSSLV2LifeCycle
    helpers.go:20: Attempting to create DCSv2 instance
    helpers.go:97: DCSv2 instance successfully created: fafed438-db25-47a8-9ca7-52017c97ac3b
    ssl_test.go:23: Attempting to enable SSL for DCSv2 instance
    ssl_test.go:31: SSL enabled
    ssl_test.go:33: Attempting to retrieve SSL settings for DCSv2 instance
    ssl_test.go:41: SSL settings retrieved
    ssl_test.go:43: Attempting to disable SSL for DCSv2 instance
    ssl_test.go:53: SSL disabled for DCSv2 instance
    helpers.go:110: Attempting to delete DCSv2 instance: fafed438-db25-47a8-9ca7-52017c97ac3b
    helpers.go:119: Deleted DCSv2 instance: fafed438-db25-47a8-9ca7-52017c97ac3b
--- PASS: TestDcsInstanceSSLV2LifeCycle (110.40s)
PASS
ok  	github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack/dcs/v2	312.515s

Process finished with the exit code 0
```