### PR TITLE
ER: enterprise router

### DIFF
--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -833,6 +833,17 @@ func NewFuncGraphClient() (client *golangsdk.ServiceClient, err error) {
 	})
 }
 
+// NewERClient returns authenticated Enterprise Router v3 client
+func NewERClient() (client *golangsdk.ServiceClient, err error) {
+	cc, err := CloudAndClient()
+	if err != nil {
+		return nil, err
+	}
+	return openstack.NewERServiceV3(cc.ProviderClient, golangsdk.EndpointOpts{
+		Region: cc.RegionName,
+	})
+}
+
 func UpdatePeerTenantDetails(cloud *openstack.Cloud) error {
 	if id := EnvOS.GetEnv("Peer_Tenant_ID"); id != "" {
 		cloud.AuthInfo.ProjectID = id

--- a/acceptance/openstack/er/helpers.go
+++ b/acceptance/openstack/er/helpers.go
@@ -1,0 +1,33 @@
+package er
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/instance"
+)
+
+func waitForInstanceAvailable(client *golangsdk.ServiceClient, secs int, instanceID string) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		erInstance, err := instance.Get(client, instanceID)
+		if err != nil {
+			return false, err
+		}
+		if erInstance.Instance.State == "available" {
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+func waitForInstanceDeleted(client *golangsdk.ServiceClient, secs int, instanceID string) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		_, err := instance.Get(client, instanceID)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return true, nil
+			}
+			return false, err
+		}
+
+		return false, nil
+	})
+}

--- a/acceptance/openstack/er/router_test.go
+++ b/acceptance/openstack/er/router_test.go
@@ -1,0 +1,86 @@
+package er
+
+import (
+	"os"
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/instance"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestEnterpriseRouterLifeCycle(t *testing.T) {
+	if os.Getenv("RUN_ER_LIFECYCLE") == "" {
+		t.Skip("too slow to run in zuul")
+	}
+	client, err := clients.NewERClient()
+	th.AssertNoErr(t, err)
+
+	routerName := tools.RandomString("acctest_er_router-", 4)
+
+	createOpts := instance.CreateOpts{
+		Name:                        routerName,
+		Description:                 "terraform created enterprise router",
+		Asn:                         64512,
+		EnableDefaultAssociation:    pointerto.Bool(true),
+		EnableDefaultPropagation:    pointerto.Bool(true),
+		AutoAcceptSharedAttachments: pointerto.Bool(true),
+		AvailabilityZoneIDs: []string{
+			"eu-de-01",
+			"eu-de-02",
+		},
+	}
+
+	t.Logf("Attempting to create enterprise router")
+
+	createResp, err := instance.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+
+	err = waitForInstanceAvailable(client, 100, createResp.Instance.ID)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, createOpts.Name, createResp.Instance.Name)
+	th.AssertEquals(t, createOpts.Description, createResp.Instance.Description)
+	th.AssertEquals(t, *createOpts.EnableDefaultPropagation, createResp.Instance.EnableDefaultPropagation)
+	th.AssertEquals(t, *createOpts.EnableDefaultAssociation, createResp.Instance.EnableDefaultAssociation)
+	th.AssertEquals(t, *createOpts.AutoAcceptSharedAttachments, createResp.Instance.AutoAcceptSharedAttachments)
+
+	defer func(client *golangsdk.ServiceClient, id string) {
+		t.Logf("Attempting to delete enterprise router")
+		err = instance.Delete(client, id)
+		th.AssertNoErr(t, err)
+		err = waitForInstanceDeleted(client, 500, createResp.Instance.ID)
+	}(client, createResp.Instance.ID)
+
+	updateOpts := instance.UpdateOpts{
+		InstanceID:                  createResp.Instance.ID,
+		Name:                        routerName + "-updated",
+		EnableDefaultAssociation:    pointerto.Bool(false),
+		EnableDefaultPropagation:    pointerto.Bool(false),
+		AutoAcceptSharedAttachments: pointerto.Bool(false),
+		Description:                 createOpts.Description + " updated",
+	}
+
+	t.Logf("Attempting to update enterprise router")
+
+	updateResp, err := instance.Update(client, updateOpts)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, updateOpts.Name, updateResp.Instance.Name)
+	th.AssertEquals(t, updateOpts.Description, updateResp.Instance.Description)
+	th.AssertEquals(t, *updateOpts.EnableDefaultPropagation, updateResp.Instance.EnableDefaultPropagation)
+	th.AssertEquals(t, *updateOpts.EnableDefaultAssociation, updateResp.Instance.EnableDefaultAssociation)
+	th.AssertEquals(t, *updateOpts.AutoAcceptSharedAttachments, updateResp.Instance.AutoAcceptSharedAttachments)
+}
+
+func TestEnterpriseRouterList(t *testing.T) {
+	client, err := clients.NewERClient()
+	th.AssertNoErr(t, err)
+
+	listOpts := instance.ListOpts{}
+	_, err = instance.List(client, listOpts)
+	th.AssertNoErr(t, err)
+}

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -976,3 +976,11 @@ func NewFuncGraph(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (
 	sc, err := initCommonServiceClient(client, eo, "functiongraph", "v2")
 	return sc, err
 }
+
+func NewERServiceV3(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	sc, err := initCommonServiceClient(client, eo, "er", "v3")
+	if err != nil {
+		return nil, err
+	}
+	return sc, nil
+}

--- a/openstack/er/v3/instance/Create.go
+++ b/openstack/er/v3/instance/Create.go
@@ -1,0 +1,96 @@
+package instance
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	tag "github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
+)
+
+type CreateOpts struct {
+	// Enterprise router name. The value can contain 1 to 64 characters, including letters, digits,
+	// underscores (_), hyphens (-), and periods (.).
+	Name string `json:"name" required:"true"`
+	// Supplementary information about an enterprise router
+	Description string `json:"description,omitempty"`
+	// Enterprise router BGP ASN. Specify a dedicated ASN in the range of 64512-65534 or 4200000000-4294967294.
+	// ASN can only be set during enterprise router creation.
+	Asn float64 `json:"asn" required:"true"`
+	// Default: postPaid
+	ChargeMode string `json:"charge_mode,omitempty"`
+	// Tag information
+	Tags []tag.ResourceTag `json:"tags,omitempty"`
+	//
+	// Whether to enable the Default Route Table Propagation function.
+	// The default value is false, indicating that the function is disabled.
+	EnableDefaultPropagation *bool `json:"enable_default_propagation,omitempty"`
+	// Whether to enable the Default Route Table Association function.
+	EnableDefaultAssociation *bool `json:"enable_default_association,omitempty"`
+	// AZs where the enterprise router is located
+	AvailabilityZoneIDs []string `json:"availability_zone_ids" required:"true"`
+	// Whether to enable Auto Accept Shared Attachments.
+	AutoAcceptSharedAttachments *bool `json:"auto_accept_shared_attachments,omitempty"`
+	// Enterprise router CIDR block. This parameter is not supported for now.
+	CidrBlocks []string `json:"cidr_blocks,omitempty"`
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*RouterInstanceResp, error) {
+	b, err := build.RequestBody(opts, "instance")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Post(client.ServiceURL("enterprise-router", "instances"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res RouterInstanceResp
+	return &res, extract.Into(raw.Body, &res)
+}
+
+type RouterInstanceResp struct {
+	// Enterprise router
+	Instance *RouterInstance `json:"instance"`
+	// Request ID
+	RequestID string `json:"request_id"`
+}
+
+type RouterInstance struct {
+	// Enterprise router ID
+	ID string `json:"id"`
+	// Enterprise router name
+	Name string `json:"name"`
+	// Supplementary information about an enterprise router
+	Description string `json:"description"`
+	// Enterprise router status.
+	State string `json:"state"`
+	// Tag information
+	Tags []tag.ResourceTag `json:"tags"`
+	// Default: postPaid
+	ChargeMode string `json:"charge_mode"`
+	// Creation time in the format YYYY-MM-DDTHH:mm:ss.sssZ
+	CreatedAt string `json:"created_at"`
+	// Update time in the format YYYY-MM-DDTHH:mm:ss.sssZ
+	UpdatedAt string `json:"updated_at"`
+	// Project ID
+	ProjectID string `json:"project_id"`
+	// Enterprise router BGP ASN
+	Asn float64 `json:"asn"`
+	// Whether to enable the Default Route Table Propagation function.
+	EnableDefaultPropagation bool `json:"enable_default_propagation"`
+	// Whether to enable the Default Route Table Association function.
+	EnableDefaultAssociation bool `json:"enable_default_association"`
+	// Default propagation route table ID
+	DefaultPropagationRouteTableID string `json:"default_propagation_route_table_id"`
+	// Default association route table ID
+	DefaultAssociationRouteTableID string `json:"default_association_route_table_id"`
+	// AZs where the enterprise router is located
+	AvailabilityZoneIDs []string `json:"availability_zone_ids"`
+	// Whether to automatically accept shared attachments.
+	AutoAcceptSharedAttachments bool `json:"auto_accept_shared_attachments"`
+	// Enterprise router CIDR block. This parameter is not supported for now.
+	CidrBlocks []string `json:"cidr_blocks"`
+}

--- a/openstack/er/v3/instance/Delete.go
+++ b/openstack/er/v3/instance/Delete.go
@@ -1,0 +1,10 @@
+package instance
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+func Delete(client *golangsdk.ServiceClient, instanceID string) (err error) {
+	_, err = client.Delete(client.ServiceURL("enterprise-router", "instances", instanceID), &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}

--- a/openstack/er/v3/instance/Get.go
+++ b/openstack/er/v3/instance/Get.go
@@ -1,0 +1,17 @@
+package instance
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Get(client *golangsdk.ServiceClient, instanceID string) (*RouterInstanceResp, error) {
+	raw, err := client.Get(client.ServiceURL("enterprise-router", "instances", instanceID), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res RouterInstanceResp
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/er/v3/instance/List.go
+++ b/openstack/er/v3/instance/List.go
@@ -1,0 +1,57 @@
+package instance
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListOpts struct {
+	// ID of the last enterprise router on the previous page. If this parameter is left blank, the first page is queried.
+	// This parameter must be used together with limit.
+	Marker string `q:"marker"`
+	// Number of records on each page. Value range: 0 to 2000
+	Limit int `q:"limit"`
+	// Enterprise router status. Value options: pending, available, modifying, deleting, deleted, failed and freezed
+	State []string `q:"state"`
+	// Query by resource ID. Multiple resources can be queried at a time.
+	ID []string `q:"id"`
+	// Attachment resource IDs
+	ResourceID []string `q:"resource_id"`
+	// Keyword for sorting. The keyword can be id, name, or state. By default, id is used.
+	SortKey []string `q:"sort_key"`
+	//
+	// Sorting order. There are two value options: asc (ascending order) and desc (descending order).
+	SortDir []string `q:"sort_dir"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListRouterInstanceResp, error) {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints("enterprise-router", "instances").WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListRouterInstanceResp
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListRouterInstanceResp struct {
+	// Enterprise routers
+	Instances []RouterInstance `json:"instances"`
+	// Request ID
+	RequestID string `json:"request_id"`
+	// Pagination query information
+	PageInfo PageInfo `json:"page_info"`
+}
+
+type PageInfo struct {
+	// Marker of the next page. The value is the resource UUID. If the value is empty, the resource is on the last page.
+	NextMarker string `json:"next_marker"`
+	// Number of resources in the list
+	CurrentCount int `json:"current_count"`
+}

--- a/openstack/er/v3/instance/Update.go
+++ b/openstack/er/v3/instance/Update.go
@@ -1,0 +1,44 @@
+package instance
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type UpdateOpts struct {
+	// Enterprise router ID
+	InstanceID string `json:"-"`
+	// Enterprise router name. The value can contain 1 to 64 characters, including letters,
+	// digits, underscores (_), hyphens (-), and periods (.).
+	Name string `json:"name,omitempty"`
+	// Supplementary information about an enterprise router
+	Description string `json:"description,omitempty"`
+	// Whether to enable Default Route Table Propagation.
+	EnableDefaultPropagation *bool `json:"enable_default_propagation,omitempty"`
+	// Whether to enable Default Route Table Association.
+	EnableDefaultAssociation *bool `json:"enable_default_association,omitempty"`
+	// Default propagation route table ID
+	DefaultPropagationRouteTableID string `json:"default_propagation_route_table_id,omitempty"`
+	// Default association route table ID
+	DefaultAssociationRouteTableID string `json:"default_association_route_table_id,omitempty"`
+	// Whether to automatically accept shared attachments.
+	AutoAcceptSharedAttachments *bool `json:"auto_accept_shared_attachments,omitempty"`
+}
+
+func Update(client *golangsdk.ServiceClient, opts UpdateOpts) (*RouterInstanceResp, error) {
+	b, err := build.RequestBody(opts, "instance")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Put(client.ServiceURL("enterprise-router", "instances", opts.InstanceID), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res RouterInstanceResp
+	return &res, extract.Into(raw.Body, &res)
+}


### PR DESCRIPTION
### What this PR does / why we need it
Implement ER methods.

### Acceptance tests
```
=== RUN   TestEnterpriseRouterLifeCycle
    router_test.go:33: Attempting to create enterprise router
    router_test.go:63: Attempting to update enterprise router
    router_test.go:48: Attempting to delete enterprise router
--- PASS: TestEnterpriseRouterLifeCycle (83.38s)
PASS

Process finished with the exit code 0

=== RUN   TestEnterpriseRouterList
--- PASS: TestEnterpriseRouterList (0.53s)
PASS

Process finished with the exit code 0
```