### PR TITLE
compute ecs api update

### DIFF
--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -37,12 +37,11 @@ jobs:
     if: ${{ github.event.label.name == 'gate' && success() }}
     steps:
       - uses: actions/checkout@v4
-      - uses: kattecon/gh-app-access-token-gen@v1
+      - uses: actions/create-github-app-token@v1
         id: gen_token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_KEY }}
-          installation_id: ${{ secrets.INSTALLATION_ID }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_KEY }}
       - run: |
           echo "Get current branch"
           BRANCH_NAME=$(curl -s -H "Authorization: token ${{ steps.gen_token.outputs.token }}" \

--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -85,7 +85,7 @@ func NewBlockStorageV3Client() (*golangsdk.ServiceClient, error) {
 }
 
 // NewComputeV2Client returns a *ServiceClient for making calls
-// to the OpenStack Compute v2 API. An error will be returned
+// to the OpenStack Compute v2.1 API. An error will be returned
 // if authentication or client creation was not possible.
 func NewComputeV2Client() (*golangsdk.ServiceClient, error) {
 	cc, err := CloudAndClient()
@@ -93,9 +93,14 @@ func NewComputeV2Client() (*golangsdk.ServiceClient, error) {
 		return nil, err
 	}
 
-	return openstack.NewComputeV2(cc.ProviderClient, golangsdk.EndpointOpts{
+	client, err := openstack.NewComputeV2(cc.ProviderClient, golangsdk.EndpointOpts{
 		Region: cc.RegionName,
 	})
+	if err != nil {
+		return nil, err
+	}
+	client.Microversion = "2.55"
+	return client, err
 }
 
 // NewComputeV1Client returns a *ServiceClient for making calls
@@ -840,6 +845,17 @@ func NewERClient() (client *golangsdk.ServiceClient, err error) {
 		return nil, err
 	}
 	return openstack.NewERServiceV3(cc.ProviderClient, golangsdk.EndpointOpts{
+		Region: cc.RegionName,
+	})
+}
+
+// NewHssClient returns authenticated HSS v5 client
+func NewHssClient() (client *golangsdk.ServiceClient, err error) {
+	cc, err := CloudAndClient()
+	if err != nil {
+		return nil, err
+	}
+	return openstack.NewHssV5(cc.ProviderClient, golangsdk.EndpointOpts{
 		Region: cc.RegionName,
 	})
 }

--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -849,17 +849,6 @@ func NewERClient() (client *golangsdk.ServiceClient, err error) {
 	})
 }
 
-// NewHssClient returns authenticated HSS v5 client
-func NewHssClient() (client *golangsdk.ServiceClient, err error) {
-	cc, err := CloudAndClient()
-	if err != nil {
-		return nil, err
-	}
-	return openstack.NewHssV5(cc.ProviderClient, golangsdk.EndpointOpts{
-		Region: cc.RegionName,
-	})
-}
-
 func UpdatePeerTenantDetails(cloud *openstack.Cloud) error {
 	if id := EnvOS.GetEnv("Peer_Tenant_ID"); id != "" {
 		cloud.AuthInfo.ProjectID = id

--- a/acceptance/openstack/compute/v2/servers_test.go
+++ b/acceptance/openstack/compute/v2/servers_test.go
@@ -17,7 +17,6 @@ import (
 func TestServerList(t *testing.T) {
 	client, err := clients.NewComputeV2Client()
 	th.AssertNoErr(t, err)
-
 	listOpts := servers.ListOpts{}
 	allServerPages, err := servers.List(client, listOpts).AllPages()
 	th.AssertNoErr(t, err)
@@ -57,7 +56,7 @@ func TestServerLifecycle(t *testing.T) {
 
 	flavorID, err := flavors.IDFromName(client, "s2.large.2")
 	th.AssertNoErr(t, err)
-
+	ecsDescription := "my description"
 	createOpts := servers.CreateOpts{
 		Name:      ecsName,
 		ImageRef:  image[0].Id,
@@ -71,6 +70,7 @@ func TestServerLifecycle(t *testing.T) {
 				UUID: networkID,
 			},
 		},
+		Description: ecsDescription,
 	}
 
 	ecs, err := servers.Create(client, createOpts).Extract()
@@ -83,6 +83,7 @@ func TestServerLifecycle(t *testing.T) {
 	ecs, err = servers.Get(client, ecs.ID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, ecsName, ecs.Name)
+	th.AssertEquals(t, ecsDescription, ecs.Description)
 
 	nicInfo, err := servers.GetNICs(client, ecs.ID).Extract()
 	th.AssertNoErr(t, err)
@@ -114,16 +115,16 @@ func TestServerLifecycle(t *testing.T) {
 
 	ecsName = tools.RandomString("update-ecs-", 3)
 	updateOpts := servers.UpdateOpts{
-		Name: ecsName,
+		Name:        ecsName,
+		Description: ecsDescription + " update",
 	}
 
 	_, err = servers.Update(client, ecs.ID, updateOpts).Extract()
-	th.AssertNoErr(t, err)
-
 	t.Logf("ECSv2 successfully updated: %s", ecs.ID)
 	th.AssertNoErr(t, err)
 
 	newECS, err := servers.Get(client, ecs.ID).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, ecsName, newECS.Name)
+	th.AssertEquals(t, ecsDescription+" update", newECS.Description)
 }

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -192,6 +192,8 @@ type CreateOpts struct {
 	// ServiceClient will allow calls to be made to retrieve an image or
 	// flavor ID by name.
 	ServiceClient *golangsdk.ServiceClient `json:"-"`
+
+	Description string `json:"description,omitempty"`
 }
 
 // ToServerCreateMap assembles a request body based on the contents of a
@@ -338,6 +340,8 @@ type UpdateOpts struct {
 
 	// AccessIPv6 provides a new IPv6 address for the instance.
 	AccessIPv6 string `json:"accessIPv6,omitempty"`
+
+	Description string `json:"description,omitempty"`
 }
 
 // ToServerUpdateMap formats an UpdateOpts structure into a request body.

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -105,7 +105,8 @@ type GetPasswordResult struct {
 // If privateKey != nil the password is decrypted with the private key.
 // If privateKey == nil the encrypted password is returned and can be decrypted
 // with:
-//   echo '<pwd>' | base64 -D | openssl rsautl -decrypt -inkey <private_key>
+//
+//	echo '<pwd>' | base64 -D | openssl rsautl -decrypt -inkey <private_key>
 func (r GetPasswordResult) ExtractPassword(privateKey *rsa.PrivateKey) (string, error) {
 	var s struct {
 		Password string `json:"password"`
@@ -222,7 +223,14 @@ type Server struct {
 	Fault Fault `json:"fault"`
 
 	// VolumeAttached includes the volumes that attached to the server.
-	VolumesAttached []map[string]string `json:"os-extended-volumes:volumes_attached"`
+	VolumesAttached []VolumesDetails `json:"os-extended-volumes:volumes_attached"`
+
+	Description string `json:"description"`
+}
+
+type VolumesDetails struct {
+	DeleteOnTermination bool   `json:"delete_on_termination"`
+	ID                  string `json:"id"`
 }
 
 type Fault struct {

--- a/openstack/compute/v2/servers/testing/fixtures.go
+++ b/openstack/compute/v2/servers/testing/fixtures.go
@@ -80,6 +80,7 @@ const ServerListBody = `
 			"OS-DCF:diskConfig": "MANUAL",
 			"os-extended-volumes:volumes_attached": [
 				{
+					"delete_on_termination": true,
 					"id": "cfb68a5e-203f-446d-9fd7-74b7e1f9722e"
 				}
 			],
@@ -154,6 +155,7 @@ const ServerListBody = `
 			"OS-DCF:diskConfig": "MANUAL",
 			"os-extended-volumes:volumes_attached": [
 				{
+					"delete_on_termination": true,
 					"id": "cfb68a5e-203f-446d-9fd7-74b7e1f9722e"
 				}
 			],
@@ -220,6 +222,7 @@ const ServerListBody = `
 		"OS-DCF:diskConfig": "MANUAL",
 		"os-extended-volumes:volumes_attached": [
 			{
+				"delete_on_termination": true,
 				"id": "cfb68a5e-203f-446d-9fd7-74b7e1f9722e"
 			}
 		],
@@ -301,6 +304,7 @@ const SingleServerBody = `
 		"OS-DCF:diskConfig": "MANUAL",
 		"os-extended-volumes:volumes_attached": [
 			{
+				"delete_on_termination": true,
 				"id": "cfb68a5e-203f-446d-9fd7-74b7e1f9722e"
 			}
 		],
@@ -382,6 +386,7 @@ const FaultyServerBody = `
 		"OS-DCF:diskConfig": "MANUAL",
 		"os-extended-volumes:volumes_attached": [
 			{
+				"delete_on_termination": true,
 				"id": "cfb68a5e-203f-446d-9fd7-74b7e1f9722e"
 			}
 		],
@@ -468,9 +473,10 @@ var (
 				"name": "default",
 			},
 		},
-		VolumesAttached: []map[string]string{
+		VolumesAttached: []servers.VolumesDetails{
 			{
-				"id": "cfb68a5e-203f-446d-9fd7-74b7e1f9722e",
+				DeleteOnTermination: true,
+				ID:                  "cfb68a5e-203f-446d-9fd7-74b7e1f9722e",
 			},
 		},
 	}
@@ -531,9 +537,10 @@ var (
 				"name": "default",
 			},
 		},
-		VolumesAttached: []map[string]string{
+		VolumesAttached: []servers.VolumesDetails{
 			{
-				"id": "cfb68a5e-203f-446d-9fd7-74b7e1f9722e",
+				DeleteOnTermination: true,
+				ID:                  "cfb68a5e-203f-446d-9fd7-74b7e1f9722e",
 			},
 		},
 	}
@@ -588,9 +595,10 @@ var (
 				"name": "default",
 			},
 		},
-		VolumesAttached: []map[string]string{
+		VolumesAttached: []servers.VolumesDetails{
 			{
-				"id": "cfb68a5e-203f-446d-9fd7-74b7e1f9722e",
+				DeleteOnTermination: true,
+				ID:                  "cfb68a5e-203f-446d-9fd7-74b7e1f9722e",
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
Need to use microversion 2.55 to use latest features of api
### What this PR does / why we need it

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
```
=== RUN   TestServerLifecycle
    servers_test.go:37: Attempting to create ECSv2
    servers_test.go:82: Created ECSv2: 98c613a9-797f-498d-be5a-5365bf60a0a1
    tools.go:72: [
          {
            "port_state": "ACTIVE",
            "fixed_ips": [
              {
                "subnet_id": "0dc48707-d96e-4443-b736-280723af7064",
                "ip_address": "10.0.39.61"
              }
            ],
            "port_id": "87f8270c-5c22-43a8-9b51-9ca63e426e8e",
            "net_id": "44ed75f0-65df-4865-b4d9-4565fc56e2f1",
            "mac_addr": "fa:16:3e:c1:e8:fe"
          }
        ]
    servers_test.go:115: Attempting to update ECSv2: 98c613a9-797f-498d-be5a-5365bf60a0a1
    servers_test.go:124: ECSv2 successfully updated: 98c613a9-797f-498d-be5a-5365bf60a0a1
    servers_test.go:94: Attempting to delete ECSv2: 98c613a9-797f-498d-be5a-5365bf60a0a1
    servers_test.go:112: ECSv2 instance deleted: 98c613a9-797f-498d-be5a-5365bf60a0a1
--- PASS: TestServerLifecycle (45.64s)
PASS

Proccess finished with the exit code 0
```