### PR TITLE
ER: add route_table parameter

### DIFF
--- a/acceptance/openstack/er/route_tables_test.go
+++ b/acceptance/openstack/er/route_tables_test.go
@@ -72,6 +72,8 @@ func TestRouteTableLifeCycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, createRouteTableOpts.Name, createRtResp.Name)
 	th.AssertEquals(t, *createRouteTableOpts.Description, createRtResp.Description)
+	th.AssertEquals(t, createRtResp.IsDefaultAssociation, false)
+	th.AssertEquals(t, createRtResp.IsDefaultPropagation, false)
 
 	err = waitForRouteTableAvailable(client, 300, createResp.Instance.ID, createRtResp.ID)
 	th.AssertNoErr(t, err)

--- a/openstack/er/v3/route_table/Create.go
+++ b/openstack/er/v3/route_table/Create.go
@@ -43,6 +43,7 @@ type RouteTable struct {
 	Name                 string             `json:"name"`
 	Description          string             `json:"description"`
 	IsDefaultAssociation bool               `json:"is_default_association"`
+	IsDefaultPropagation bool               `json:"is_default_propagation"`
 	State                string             `json:"state"`
 	Tags                 []tags.ResourceTag `json:"tags"`
 	BgpOptions           *BgpOptions        `json:"bgp_options"`


### PR DESCRIPTION
### What this PR does / why we need it

### Acceptance test
```
=== RUN   TestRouteTableLifeCycle
    route_tables_test.go:39: Attempting to create enterprise router
    route_tables_test.go:70: Attempting to create route table
    route_tables_test.go:88: Attempting to update route table
    route_tables_test.go:97: Attempting to list route table
    tools.go:72: {
          "route_tables": [
            {
              "id": "ca398576-e604-458c-9649-7339e02df747",
              "name": "acctest_route-table-IAcP-updated",
              "description": "test vpc attachment",
              "is_default_association": false,
              "is_default_propagation": false,
              "state": "available",
              "tags": [
                {
                  "key": "muh",
                  "value": "muh"
                },
                {
                  "key": "test",
                  "value": "test"
                }
              ],
              "bgp_options": {
                "load_balancing_as_path_ignore": false,
                "load_balancing_as_path_relax": false
              },
              "created_at": "2024-08-01T12:42:28.648Z",
              "updated_at": "2024-08-01T12:42:32.734Z"
            }
          ],
          "page_info": {
            "next_marker": "",
            "current_count": 1
          },
          "request_id": "0d30e0f74fe19a0a6b0300d14fbfe306"
        }
    route_tables_test.go:82: Attempting to delete route table
    route_tables_test.go:48: Attempting to delete enterprise router
--- PASS: TestRouteTableLifeCycle (62.44s)
PASS

Process finished with the exit code 0
```