### PR TITLE
[WAF] fix AdvancedIgnoreObject type

### DIFF
--- a/acceptance/openstack/waf-premium/v1/rule_test.go
+++ b/acceptance/openstack/waf-premium/v1/rule_test.go
@@ -607,6 +607,10 @@ func TestWafPremiumAlarmMaskingRuleWorkflow(t *testing.T) {
 			Contents:       []string{"/login"},
 			LogicOperation: "equal",
 		}},
+		Advanced: rules.AdvancedIgnoreObject{
+			Index:    "header",
+			Contents: []string{"content-type"},
+		},
 		Mode:        1,
 		Rule:        "all",
 		Description: "desc",
@@ -637,6 +641,10 @@ func TestWafPremiumAlarmMaskingRuleWorkflow(t *testing.T) {
 			Contents:       []string{"192.168.1.1"},
 			LogicOperation: "equal",
 		}},
+		Advanced: rules.AdvancedIgnoreObject{
+			Index:    "header",
+			Contents: []string{"content-type"},
+		},
 		Mode:        1,
 		Rule:        "all",
 		Description: "updated",

--- a/openstack/waf-premium/v1/rules/CreateIgnore.go
+++ b/openstack/waf-premium/v1/rules/CreateIgnore.go
@@ -19,7 +19,7 @@ type CreateIgnoreOpts struct {
 	// To ignore attacks of a specific field, specify the field in the Advanced settings area.
 	// After you add the rule, WAF will stop blocking attacks of the specified field.
 	// This parameter is not included if all modules are bypassed.
-	Advanced []AdvancedIgnoreObject `json:"advanced"`
+	Advanced AdvancedIgnoreObject `json:"advanced"`
 	// Description of the rule
 	Description string `json:"description,omitempty"`
 }
@@ -97,7 +97,7 @@ type IgnoreRule struct {
 	// Condition list.
 	Conditions []IgnoreCondition `json:"conditions"`
 	// Advanced settings.
-	Advanced []AdvancedIgnoreObject `json:"advanced"`
+	Advanced AdvancedIgnoreObject `json:"advanced"`
 	// Domain names.
 	Domains []string `json:"domain"`
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer

```
=== RUN   TestWafPremiumAlarmMaskingRuleWorkflow
    rule_test.go:618: Attempting to Create WAF Premium alarm masking rule
    rule_test.go:629: Attempting to List WAF Premium alarm masking rule
    rule_test.go:636: Attempting to Update WAF Premium alarm masking rule: 4eef979a584a47479cd80d1c59486a56
    rule_test.go:654: Attempting to Get WAF Premium alarm masking rule: 576a5f9e8a0b45069e28a522bad1b0cb
    rule_test.go:624: Attempting to delete WAF Premium alarm masking rule: 576a5f9e8a0b45069e28a522bad1b0cb
    rule_test.go:626: Deleted WAF Premium information leakage protection rule: 576a5f9e8a0b45069e28a522bad1b0cb
    rule_test.go:599: Attempting to delete WAF Premium policy: 4eef979a584a47479cd80d1c59486a56
    rule_test.go:601: Deleted WAF Premium policy: 4eef979a584a47479cd80d1c59486a56
--- PASS: TestWafPremiumAlarmMaskingRuleWorkflow (19.48s)
PASS

Process finished with the exit code 0
```