### PR TITLE
ER: routes

### DIFF
--- a/acceptance/openstack/er/routes_test.go
+++ b/acceptance/openstack/er/routes_test.go
@@ -1,0 +1,174 @@
+package er
+
+import (
+	"os"
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	tag "github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/instance"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/route"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/route_table"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/vpc"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestRoutesLifeCycle(t *testing.T) {
+	if os.Getenv("RUN_ER_LIFECYCLE") == "" {
+		t.Skip("too slow to run in zuul")
+	}
+	client, err := clients.NewERClient()
+	th.AssertNoErr(t, err)
+
+	routerName := tools.RandomString("acctest_er_router-", 4)
+
+	createOpts := instance.CreateOpts{
+		Name:                        routerName,
+		Description:                 "terraform created enterprise router",
+		Asn:                         64512,
+		EnableDefaultAssociation:    pointerto.Bool(true),
+		EnableDefaultPropagation:    pointerto.Bool(true),
+		AutoAcceptSharedAttachments: pointerto.Bool(true),
+		AvailabilityZoneIDs: []string{
+			"eu-de-01",
+			"eu-de-02",
+		},
+	}
+
+	t.Logf("Attempting to create enterprise router")
+
+	createResp, err := instance.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+
+	err = waitForInstanceAvailable(client, 100, createResp.Instance.ID)
+	th.AssertNoErr(t, err)
+
+	t.Cleanup(func() {
+		t.Logf("Attempting to delete enterprise router")
+		err = instance.Delete(client, createResp.Instance.ID)
+		th.AssertNoErr(t, err)
+		err = waitForInstanceDeleted(client, 500, createResp.Instance.ID)
+	})
+
+	createRouteTableOpts := route_table.CreateOpts{
+		Name:        rtName,
+		RouterID:    createResp.Instance.ID,
+		Description: &descriptionRt,
+	}
+
+	t.Logf("Attempting to create route table")
+	createRtResp, err := route_table.Create(client, createRouteTableOpts)
+	th.AssertNoErr(t, err)
+
+	err = waitForRouteTableAvailable(client, 300, createResp.Instance.ID, createRtResp.ID)
+	th.AssertNoErr(t, err)
+
+	rtId := createRtResp.ID
+
+	t.Cleanup(func() {
+		t.Logf("Attempting to delete route table")
+		err = route_table.Delete(client, createResp.Instance.ID, createRtResp.ID)
+		th.AssertNoErr(t, err)
+		err = waitForRouteTableDeleted(client, 500, createResp.Instance.ID, createRtResp.ID)
+	})
+
+	t.Logf("Attempting to create route")
+
+	routeResp, err := route.Create(client, route.CreateOpts{
+		RouteTableId: rtId,
+		Destination:  "192.168.0.0/16",
+		IsBlackhole:  pointerto.Bool(true),
+	})
+
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, routeResp.Destination, "192.168.0.0/16")
+	th.AssertEquals(t, routeResp.IsBlackhole, true)
+	th.AssertEquals(t, routeResp.State, "pending")
+
+	err = waitForRouteAvailable(client, 100, rtId, routeResp.ID)
+	th.AssertNoErr(t, err)
+
+	t.Cleanup(func() {
+		t.Logf("Attempting to delete route")
+		err = route.Delete(client, rtId, routeResp.ID)
+		th.AssertNoErr(t, err)
+	})
+
+	createVpcOpts := vpc.CreateOpts{
+		Name:                vpcName,
+		RouterID:            createResp.Instance.ID,
+		VpcId:               vpcId,
+		SubnetId:            networkId,
+		Description:         description,
+		AutoCreateVpcRoutes: true,
+		Tags: []tag.ResourceTag{
+			{
+				Key:   "muh",
+				Value: "muh",
+			},
+			{
+				Key:   "test",
+				Value: "test",
+			},
+		},
+	}
+
+	t.Logf("Attempting to create vpc attachemnt")
+	createVpcResp, err := vpc.Create(client, createVpcOpts)
+	th.AssertNoErr(t, err)
+
+	err = waitForVpcAttachmentsAvailable(client, 100, createResp.Instance.ID, createVpcResp.ID)
+	th.AssertNoErr(t, err)
+
+	t.Cleanup(func() {
+		t.Logf("Attempting to delete vpc attachemnt")
+		err = vpc.Delete(client, createResp.Instance.ID, createVpcResp.ID)
+		th.AssertNoErr(t, err)
+		err = waitForVpcAttachmentsDeleted(client, 500, createResp.Instance.ID, createVpcResp.ID)
+		th.AssertNoErr(t, err)
+	})
+
+	updateRoute, err := route.Update(client, route.UpdateOpts{
+		RouteTableId: rtId,
+		RouteId:      routeResp.ID,
+		IsBlackhole:  pointerto.Bool(false),
+		AttachmentId: createVpcResp.ID,
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, updateRoute.Destination, "192.168.0.0/16")
+	th.AssertEquals(t, updateRoute.IsBlackhole, false)
+	th.AssertEquals(t, updateRoute.State, "modifying")
+	th.AssertEquals(t, updateRoute.Attachments[0].ResourceType, "vpc")
+
+	listResp, err := route.List(client, route.ListOpts{
+		RouteTableId: rtId,
+		Destination: []string{
+			"192.168.0.0/16",
+		},
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, len(listResp.Routes), 1)
+	th.AssertEquals(t, listResp.Routes[0].Destination, "192.168.0.0/16")
+
+	listStaticResp, err := route.ListStatic(client, route.ListStaticOpts{
+		RouteTableId: rtId,
+	})
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, listStaticResp)
+}
+
+func waitForRouteAvailable(client *golangsdk.ServiceClient, secs int, rtId, routeId string) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		rtInstance, err := route.Get(client, rtId, routeId)
+		if err != nil {
+			return false, err
+		}
+		if rtInstance.State == "available" {
+			return true, nil
+		}
+		return false, nil
+	})
+}

--- a/openstack/er/v3/route/Create.go
+++ b/openstack/er/v3/route/Create.go
@@ -1,0 +1,49 @@
+package route
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateOpts struct {
+	RouteTableId string `json:"-" required:"true"`
+	Destination  string `json:"destination" required:"true"`
+	AttachmentId string `json:"attachment_id,omitempty"`
+	IsBlackhole  *bool  `json:"is_blackhole,omitempty"`
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*Route, error) {
+	b, err := build.RequestBody(opts, "route")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Post(client.ServiceURL("enterprise-router", "route-tables", opts.RouteTableId, "static-routes"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res Route
+	return &res, extract.IntoStructPtr(raw.Body, &res, "route")
+}
+
+type Route struct {
+	ID           string            `json:"id"`
+	Type         string            `json:"type"`
+	State        string            `json:"state"`
+	IsBlackhole  bool              `json:"is_blackhole"`
+	Destination  string            `json:"destination"`
+	RouteTableId string            `json:"route_table_id"`
+	CreatedAt    string            `json:"created_at"`
+	UpdatedAt    string            `json:"updated_at"`
+	Attachments  []RouteAttachment `json:"attachments"`
+}
+
+type RouteAttachment struct {
+	ResourceId   string `json:"resource_id"`
+	ResourceType string `json:"resource_type"`
+	AttachmentId string `json:"attachment_id"`
+}

--- a/openstack/er/v3/route/Delete.go
+++ b/openstack/er/v3/route/Delete.go
@@ -1,0 +1,10 @@
+package route
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+func Delete(client *golangsdk.ServiceClient, routeTableId, routeId string) (err error) {
+	_, err = client.Delete(client.ServiceURL("enterprise-router", "route-tables", routeTableId, "static-routes", routeId), &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}

--- a/openstack/er/v3/route/Get.go
+++ b/openstack/er/v3/route/Get.go
@@ -1,0 +1,17 @@
+package route
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Get(client *golangsdk.ServiceClient, routeTableId, routeId string) (*Route, error) {
+	raw, err := client.Get(client.ServiceURL("enterprise-router", "route-tables", routeTableId, "static-routes", routeId), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res Route
+	err = extract.IntoStructPtr(raw.Body, &res, "route")
+	return &res, err
+}

--- a/openstack/er/v3/route/List.go
+++ b/openstack/er/v3/route/List.go
@@ -1,0 +1,45 @@
+package route
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListOpts struct {
+	RouteTableId string   `json:"-"`
+	Marker       string   `q:"marker"`
+	Limit        int      `q:"limit"`
+	Destination  []string `q:"destination"`
+	ResourceType []string `q:"resource_type"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListRoutes, error) {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints("enterprise-router", "route-tables", opts.RouteTableId, "routes").WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListRoutes
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListRoutes struct {
+	Routes    []EffectiveRoute `json:"routes"`
+	PageInfo  *PageInfo        `json:"page_info"`
+	RequestId string           `json:"request_id"`
+}
+
+type EffectiveRoute struct {
+	RouteId        string            `json:"route_id"`
+	Destination    string            `json:"destination"`
+	NextHops       []RouteAttachment `json:"next_hops"`
+	IsBlackhole    bool              `json:"is_blackhole"`
+	RouteType      string            `json:"route_type"`
+	AddressGroupId string            `json:"address_group_id"`
+}

--- a/openstack/er/v3/route/ListStatic.go
+++ b/openstack/er/v3/route/ListStatic.go
@@ -1,0 +1,44 @@
+package route
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListStaticOpts struct {
+	RouteTableId string   `json:"-"`
+	Marker       string   `q:"marker"`
+	Limit        int      `q:"limit"`
+	Destination  []string `q:"destination"`
+	AttachmentId []string `q:"attachment_id"`
+	ResourceType []string `q:"resource_type"`
+	SortKey      []string `q:"sort_key"`
+	SortDir      []string `q:"sort_dir"`
+}
+
+func ListStatic(client *golangsdk.ServiceClient, opts ListStaticOpts) (*ListStaticRoutes, error) {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints("enterprise-router", "route-tables", opts.RouteTableId, "static-routes").WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListStaticRoutes
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListStaticRoutes struct {
+	Routes    []Route   `json:"routes"`
+	PageInfo  *PageInfo `json:"page_info"`
+	RequestId string    `json:"request_id"`
+}
+
+type PageInfo struct {
+	NextMarker   string `json:"next_marker"`
+	CurrentCount int    `json:"current_count"`
+}

--- a/openstack/er/v3/route/Update.go
+++ b/openstack/er/v3/route/Update.go
@@ -1,0 +1,31 @@
+package route
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type UpdateOpts struct {
+	RouteTableId string `json:"-"`
+	RouteId      string `json:"-"`
+	AttachmentId string `json:"attachment_id,omitempty"`
+	IsBlackhole  *bool  `json:"is_blackhole,omitempty"`
+}
+
+func Update(client *golangsdk.ServiceClient, opts UpdateOpts) (*Route, error) {
+	b, err := build.RequestBody(opts, "route")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Put(client.ServiceURL("enterprise-router", "route-tables", opts.RouteTableId, "static-routes", opts.RouteId), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res Route
+	return &res, extract.IntoStructPtr(raw.Body, &res, "route")
+}


### PR DESCRIPTION
### What this PR does / why we need it

### Acceptance tests
```
=== RUN   TestRoutesLifeCycle
    routes_test.go:41: Attempting to create enterprise router
    routes_test.go:62: Attempting to create route table
    routes_test.go:78: Attempting to create route
    routes_test.go:119: Attempting to create vpc attachemnt
    tools.go:72: {
          "routes": [
            {
              "id": "9149ef1b-c996-4d3e-a4e1-7afba2c90098",
              "type": "static",
              "state": "available",
              "is_blackhole": false,
              "destination": "192.168.0.0/16",
              "route_table_id": "c05c09c3-943a-4a17-92cc-41c7e046ac7c",
              "created_at": "2024-07-31T11:05:35.048Z",
              "updated_at": "2024-07-31T11:06:04.089Z",
              "attachments": [
                {
                  "resource_id": "cf9e960a-59c4-430e-8cd4-ea246bfd50a4",
                  "resource_type": "vpc",
                  "attachment_id": "cea75542-821e-4a36-be14-24edf6ff0c9e"
                }
              ]
            }
          ],
          "page_info": {
            "next_marker": "",
            "current_count": 1
          },
          "request_id": "bdc12a6815c7ba7745ade88c7268493c"
        }
    routes_test.go:127: Attempting to delete vpc attachemnt
    routes_test.go:95: Attempting to delete route
    routes_test.go:72: Attempting to delete route table
    routes_test.go:50: Attempting to delete enterprise router
--- PASS: TestRoutesLifeCycle (124.98s)
PASS

Process finished with the exit code 0
```
