### PR TITLE
DCS: cert download method

### DIFF
--- a/acceptance/openstack/dcs/v2/ssl_test.go
+++ b/acceptance/openstack/dcs/v2/ssl_test.go
@@ -40,6 +40,11 @@ func TestDcsInstanceSSLV2LifeCycle(t *testing.T) {
 
 	t.Logf("SSL settings retrieved")
 
+	t.Logf("Attempting to download SSL Cert")
+	_, err = ssl.DownloadCert(client, dcsInstance.InstanceID)
+	th.AssertNoErr(t, err)
+	t.Logf("DCS SSL Cert download successful")
+
 	t.Logf("Attempting to disable SSL for DCSv2 instance")
 
 	sslOpts.Enabled = pointerto.Bool(false)

--- a/openstack/dcs/v2/ssl/DownloadCert.go
+++ b/openstack/dcs/v2/ssl/DownloadCert.go
@@ -1,0 +1,26 @@
+package ssl
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func DownloadCert(client *golangsdk.ServiceClient, id string) (*DownloadCertResp, error) {
+	raw, err := client.Post(client.ServiceURL("instances", id, "ssl-certs", "download"), nil, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	var res DownloadCertResp
+
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type DownloadCertResp struct {
+	FileName   string `json:"file_name"`
+	Link       string `json:"link"`
+	BucketName string `json:"bucket_name"`
+}


### PR DESCRIPTION
### What this PR does / why we need it
Method to download DCS 6.0 cert.

### Acceptance tests
```
=== RUN   TestDcsInstanceSSLV2LifeCycle
    helpers.go:20: Attempting to create DCSv2 instance
    helpers.go:97: DCSv2 instance successfully created: f6b8b533-5a3c-493d-9a91-5a4c3f4bb8d1
    ssl_test.go:24: Attempting to enable SSL for DCSv2 instance
    ssl_test.go:32: SSL enabled
    ssl_test.go:34: Attempting to retrieve SSL settings for DCSv2 instance
    ssl_test.go:42: SSL settings retrieved
    ssl_test.go:44: Attempting to download SSL Cert
    ssl_test.go:49: Attempting to disable SSL for DCSv2 instance
    ssl_test.go:59: SSL disabled for DCSv2 instance
    helpers.go:110: Attempting to delete DCSv2 instance: f6b8b533-5a3c-493d-9a91-5a4c3f4bb8d1
    helpers.go:119: Deleted DCSv2 instance: f6b8b533-5a3c-493d-9a91-5a4c3f4bb8d1
--- PASS: TestDcsInstanceSSLV2LifeCycle (199.19s)
PASS

Debugger finished with the exit code 0
```