### PR TITLE
CCE: master volume encryption feature

### DIFF
--- a/acceptance/openstack/cce/helpers.go
+++ b/acceptance/openstack/cce/helpers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/clusters"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/keypairs"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
@@ -37,7 +38,11 @@ func CreateCluster(t *testing.T, vpcID, subnetID string) string {
 				Mode:                "rbac",
 				AuthenticatingProxy: make(map[string]string),
 			},
-			KubernetesSvcIpRange: "10.247.0.0/16",
+			KubernetesSvcIpRange:         "10.247.0.0/16",
+			EnableMasterVolumeEncryption: pointerto.Bool(true),
+			ExtendParam: map[string]string{
+				"kubernetes.io/cpuManagerPolicy": "static",
+			},
 		},
 	}).Extract()
 	th.AssertNoErr(t, err)

--- a/openstack/cce/v3/clusters/results.go
+++ b/openstack/cce/v3/clusters/results.go
@@ -71,6 +71,8 @@ type Spec struct {
 	KubernetesSvcIpRange string `json:"kubernetesSvcIpRange,omitempty"`
 	// KubeProxyMode Service forwarding mode. One of `iptables`, `ipvs`
 	KubeProxyMode string `json:"kubeProxyMode,omitempty"`
+	// The system disks and data disks of the master nodes in the cluster are encrypted.
+	EnableMasterVolumeEncryption *bool `json:"enableMasterVolumeEncryption,omitempty"`
 }
 
 // Node network parameters


### PR DESCRIPTION
### What this PR does / why we need it
Enable master volume encryption support for CCE cluster.

### Acceptance tests
```
=== RUN   TestNodes
--- PASS: TestNodes (991.05s)
=== RUN   TestNodes/TestNodeLifecycle
    --- PASS: TestNodes/TestNodeLifecycle (239.46s)
=== RUN   TestNodes/TestNodePoolLifecycle
    --- PASS: TestNodes/TestNodePoolLifecycle (242.33s)
PASS

Process finished with the exit code 0
```
