### PR TITLE
[ER]: route tables

### DIFF
--- a/acceptance/openstack/er/route_tables_test.go
+++ b/acceptance/openstack/er/route_tables_test.go
@@ -44,12 +44,12 @@ func TestRouteTableLifeCycle(t *testing.T) {
 	err = waitForInstanceAvailable(client, 100, createResp.Instance.ID)
 	th.AssertNoErr(t, err)
 
-	defer func(client *golangsdk.ServiceClient, id string) {
+	t.Cleanup(func() {
 		t.Logf("Attempting to delete enterprise router")
-		err = instance.Delete(client, id)
+		err = instance.Delete(client, createResp.Instance.ID)
 		th.AssertNoErr(t, err)
 		err = waitForInstanceDeleted(client, 500, createResp.Instance.ID)
-	}(client, createResp.Instance.ID)
+	})
 
 	createRouteTableOpts := route_table.CreateOpts{
 		Name:        rtName,
@@ -76,12 +76,12 @@ func TestRouteTableLifeCycle(t *testing.T) {
 	err = waitForRouteTableAvailable(client, 300, createResp.Instance.ID, createRtResp.ID)
 	th.AssertNoErr(t, err)
 
-	defer func(client *golangsdk.ServiceClient, erId, rtId string) {
+	t.Cleanup(func() {
 		t.Logf("Attempting to delete route table")
-		err = route_table.Delete(client, erId, rtId)
+		err = route_table.Delete(client, createResp.Instance.ID, createRtResp.ID)
 		th.AssertNoErr(t, err)
-		err = waitForRouteTableDeleted(client, 500, erId, rtId)
-	}(client, createResp.Instance.ID, createRtResp.ID)
+		err = waitForRouteTableDeleted(client, 500, createResp.Instance.ID, createRtResp.ID)
+	})
 
 	t.Logf("Attempting to update route table")
 	updateRtResp, err := route_table.Update(client, route_table.UpdateOpts{

--- a/acceptance/openstack/er/route_tables_test.go
+++ b/acceptance/openstack/er/route_tables_test.go
@@ -1,0 +1,128 @@
+package er
+
+import (
+	"os"
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	tag "github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/instance"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/route_table"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+var (
+	rtName        = tools.RandomString("acctest_route-table-", 4)
+	descriptionRt = "test vpc attachment"
+)
+
+func TestRouteTableLifeCycle(t *testing.T) {
+	if os.Getenv("RUN_ER_LIFECYCLE") == "" {
+		t.Skip("too slow to run in zuul")
+	}
+	client, err := clients.NewERClient()
+	th.AssertNoErr(t, err)
+
+	createOpts := instance.CreateOpts{
+		Name:                        tools.RandomString("acctest_er_router-", 4),
+		Asn:                         64512,
+		AutoAcceptSharedAttachments: pointerto.Bool(true),
+		AvailabilityZoneIDs: []string{
+			"eu-de-01",
+			"eu-de-02",
+		},
+	}
+
+	t.Logf("Attempting to create enterprise router")
+
+	createResp, err := instance.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+
+	err = waitForInstanceAvailable(client, 100, createResp.Instance.ID)
+	th.AssertNoErr(t, err)
+
+	defer func(client *golangsdk.ServiceClient, id string) {
+		t.Logf("Attempting to delete enterprise router")
+		err = instance.Delete(client, id)
+		th.AssertNoErr(t, err)
+		err = waitForInstanceDeleted(client, 500, createResp.Instance.ID)
+	}(client, createResp.Instance.ID)
+
+	createRouteTableOpts := route_table.CreateOpts{
+		Name:        rtName,
+		RouterID:    createResp.Instance.ID,
+		Description: &descriptionRt,
+		Tags: []tag.ResourceTag{
+			{
+				Key:   "muh",
+				Value: "muh",
+			},
+			{
+				Key:   "test",
+				Value: "test",
+			},
+		},
+	}
+
+	t.Logf("Attempting to create route table")
+	createRtResp, err := route_table.Create(client, createRouteTableOpts)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, createRouteTableOpts.Name, createRtResp.Name)
+	th.AssertEquals(t, *createRouteTableOpts.Description, createRtResp.Description)
+
+	err = waitForRouteTableAvailable(client, 300, createResp.Instance.ID, createRtResp.ID)
+	th.AssertNoErr(t, err)
+
+	defer func(client *golangsdk.ServiceClient, erId, rtId string) {
+		t.Logf("Attempting to delete route table")
+		err = route_table.Delete(client, erId, rtId)
+		th.AssertNoErr(t, err)
+		err = waitForRouteTableDeleted(client, 500, erId, rtId)
+	}(client, createResp.Instance.ID, createRtResp.ID)
+
+	t.Logf("Attempting to update route table")
+	updateRtResp, err := route_table.Update(client, route_table.UpdateOpts{
+		RouterID:     createResp.Instance.ID,
+		RouteTableId: createRtResp.ID,
+		Name:         rtName + "-updated",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, updateRtResp.Name, rtName+"-updated")
+
+	t.Logf("Attempting to list route table")
+	listResp, err := route_table.List(client, route_table.ListOpts{
+		RouterId: createResp.Instance.ID,
+	})
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, listResp)
+}
+
+func waitForRouteTableAvailable(client *golangsdk.ServiceClient, secs int, erId, routeTableId string) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		rtInstance, err := route_table.Get(client, erId, routeTableId)
+		if err != nil {
+			return false, err
+		}
+		if rtInstance.State == "available" {
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+func waitForRouteTableDeleted(client *golangsdk.ServiceClient, secs int, erId, rtId string) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		_, err := route_table.Get(client, erId, rtId)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return true, nil
+			}
+			return false, err
+		}
+
+		return false, nil
+	})
+}

--- a/acceptance/openstack/er/router_test.go
+++ b/acceptance/openstack/er/router_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
@@ -48,12 +47,12 @@ func TestEnterpriseRouterLifeCycle(t *testing.T) {
 	th.AssertEquals(t, *createOpts.EnableDefaultAssociation, createResp.Instance.EnableDefaultAssociation)
 	th.AssertEquals(t, *createOpts.AutoAcceptSharedAttachments, createResp.Instance.AutoAcceptSharedAttachments)
 
-	defer func(client *golangsdk.ServiceClient, id string) {
+	t.Cleanup(func() {
 		t.Logf("Attempting to delete enterprise router")
-		err = instance.Delete(client, id)
+		err = instance.Delete(client, createResp.Instance.ID)
 		th.AssertNoErr(t, err)
 		err = waitForInstanceDeleted(client, 500, createResp.Instance.ID)
-	}(client, createResp.Instance.ID)
+	})
 
 	updateOpts := instance.UpdateOpts{
 		InstanceID:                  createResp.Instance.ID,

--- a/acceptance/openstack/er/vpc_attachments_test.go
+++ b/acceptance/openstack/er/vpc_attachments_test.go
@@ -87,6 +87,7 @@ func TestVPCAttachmentsLifeCycle(t *testing.T) {
 		err = vpc.Delete(client, erId, vpcId)
 		th.AssertNoErr(t, err)
 		err = waitForVpcAttachmentsDeleted(client, 500, erId, vpcId)
+		th.AssertNoErr(t, err)
 	}(client, createResp.Instance.ID, createVpcResp.ID)
 
 	updateOpts := vpc.UpdateOpts{
@@ -101,17 +102,16 @@ func TestVPCAttachmentsLifeCycle(t *testing.T) {
 	updateResp, err := vpc.Update(client, updateOpts)
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, updateOpts.Name, updateResp.Name)
-	th.AssertEquals(t, updateOpts.Description, updateResp.Description)
+	th.AssertEquals(t, *updateOpts.Description, updateResp.Description)
 
-	t.Logf("Attempting to update vpc attachemnt")
-}
+	t.Logf("Attempting to list vpc attachemnt")
 
-func TestVPCAttachmentsList(t *testing.T) {
-	client, err := clients.NewERClient()
+	listResp, err := vpc.List(client, vpc.ListOpts{
+		RouterId: createResp.Instance.ID,
+	})
 	th.AssertNoErr(t, err)
 
-	_, err = vpc.List(client, vpc.ListOpts{})
-	th.AssertNoErr(t, err)
+	th.AssertEquals(t, updateOpts.Name, listResp.VpcAttachments[0].Name)
 }
 
 func waitForVpcAttachmentsAvailable(client *golangsdk.ServiceClient, secs int, erId, vpcId string) error {

--- a/acceptance/openstack/er/vpc_attachments_test.go
+++ b/acceptance/openstack/er/vpc_attachments_test.go
@@ -46,12 +46,12 @@ func TestVPCAttachmentsLifeCycle(t *testing.T) {
 	err = waitForInstanceAvailable(client, 100, createResp.Instance.ID)
 	th.AssertNoErr(t, err)
 
-	defer func(client *golangsdk.ServiceClient, id string) {
+	t.Cleanup(func() {
 		t.Logf("Attempting to delete enterprise router")
-		err = instance.Delete(client, id)
+		err = instance.Delete(client, createResp.Instance.ID)
 		th.AssertNoErr(t, err)
 		err = waitForInstanceDeleted(client, 500, createResp.Instance.ID)
-	}(client, createResp.Instance.ID)
+	})
 
 	createVpcOpts := vpc.CreateOpts{
 		Name:                vpcName,
@@ -82,13 +82,13 @@ func TestVPCAttachmentsLifeCycle(t *testing.T) {
 	err = waitForVpcAttachmentsAvailable(client, 100, createResp.Instance.ID, createVpcResp.ID)
 	th.AssertNoErr(t, err)
 
-	defer func(client *golangsdk.ServiceClient, erId, vpcId string) {
+	t.Cleanup(func() {
 		t.Logf("Attempting to delete vpc attachemnt")
-		err = vpc.Delete(client, erId, vpcId)
+		err = vpc.Delete(client, createResp.Instance.ID, createVpcResp.ID)
 		th.AssertNoErr(t, err)
-		err = waitForVpcAttachmentsDeleted(client, 500, erId, vpcId)
+		err = waitForVpcAttachmentsDeleted(client, 500, createResp.Instance.ID, createVpcResp.ID)
 		th.AssertNoErr(t, err)
-	}(client, createResp.Instance.ID, createVpcResp.ID)
+	})
 
 	updateOpts := vpc.UpdateOpts{
 		RouterID:        createResp.Instance.ID,

--- a/openstack/er/v3/route_table/Create.go
+++ b/openstack/er/v3/route_table/Create.go
@@ -1,0 +1,51 @@
+package route_table
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
+)
+
+type CreateOpts struct {
+	RouterID    string  `json:"-" required:"true"`
+	Name        string  `json:"name" required:"true"`
+	Description *string `json:"description,omitempty"`
+	// parameter not supported ☻
+	// BgpOptions  *BgpOptions        `json:"bgp_options,omitempty"`
+	Tags []tags.ResourceTag `json:"tags,omitempty"`
+}
+
+type BgpOptions struct {
+	LoadBalancingAsPathIgnore *bool `json:"load_balancing_as_path_ignore,omitempty"`
+	LoadBalancingAsPathRelax  *bool `json:"load_balancing_as_path_relax,omitempty"`
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*RouteTable, error) {
+	b, err := build.RequestBody(opts, "route_table")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Post(client.ServiceURL("enterprise-router", opts.RouterID, "route-tables"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res RouteTable
+	return &res, extract.IntoStructPtr(raw.Body, &res, "route_table")
+}
+
+type RouteTable struct {
+	ID                   string             `json:"id"`
+	Name                 string             `json:"name"`
+	Description          string             `json:"description"`
+	IsDefaultAssociation bool               `json:"is_default_association"`
+	State                string             `json:"state"`
+	Tags                 []tags.ResourceTag `json:"tags"`
+	BgpOptions           *BgpOptions        `json:"bgp_options"`
+	CreatedAt            string             `json:"created_at"`
+	UpdatedAt            string             `json:"updated_at"`
+}

--- a/openstack/er/v3/route_table/Delete.go
+++ b/openstack/er/v3/route_table/Delete.go
@@ -1,0 +1,10 @@
+package route_table
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+func Delete(client *golangsdk.ServiceClient, erId, routeTableId string) (err error) {
+	_, err = client.Delete(client.ServiceURL("enterprise-router", erId, "route-tables", routeTableId), &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}

--- a/openstack/er/v3/route_table/Get.go
+++ b/openstack/er/v3/route_table/Get.go
@@ -1,0 +1,17 @@
+package route_table
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Get(client *golangsdk.ServiceClient, erID, routeTableId string) (*RouteTable, error) {
+	raw, err := client.Get(client.ServiceURL("enterprise-router", erID, "route-tables", routeTableId), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res RouteTable
+	err = extract.IntoStructPtr(raw.Body, &res, "route_table")
+	return &res, err
+}

--- a/openstack/er/v3/route_table/List.go
+++ b/openstack/er/v3/route_table/List.go
@@ -1,0 +1,42 @@
+package route_table
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListOpts struct {
+	RouterId string   `json:"-"`
+	Marker   string   `q:"marker"`
+	Limit    int      `q:"limit"`
+	State    []string `q:"state"`
+	SortKey  []string `q:"sort_key"`
+	SortDir  []string `q:"sort_dir"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListRouteTables, error) {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints("enterprise-router", opts.RouterId, "route-tables").WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListRouteTables
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListRouteTables struct {
+	RouteTables []RouteTable `json:"route_tables"`
+	PageInfo    *PageInfo    `json:"page_info"`
+	RequestId   string       `json:"request_id"`
+}
+
+type PageInfo struct {
+	NextMarker   string `json:"next_marker"`
+	CurrentCount int    `json:"current_count"`
+}

--- a/openstack/er/v3/route_table/Update.go
+++ b/openstack/er/v3/route_table/Update.go
@@ -1,0 +1,33 @@
+package route_table
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type UpdateOpts struct {
+	RouterID     string  `json:"-"`
+	RouteTableId string  `json:"-"`
+	Name         string  `json:"name,omitempty"`
+	Description  *string `json:"description,omitempty"`
+	// parameter not supported ☻
+	// BgpOptions   *BgpOptions `json:"bgp_options,omitempty"`
+}
+
+func Update(client *golangsdk.ServiceClient, opts UpdateOpts) (*RouteTable, error) {
+	b, err := build.RequestBody(opts, "route_table")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Put(client.ServiceURL("enterprise-router", opts.RouterID, "route-tables", opts.RouteTableId), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res RouteTable
+	return &res, extract.IntoStructPtr(raw.Body, &res, "route_table")
+}

--- a/openstack/er/v3/vpc/List.go
+++ b/openstack/er/v3/vpc/List.go
@@ -6,6 +6,7 @@ import (
 )
 
 type ListOpts struct {
+	RouterId string `json:"-"`
 	// ID of the last enterprise router on the previous page. If this parameter is left blank, the first page is queried.
 	// This parameter must be used together with limit.
 	Marker string `q:"marker"`
@@ -24,7 +25,7 @@ type ListOpts struct {
 }
 
 func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListVpcAttachmentDetails, error) {
-	url, err := golangsdk.NewURLBuilder().WithEndpoints("enterprise-router", "instances").WithQueryParams(&opts).Build()
+	url, err := golangsdk.NewURLBuilder().WithEndpoints("enterprise-router", opts.RouterId, "vpc-attachments").WithQueryParams(&opts).Build()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What this PR does / why we need it

### Acceptance tests
```
=== RUN   TestRouteTableLifeCycle
    route_tables_test.go:39: Attempting to create enterprise router
    route_tables_test.go:70: Attempting to create route table
    route_tables_test.go:86: Attempting to update route table
    route_tables_test.go:95: Attempting to list route table
    tools.go:72: {
          "route_tables": [
            {
              "id": "42b73a31-cd42-4737-89e4-6fa701edc360",
              "name": "acctest_route-table-OraR-updated",
              "description": "test vpc attachment",
              "is_default_association": false,
              "state": "available",
              "tags": [
                {
                  "key": "muh",
                  "value": "muh"
                },
                {
                  "key": "test",
                  "value": "test"
                }
              ],
              "bgp_options": {
                "load_balancing_as_path_ignore": false,
                "load_balancing_as_path_relax": false
              },
              "created_at": "2024-07-10T11:54:27.221Z",
              "updated_at": "2024-07-10T11:54:31.58Z"
            }
          ],
          "page_info": {
            "next_marker": "",
            "current_count": 1
          },
          "request_id": "9f68a54e2f7ff64de9cb2a4bae6c2951"
        }
    route_tables_test.go:80: Attempting to delete route table
    route_tables_test.go:48: Attempting to delete enterprise router
--- PASS: TestRouteTableLifeCycle (75.12s)
PASS

Process finished with the exit code 0
```