### PR TITLE
feat: DDS Backup, Restore, Configuration support

### DIFF
--- a/acceptance/openstack/dds/v3/backups_test.go
+++ b/acceptance/openstack/dds/v3/backups_test.go
@@ -1,0 +1,117 @@
+package v3
+
+import (
+	"os"
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dds/v3/backups"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dds/v3/instances"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestDdsBackupLifeCycle(t *testing.T) {
+	instanceId := os.Getenv("DDS_INSTANCE_ID")
+	if instanceId == "" {
+		t.Skip("`DDS_INSTANCE_ID` need to be defined")
+	}
+	client, err := clients.NewDdsV3Client()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to create DDSv3 backup for instance: %s", instanceId)
+	backupOpts := backups.CreateOpts{
+		Backup: &backups.Backup{
+			InstanceId:  instanceId,
+			Name:        tools.RandomString("dmd-dds-backup-", 5),
+			Description: "this is backup for dds",
+		},
+	}
+	backup, err := backups.Create(client, backupOpts)
+	th.AssertNoErr(t, err)
+	err = waitForBackupAvailable(client, 600, backup.BackupId)
+	th.AssertNoErr(t, err)
+	t.Logf("DDSv3 backup successfully created")
+	th.AssertNoErr(t, err)
+
+	t.Cleanup(func() {
+		t.Logf("Attempting to delete DDSv3 backup: %s", backup.BackupId)
+		delJob, err := backups.Delete(client, backup.BackupId)
+		err = waitForJobCompleted(client, 600, delJob.JobId)
+		th.AssertNoErr(t, err)
+		t.Logf("Deleted DDSv3 backup: %s", backup.BackupId)
+	})
+
+	t.Logf("Attempting to list DDSv3 backups for instance: %s", instanceId)
+	backupList, err := backups.List(client, backups.ListBackupsOpts{
+		InstanceId: instanceId,
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, backupList.TotalCount, 2)
+
+	t.Logf("Attempting to get download links for DDSv3 backup: %s", backup.BackupId)
+	links, err := backups.ListBackupDownloadLinks(client, backups.BackupLinkOpts{
+		InstanceId: instanceId,
+		BackupId:   backup.BackupId,
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, len(links.Files), 1)
+
+	t.Logf("Attempting to set backup policy for DDSv3 instance: %s", instanceId)
+	err = backups.SetBackupPolicy(client, backups.ModifyBackupPolicyOpts{
+		InstanceId: instanceId,
+		BackupPolicy: &instances.BackupStrategy{
+			StartTime: "01:00-02:00",
+			KeepDays:  pointerto.Int(365),
+			Period:    "1,2,3,5,6,7",
+		},
+	})
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to get backup policy for DDSv3 instance: %s", instanceId)
+	getPolicy, err := backups.GetBackupPolicy(client, instanceId)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "01:00-02:00", getPolicy.StartTime)
+	th.AssertEquals(t, 365, *getPolicy.KeepDays)
+	th.AssertEquals(t, "1,2,3,5,6,7", getPolicy.Period)
+
+	t.Logf("Attempting to modify backup policy for DDSv3 instance: %s", instanceId)
+	err = backups.SetBackupPolicy(client, backups.ModifyBackupPolicyOpts{
+		InstanceId: instanceId,
+		BackupPolicy: &instances.BackupStrategy{
+			StartTime: "03:00-04:00",
+			KeepDays:  pointerto.Int(7),
+			Period:    "1,2,3",
+		},
+	})
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to get again backup policy for DDSv3 instance: %s", instanceId)
+	getPolicyModified, err := backups.GetBackupPolicy(client, instanceId)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "03:00-04:00", getPolicyModified.StartTime)
+	th.AssertEquals(t, 7, *getPolicyModified.KeepDays)
+	th.AssertEquals(t, "1,2,3", getPolicyModified.Period)
+}
+
+func waitForBackupAvailable(client *golangsdk.ServiceClient, secs int, backupId string) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		listOpts := backups.ListBackupsOpts{
+			BackupId: backupId,
+		}
+		backupList, err := backups.List(client, listOpts)
+		if err != nil {
+			return false, err
+		}
+		if backupList.TotalCount == 1 {
+			b := backupList.Backups
+			if len(b) == 1 && b[0].Status == "COMPLETED" {
+				return true, nil
+			}
+			return false, nil
+		}
+		return false, nil
+	})
+}

--- a/acceptance/openstack/dds/v3/backups_test.go
+++ b/acceptance/openstack/dds/v3/backups_test.go
@@ -38,9 +38,9 @@ func TestDdsBackupLifeCycle(t *testing.T) {
 
 	t.Cleanup(func() {
 		t.Logf("Attempting to delete DDSv3 backup: %s", backup.BackupId)
-		delJob, err := backups.Delete(client, backup.BackupId)
+		delJob, errDel := backups.Delete(client, backup.BackupId)
 		err = waitForJobCompleted(client, 600, delJob.JobId)
-		th.AssertNoErr(t, err)
+		th.AssertNoErr(t, errDel)
 		t.Logf("Deleted DDSv3 backup: %s", backup.BackupId)
 	})
 

--- a/acceptance/openstack/dds/v3/configuration_test.go
+++ b/acceptance/openstack/dds/v3/configuration_test.go
@@ -1,0 +1,41 @@
+package v3
+
+import (
+	"os"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dds/v3/configurations"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestDdsConfigurationLifeCycle(t *testing.T) {
+	instanceId := os.Getenv("DDS_INSTANCE_ID")
+
+	if instanceId == "" {
+		t.Skip("`DDS_INSTANCE_ID` need to be defined")
+	}
+
+	client, err := clients.NewDdsV3Client()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to get DDSv3 instance config")
+	config, err := configurations.GetInstanceConfig(client, instanceId, configurations.ConfigOpts{EntityId: instanceId})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "mongodb", config.DatastoreName)
+
+	t.Logf("Attempting to list DDSv3 template configurations")
+	configList, err := configurations.List(client, configurations.ListConfigOpts{})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 29, configList.TotalCount)
+
+	t.Logf("Attempting to get DDSv3 template configuration")
+	getConfig, err := configurations.Get(client, configList.Configurations[0].ID)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "Default-DDS-3.2-Shard", getConfig.Name)
+
+	t.Logf("Attempting to apply DDSv3 template configuration")
+	_, err = configurations.Apply(client, configList.Configurations[11].ID,
+		configurations.ApplyOpts{EntityIDs: []string{instanceId}})
+	th.AssertNoErr(t, err)
+}

--- a/acceptance/openstack/dds/v3/restore_test.go
+++ b/acceptance/openstack/dds/v3/restore_test.go
@@ -1,0 +1,59 @@
+package v3
+
+import (
+	"os"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dds/v3/backups"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dds/v3/instances"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestDdsRestoreLifeCycle(t *testing.T) {
+	instanceId := os.Getenv("DDS_INSTANCE_ID")
+
+	if instanceId == "" {
+		t.Skip("`DDS_INSTANCE_ID` need to be defined")
+	}
+
+	client, err := clients.NewDdsV3Client()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to create DDSv3 backup for instance: %s", instanceId)
+	backupOpts := backups.CreateOpts{
+		Backup: &backups.Backup{
+			InstanceId:  instanceId,
+			Name:        tools.RandomString("dmd-dds-backup-", 5),
+			Description: "this is backup for dds",
+		},
+	}
+	backup, err := backups.Create(client, backupOpts)
+	th.AssertNoErr(t, err)
+	err = waitForBackupAvailable(client, 600, backup.BackupId)
+	th.AssertNoErr(t, err)
+	t.Logf("DDSv3 backup successfully created")
+	th.AssertNoErr(t, err)
+
+	t.Cleanup(func() {
+		t.Logf("Attempting to delete DDSv3 backup: %s", backup.BackupId)
+		delJob, err := backups.Delete(client, backup.BackupId)
+		err = waitForJobCompleted(client, 600, delJob.JobId)
+		th.AssertNoErr(t, err)
+		t.Logf("Deleted DDSv3 backup: %s", backup.BackupId)
+	})
+
+	t.Logf("Attempting to restore DDSv3 instance to Original: %s", instanceId)
+	restoreJob, err := instances.RestoreToOriginal(client, instances.RestoreToOriginalOpts{
+		Source: instances.Source{
+			InstanceId: instanceId,
+			Type:       "backup",
+			BackupId:   backup.BackupId,
+		},
+		Target: instances.Target{InstanceId: instanceId},
+	})
+	th.AssertNoErr(t, err)
+	err = waitForJobCompleted(client, 600, *restoreJob)
+	th.AssertNoErr(t, err)
+}

--- a/acceptance/openstack/dds/v3/restore_test.go
+++ b/acceptance/openstack/dds/v3/restore_test.go
@@ -38,9 +38,9 @@ func TestDdsRestoreLifeCycle(t *testing.T) {
 
 	t.Cleanup(func() {
 		t.Logf("Attempting to delete DDSv3 backup: %s", backup.BackupId)
-		delJob, err := backups.Delete(client, backup.BackupId)
+		delJob, errDel := backups.Delete(client, backup.BackupId)
 		err = waitForJobCompleted(client, 600, delJob.JobId)
-		th.AssertNoErr(t, err)
+		th.AssertNoErr(t, errDel)
 		t.Logf("Deleted DDSv3 backup: %s", backup.BackupId)
 	})
 

--- a/acceptance/openstack/hss/v5/server_group_test.go
+++ b/acceptance/openstack/hss/v5/server_group_test.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"os"
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
@@ -33,9 +32,9 @@ func TestServerList(t *testing.T) {
 }
 
 func TestServerLifecycle(t *testing.T) {
-	if os.Getenv("RUN_HSS_LIFECYCLE") == "" {
-		t.Skip("too slow to run in zuul")
-	}
+	// if os.Getenv("RUN_HSS_LIFECYCLE") == "" {
+	// 	t.Skip("too slow to run in zuul")
+	// }
 	client, err := clients.NewHssClient()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/tools/tools.go
+++ b/acceptance/tools/tools.go
@@ -4,7 +4,9 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+	"fmt"
 	mrand "math/rand"
+	"strings"
 	"testing"
 	"time"
 )
@@ -70,4 +72,28 @@ func Elide(value string) string {
 func PrintResource(t *testing.T, resource interface{}) {
 	b, _ := json.MarshalIndent(resource, "", "  ")
 	t.Logf(string(b))
+}
+
+// ExtractNetworkAddress removes the mask from the CIDR block
+func ExtractNetworkAddress(cidr string) string {
+	parts := strings.Split(cidr, "/")
+	if len(parts) != 2 {
+		return ""
+	}
+	return parts[0]
+}
+
+// SetLastOctet changes the last octet of the IP address to the specified value
+func SetLastOctet(ip string, newLastOctet int) string {
+	// Split IP into its components
+	parts := strings.Split(ip, ".")
+	if len(parts) != 4 {
+		return ip
+	}
+
+	// Replace the last octet with the new value
+	parts[3] = fmt.Sprintf("%d", newLastOctet)
+
+	// Reassemble the IP address
+	return strings.Join(parts, ".")
 }

--- a/openstack/dds/v3/backups/Create.go
+++ b/openstack/dds/v3/backups/Create.go
@@ -1,0 +1,41 @@
+package backups
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type CreateOpts struct {
+	Backup *Backup `json:"backup" required:"true"`
+}
+
+type Backup struct {
+	// Specifies the instance ID, which can be obtained by calling the API for querying instances.
+	// If you do not have an instance, you can call the API used for creating an instance.
+	InstanceId string `json:"instance_id" required:"true"`
+	// Specifies the manual backup name.
+	// The value must be 4 to 64 characters in length and start with a letter (from A to Z or from a to z).
+	// It is case-sensitive and can contain only letters, digits (from 0 to 9), hyphens (-), and underscores (_).
+	Name string `json:"name" required:"true"`
+	// Specifies the manual backup description.
+	// The description must consist of a maximum of 256 characters and cannot
+	// contain the following special characters: >!<"&'=
+	Description string `json:"description,omitempty"`
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*Job, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST https://{Endpoint}/v3/{project_id}/backups
+	raw, err := client.Post(client.ServiceURL("backups"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return extractJob(err, raw)
+}

--- a/openstack/dds/v3/backups/Delete.go
+++ b/openstack/dds/v3/backups/Delete.go
@@ -1,0 +1,11 @@
+package backups
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+func Delete(client *golangsdk.ServiceClient, backupId string) (*Job, error) {
+	// DELETE https://{Endpoint}/v3/{project_id}/backups/{backup_id}
+	raw, err := client.Delete(client.ServiceURL("backups", backupId), &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return extractJob(err, raw)
+}

--- a/openstack/dds/v3/backups/GetBackupPolicy.go
+++ b/openstack/dds/v3/backups/GetBackupPolicy.go
@@ -1,0 +1,19 @@
+package backups
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dds/v3/instances"
+)
+
+func GetBackupPolicy(client *golangsdk.ServiceClient, instanceId string) (*instances.BackupStrategy, error) {
+	// GET https://{Endpoint}/v3/{project_id}/instances/{instance_id}/backups/policy
+	raw, err := client.Get(client.ServiceURL("instances", instanceId, "backups", "policy"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res instances.BackupStrategy
+	err = extract.IntoStructPtr(raw.Body, &res, "backup_policy")
+	return &res, err
+}

--- a/openstack/dds/v3/backups/List.go
+++ b/openstack/dds/v3/backups/List.go
@@ -1,0 +1,87 @@
+package backups
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dds/v3/instances"
+)
+
+type ListBackupsOpts struct {
+	// Index offset.
+	// If offset is set to N, the resource query starts from the N+1 piece of data. The default value is 0, indicating that the query starts from the first piece of data.
+	// The value must be a positive integer.
+	Offset int `q:"offset"`
+	// Maximum number of specifications that can be queried
+	// Value range: 1-100
+	// If this parameter is not transferred, the first 100 pieces of specification information can be queried by default.
+	Limit int `q:"limit"`
+	// Instance id.
+	InstanceId string `q:"instance_id"`
+	// Specifies the backup ID.
+	BackupId string `q:"backup_id"`
+	// Specifies the backup type.
+	// Auto: indicates automated full backup.
+	// Manual indicates manual full backup.
+	BackupType string `q:"backup_type"`
+	// Specifies the start time of the query. The format is yyyy-mm-dd hh:mm:ss. The value is in UTC format.
+	BeginTime string `q:"begin_time"`
+	// Specifies the end time of the query. The format is "yyyy-mm-dd hh:mm:ss". The value is in UTC format.
+	EndTime string `q:"end_time"`
+	// Specifies the DB instance mode.
+	// Valid value:
+	// Sharding
+	// ReplicaSet
+	// Single
+	Mode string `q:"mode"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListBackupsOpts) (*ListResponse, error) {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints("backups").WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	// GET https://{Endpoint}/v3/{project_id}/backups
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListResponse struct {
+	Backups    []BackupsResponse `json:"backups"`
+	TotalCount int               `json:"total_count"`
+}
+
+type BackupsResponse struct {
+	// Indicates the backup ID.
+	ID string `json:"id"`
+	// Indicates the backup name.
+	Name string `json:"name"`
+	// Indicates the ID of the DB instance from which the backup was created.
+	InstanceId string `json:"instance_id"`
+	// Indicates the name of the DB instance for which the backup is created.
+	InstanceName string `json:"instance_name"`
+	// Indicates the database version.
+	Datastore instances.DataStore `json:"datastore"`
+	// Indicates the backup type.
+	Type string `json:"type"`
+	// Indicates the backup start time. The format of the start time is yyyy-mm-dd hh:mm:ss. The value is in UTC format.
+	BeginTime string `json:"begin_time"`
+	// Indicates the backup end time. The format of the end time is yyyy-mm-dd hh:mm:ss. The value is in UTC format.
+	EndTime string `json:"end_time"`
+	// Indicates the backup status. Valid value:
+	// BUILDING: Backup in progress
+	// COMPLETED: Backup completed
+	// FAILED: Backup failed
+	// DISABLED: Backup being deleted
+	Status string `json:"status"`
+	// Indicates the backup size in KB.
+	Size int64 `json:"size"`
+	// Indicates the backup description.
+	Description string `json:"description"`
+}

--- a/openstack/dds/v3/backups/ListBackupLinks.go
+++ b/openstack/dds/v3/backups/ListBackupLinks.go
@@ -1,0 +1,47 @@
+package backups
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type BackupLinkOpts struct {
+	// Instance id.
+	InstanceId string `q:"instance_id" required:"true"`
+	// Specifies the backup ID.
+	BackupId string `q:"backup_id" required:"true"`
+}
+
+func ListBackupDownloadLinks(client *golangsdk.ServiceClient, opts BackupLinkOpts) (*LinkResponse, error) {
+	// GET https://{Endpoint}/v3/{project_id}/instances/{instance_id}/backups/download-file
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("backups", "download-file").
+		WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res LinkResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type LinkResponse struct {
+	Files  []Files `json:"files"`
+	Bucket string  `json:"bucket"`
+}
+
+type Files struct {
+	// Indicates the file name.
+	Name string `json:"name"`
+	// Indicates the file size in KB.
+	Size int64 `json:"size"`
+	// Indicates the link for downloading the backup file.
+	DownloadLink string `json:"download_link"`
+	// Indicates the link expiration time.
+	LinkExpiredTime string `json:"link_expired_time"`
+}

--- a/openstack/dds/v3/backups/ModifyBackupPolicy.go
+++ b/openstack/dds/v3/backups/ModifyBackupPolicy.go
@@ -1,0 +1,25 @@
+package backups
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dds/v3/instances"
+)
+
+type ModifyBackupPolicyOpts struct {
+	InstanceId   string                    `json:"-"`
+	BackupPolicy *instances.BackupStrategy `json:"backup_policy" required:"true"`
+}
+
+func SetBackupPolicy(client *golangsdk.ServiceClient, opts ModifyBackupPolicyOpts) (err error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	// PUT https://{Endpoint}/v3/{project_id}/instances/{instance_id}/backups/policy
+	_, err = client.Put(client.ServiceURL("instances", opts.InstanceId, "backups", "policy"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/dds/v3/backups/job.go
+++ b/openstack/dds/v3/backups/job.go
@@ -1,0 +1,22 @@
+package backups
+
+import (
+	"net/http"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type Job struct {
+	JobId    string `json:"job_id"`
+	BackupId string `json:"backup_id"`
+}
+
+func extractJob(err error, raw *http.Response) (*Job, error) {
+	if err != nil {
+		return nil, err
+	}
+
+	var res Job
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/dds/v3/configurations/Apply.go
+++ b/openstack/dds/v3/configurations/Apply.go
@@ -1,0 +1,33 @@
+package configurations
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dds/v3/instances"
+)
+
+type ApplyOpts struct {
+	// Instance IDs, group IDs, or node IDs. You can call the API used for querying instances and details to obtain the value.
+	// If you do not have an instance, you can call the API used for creating an instance.
+	// If the DB instance type is cluster and the shard or config parameter template is to be changed, the value is the group ID.
+	// If the parameter template of the mongos node is changed, the value is the node ID.
+	// If the DB instance to be changed is a replica set instance or a single node instance, the value is the instance ID.
+	EntityIDs []string `json:"entity_ids" required:"true"`
+}
+
+func Apply(client *golangsdk.ServiceClient, configId string, opts ApplyOpts) (*string, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// PUT https://{Endpoint}/v3/{project_id}/configurations/{config_id}/apply
+	raw, err := client.Put(client.ServiceURL("configurations", configId, "apply"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return instances.ExtractJob(err, raw)
+}

--- a/openstack/dds/v3/configurations/Get.go
+++ b/openstack/dds/v3/configurations/Get.go
@@ -1,0 +1,64 @@
+package configurations
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Get(client *golangsdk.ServiceClient, configId string) (*Response, error) {
+	// GET https://{Endpoint}/v3/{project_id}/configurations/{config_id}
+	raw, err := client.Get(client.ServiceURL("configurations", configId), nil, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res Response
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type Response struct {
+	// Parameter template ID.
+	ID string `json:"id"`
+	// Parameter template name.
+	Name string `json:"name"`
+	// Parameter template description.
+	Description string `json:"description"`
+	// Node type of the parameter template.
+	NodeType string `json:"node_type"`
+	// Database version.
+	DatastoreVersion string `json:"datastore_version"`
+	// Database type.
+	DatastoreName string `json:"datastore_name"`
+	// Creation time in the "yyyy-MM-ddTHH:mm:ssZ" format.
+	CreatedAt string `json:"created"`
+	// Update time in the "yyyy-MM-ddTHH:mm:ssZ" format.
+	UpdatedAt string `json:"updated"`
+	// The parameters defined by users based on the default parameter templates.
+	Parameters []Parameters `json:"parameters"`
+}
+
+type Parameters struct {
+	// The parameter name.
+	Name string `json:"name"`
+	// The parameter value.
+	Value string `json:"value"`
+	// The parameter description.
+	Description string `json:"description"`
+	// Parameter type.
+	// The value can be integer, string, boolean, float, or list.
+	Type string `json:"type"`
+	// Value range.
+	// For example, the value of integer is 0 or 1, and the value of boolean is true or false.
+	ValueRange string `json:"value_range"`
+	// Whether the instance needs to be restarted.
+	// If the value is true, restart is required.
+	// If the value is false, restart is not required.
+	RestartRequired bool `json:"restart_required"`
+	// Whether the parameter is read-only.
+	// If the value is true, the parameter is read-only.
+	// If the value false, the parameter is not read-only.
+	ReadOnly bool `json:"readonly"`
+}

--- a/openstack/dds/v3/configurations/GetInstanceConfig.go
+++ b/openstack/dds/v3/configurations/GetInstanceConfig.go
@@ -1,0 +1,36 @@
+package configurations
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ConfigOpts struct {
+	// Instance ID, group ID, or node ID. You can call the API used for querying instances and details to obtain the value.
+	// If you do not have an instance, you can call the API used for creating an instance.
+	// If the DB instance type is cluster and the shard or config parameter template is obtained, the value is the group ID.
+	// If the parameter template of the mongos node is obtained, the value is the node ID.
+	// If the DB instance type is a replica set instance or a single node instance, the value is the instance ID.
+	EntityId string `q:"entity_id"`
+}
+
+func GetInstanceConfig(client *golangsdk.ServiceClient, instanceId string, opts ConfigOpts) (*Response, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("instances", instanceId, "configurations").
+		WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	// GET https://{Endpoint}/v3/{project_id}/instances/{instance_id}/configurations
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res Response
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/dds/v3/configurations/List.go
+++ b/openstack/dds/v3/configurations/List.go
@@ -1,0 +1,63 @@
+package configurations
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListConfigOpts struct {
+	// Index offset.
+	// If offset is set to N, the resource query starts from the N+1 piece of data. The default value is 0, indicating that the query starts from the first piece of data.
+	// The value must be a positive integer.
+	Offset int `q:"offset"`
+	// Maximum number of specifications that can be queried
+	// Value range: 1-100
+	// If this parameter is not transferred, the first 100 pieces of specification information can be queried by default.
+	Limit int `q:"limit"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListConfigOpts) (*ListResponse, error) {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints("configurations").WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	// GET https://{Endpoint}/v3/{project_id}/configurations
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListResponse struct {
+	Configurations []ConfigurationsResponse `json:"configurations"`
+	Quota          int                      `json:"quota"`
+	TotalCount     int                      `json:"total_count"`
+}
+
+type ConfigurationsResponse struct {
+	// Parameter template ID.
+	ID string `json:"id"`
+	// Parameter template name.
+	Name string `json:"name"`
+	// Parameter template description.
+	Description string `json:"description"`
+	// Database version.
+	DatastoreVersion string `json:"datastore_version"`
+	// Database type.
+	DatastoreName string `json:"datastore_name"`
+	// Node type of the parameter template.
+	NodeType string `json:"node_type"`
+	// Creation time in the "yyyy-MM-ddTHH:mm:ssZ" format.
+	CreatedAt string `json:"created"`
+	// Update time in the "yyyy-MM-ddTHH:mm:ssZ" format.
+	UpdatedAt string `json:"updated"`
+	// Indicates whether the parameter template is created by users.
+	// false: The parameter template is a default parameter template.
+	// true: The parameter template is a custom template.
+	UserDefined bool `json:"user_defined"`
+}

--- a/openstack/dds/v3/instances/AddNode.go
+++ b/openstack/dds/v3/instances/AddNode.go
@@ -26,5 +26,5 @@ func AddNode(client *golangsdk.ServiceClient, opts AddNodeOpts) (*string, error)
 	raw, err := client.Post(client.ServiceURL("instances", opts.InstanceId, "enlarge"), b, nil, &golangsdk.RequestOpts{
 		OkCodes: []int{200, 202},
 	})
-	return extractJob(err, raw)
+	return ExtractJob(err, raw)
 }

--- a/openstack/dds/v3/instances/BindEIP.go
+++ b/openstack/dds/v3/instances/BindEIP.go
@@ -20,5 +20,5 @@ func BindEIP(client *golangsdk.ServiceClient, opts BindEIPOpts) (*string, error)
 	raw, err := client.Post(client.ServiceURL("nodes", opts.NodeId, "bind-eip"), b, nil, &golangsdk.RequestOpts{
 		OkCodes: []int{200, 202},
 	})
-	return extractJob(err, raw)
+	return ExtractJob(err, raw)
 }

--- a/openstack/dds/v3/instances/Create.go
+++ b/openstack/dds/v3/instances/Create.go
@@ -11,7 +11,6 @@ import (
 
 type CreateOpts struct {
 	// Specifies the DB instance name. Instance name, which can be the same as an existing name.
-	//
 	// The instance name must contain 4 to 64 characters and must start with a letter. It is case sensitive and can contain letters, digits, hyphens (-), and underscores (_). It cannot contain other special characters.
 	Name string `json:"name" required:"true"`
 	// Specifies the database information.
@@ -39,9 +38,7 @@ type CreateOpts struct {
 	// If this parameter is not transferred, disk encryption is not performed.
 	DiskEncryptionId string `json:"disk_encryption_id,omitempty"`
 	// Specifies the instance type. Cluster, replica set, and single node instances are supported.
-	//
 	// Valid value:
-	//
 	// Sharding
 	// ReplicaSet
 	// Single
@@ -51,9 +48,7 @@ type CreateOpts struct {
 	// Specifies the advanced backup policy.
 	BackupStrategy BackupStrategy `json:"backup_strategy" required:"true"`
 	// Specifies whether to enable or disable SSL.
-	//
 	// Valid value:
-	//
 	// The value 0 indicates that SSL is disabled by default.
 	// The value 1 indicates that SSL is enabled by default.
 	// If this parameter is not transferred, SSL is enabled by default.
@@ -69,7 +64,6 @@ type DataStore struct {
 	// Specifies the database version. Versions 4.2, 4.0, and 3.4 are supported. The value can be 4.2, 4.0, or 3.4.
 	Version string `json:"version" required:"true"`
 	// Specifies the storage engine. DDS supports the WiredTiger and RocksDB storage engines.
-	//
 	// If the database version is 4.2 and the storage engine is RocksDB, the value is rocksDB.
 	// If the database version is 4.0 or 3.4 and the storage engine is WiredTiger, the value is wiredTiger.
 	StorageEngine string `json:"storage_engine" required:"true"`
@@ -77,17 +71,13 @@ type DataStore struct {
 
 type Flavor struct {
 	// Specifies the node type.
-	//
 	// Valid value:
-	//
 	// For a cluster instance, the value can be mongos, shard, or config.
 	// For a replica set instance, the value is replica.
 	// For a single node instance, the value is single.
 	Type string `json:"type" required:"true"`
 	// Specifies node quantity.
-	//
 	// Valid value:
-	//
 	// mongos: The value ranges from 2 to 32.
 	// mongos: The value ranges from 2 to 32.
 	// config: The value is 1.
@@ -95,47 +85,44 @@ type Flavor struct {
 	// single: The value is 1.
 	Num int `json:"num" required:"true"`
 	// Specifies the disk type.
-	//
 	// Valid value: ULTRAHIGH, which indicates the type SSD.
-	//
 	// This parameter is valid for the shard and config nodes of a cluster instance, replica set instances, and single node instances. This parameter is invalid for mongos nodes. Therefore, you do not need to specify the storage space for mongos nodes.
 	Storage string `json:"storage,omitempty"`
 	// Specifies the disk size.
-	//
 	// This parameter is mandatory for all nodes except mongos. This parameter is invalid for the mongos nodes.
-	//
 	// The value must be a multiple of 10. The unit is GB.
-	//
 	// For a cluster instance, the storage space of a shard node can be 10 to 2000 GB, and the config storage space is 20 GB. This parameter is invalid for mongos nodes. Therefore, you do not need to specify the storage space for mongos nodes.
 	// For a replica set instance, the value ranges from 10 to 2000.
 	// For a single node instance, the value ranges from 10 to 1000.
 	Size int `json:"size,omitempty"`
 	// Specifies the resource specification code. For details about how to obtain the value, see the response values of spec_code in Querying Database Specifications.
-	//
 	// In a cluster instance, multiple specifications need to be specified. All specifications must be of the same series, that is, general-purpose (s6), enhanced (c3), or enhanced II (c6).
 	SpecCode string `json:"spec_code" required:"true"`
 }
 
 type BackupStrategy struct {
 	// Specifies the backup time window. Automated backups will be triggered during the backup time window.
-	//
 	// The value cannot be empty. It must be a valid value in the "hh:mm-HH:MM" format. The current time is in the UTC format.
-	//
 	// The HH value must be 1 greater than the hh value.
 	// The values of mm and MM must be the same and must be set to 00.
 	// If this parameter is not transferred, the default backup time window is set to 00:00-01:00.
 	// Example value:
-	//
 	//23:00-00:00
 	StartTime string `json:"start_time" required:"true"`
-	//
 	// Specifies the number of days to retain the generated backup files.
-	//
 	// The value range is from 0 to 732.
-	//
 	// If this parameter is set to 0, the automated backup policy is not set.
 	// If this parameter is not transferred, the automated backup policy is enabled by default. Backup files are stored for seven days by default.
-	KeepDays int `json:"keep_days,omitempty"`
+	KeepDays *int `json:"keep_days,omitempty"`
+	// Specifies the backup cycle configuration. Data will be automatically backed up on the selected days every week.
+	// Value range: The value is a number separated by DBS case commas (,). The number indicates the week.
+	// The restrictions on the backup retention period are as follows:
+	// This parameter is not transferred if its value is set to 0.
+	// If you set the retention period to 1 to 6 days, data is automatically backed up each day of the week.
+	// Set the parameter value to 1,2,3,4,5,6,7.
+	// If you set the retention period to 7 to 732 days, select at least one day of the week for the backup cycle.
+	// Example value: 1,2,3,4
+	Period string `json:"period,omitempty"`
 }
 
 func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*Instance, error) {
@@ -204,63 +191,37 @@ type Instance struct {
 
 type FlavorOpt struct {
 	// Specifies the node type.
-	//
 	// Valid value:
-	//
 	// For a cluster instance, the value can be mongos, shard, or config.
 	// For a replica set instance, the value is replica.
 	// For a single node instance, the value is single.
 	Type string `json:"type" required:"true"`
 	// Specifies node quantity.
-	//
 	// Valid value:
-	//
 	// mongos: The value ranges from 2 to 32.
 	// mongos: The value ranges from 2 to 32.
 	// config: The value is 1.
 	// replica: The number of nodes can be 3, 5, or 7.
 	// single: The value is 1.
 	Num string `json:"num" required:"true"`
-	//
 	// Specifies the disk type.
-	//
 	// Valid value: ULTRAHIGH, which indicates the type SSD.
-	//
 	// This parameter is valid for the shard and config nodes of a cluster instance, replica set instances, and single node instances. This parameter is invalid for mongos nodes. Therefore, you do not need to specify the storage space for mongos nodes.
 	Storage string `json:"storage,omitempty"`
 	// Specifies the disk size.
-	//
 	// This parameter is mandatory for all nodes except mongos. This parameter is invalid for the mongos nodes.
-	//
 	// The value must be a multiple of 10. The unit is GB.
-	//
 	// For a cluster instance, the storage space of a shard node can be 10 to 2000 GB, and the config storage space is 20 GB. This parameter is invalid for mongos nodes. Therefore, you do not need to specify the storage space for mongos nodes.
 	// For a replica set instance, the value ranges from 10 to 2000.
 	// For a single node instance, the value ranges from 10 to 1000.
 	Size string `json:"size,omitempty"`
 	// Specifies the resource specification code. For details about how to obtain the value, see the response values of spec_code in Querying Database Specifications.
-	//
 	// In a cluster instance, multiple specifications need to be specified. All specifications must be of the same series, that is, general-purpose (s6), enhanced (c3), or enhanced II (c6).
 	SpecCode string `json:"spec_code" required:"true"`
 }
 
 type BackupStrategyOpt struct {
-	// Specifies the backup time window. Automated backups will be triggered during the backup time window.
-	//
-	// The value cannot be empty. It must be a valid value in the "hh:mm-HH:MM" format. The current time is in the UTC format.
-	//
-	// The HH value must be 1 greater than the hh value.
-	// The values of mm and MM must be the same and must be set to 00.
-	// If this parameter is not transferred, the default backup time window is set to 00:00-01:00.
-	// Example value:
-	//
-	//23:00-00:00
 	StartTime string `json:"start_time" required:"true"`
-	// Specifies the number of days to retain the generated backup files.
-	//
-	// The value range is from 0 to 732.
-	//
-	// If this parameter is set to 0, the automated backup policy is not set.
-	// If this parameter is not transferred, the automated backup policy is enabled by default. Backup files are stored for seven days by default.
-	KeepDays string `json:"keep_days,omitempty"`
+	KeepDays  string `json:"keep_days,omitempty"`
+	Period    string `json:"period,omitempty"`
 }

--- a/openstack/dds/v3/instances/CrossCIDRAccess.go
+++ b/openstack/dds/v3/instances/CrossCIDRAccess.go
@@ -1,0 +1,24 @@
+package instances
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type NetworkRangesOpts struct {
+	// CIDR block where the client is located
+	NetworkRanges []string `json:"client_network_ranges" required:"true"`
+}
+
+func CreateClientNetwork(client *golangsdk.ServiceClient, instanceId string, opts NetworkRangesOpts) (err error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	// POST https://{Endpoint}/v3/{project_id}/instances/{instance_id}/client-network
+	_, err = client.Post(client.ServiceURL("instances", instanceId, "client-network"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/dds/v3/instances/Delete.go
+++ b/openstack/dds/v3/instances/Delete.go
@@ -5,5 +5,5 @@ import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 func Delete(client *golangsdk.ServiceClient, instanceId string) (*string, error) {
 	// DELETE https://{Endpoint}/v3/{project_id}/instances/{instance_id}
 	raw, err := client.Delete(client.ServiceURL("instances", instanceId), nil)
-	return extractJob(err, raw)
+	return ExtractJob(err, raw)
 }

--- a/openstack/dds/v3/instances/GetRecyclePolicy.go
+++ b/openstack/dds/v3/instances/GetRecyclePolicy.go
@@ -1,0 +1,18 @@
+package instances
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func GetRecyclePolicy(client *golangsdk.ServiceClient) (*RecyclePolicy, error) {
+	// GET https://{Endpoint}/v3/{project_id}/instances/recycle-policy
+	raw, err := client.Get(client.ServiceURL("instances", "recycle-policy"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res RecyclePolicy
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/dds/v3/instances/GetRecycledInstances.go
+++ b/openstack/dds/v3/instances/GetRecycledInstances.go
@@ -1,0 +1,64 @@
+package instances
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListRecycledOpts struct {
+	// Index offset. If offset is set to N, the resource query starts from the N+1 piece of data.
+	// The default value is 0, indicating that the query starts from the first piece of data. The value must be a positive integer.
+	Offset int `q:"offset"`
+	// Number of records displayed on each page. The default value is 100.
+	Limit int `q:"limit"`
+}
+
+func ListRecycledInstances(client *golangsdk.ServiceClient, opts ListRecycledOpts) (*ListRecycledResponse, error) {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints("recycle-instances").WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	// GET https://{Endpoint}/v3/{project_id}/recycle-instances
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListRecycledResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListRecycledResponse struct {
+	Instances  []RecycledInstanceResponse `json:"instances"`
+	TotalCount int                        `json:"total_count"`
+}
+
+type RecycledInstanceResponse struct {
+	// Indicates the DB instance ID.
+	Id string `json:"id"`
+	// Indicates the DB instance name.
+	Name string `json:"name"`
+	// Instance type. Cluster, replica set, and single node instances are supported. The value can be:
+	// Sharding
+	// ReplicaSet
+	// Single
+	Mode string `json:"mode"`
+	// Database information.
+	Datastore DataStore `json:"datastore"`
+	// Billing mode.
+	// 0: indicates the instance is billed on a pay-per-use basis.
+	// 1: indicates the instance is billed based on a yearly/monthly basis.
+	PayMode string `json:"pay_mode"`
+	// Backup ID.
+	BackupId string `json:"backup_id"`
+	// Creation time.
+	CreatedAt string `json:"created_at"`
+	// Deletion time.
+	DeletedAt string `json:"deleted_at"`
+	// Retention end time.
+	RetainedUntil string `json:"retained_until"`
+	// Instance backup recycling status.
+	Status string `json:"status"`
+}

--- a/openstack/dds/v3/instances/ManageSSL.go
+++ b/openstack/dds/v3/instances/ManageSSL.go
@@ -19,5 +19,5 @@ func SwitchSSL(client *golangsdk.ServiceClient, opts SSLOpt) (*string, error) {
 	raw, err := client.Post(client.ServiceURL("instances", opts.InstanceId, "switch-ssl"), b, nil, &golangsdk.RequestOpts{
 		OkCodes: []int{200, 202},
 	})
-	return extractJob(err, raw)
+	return ExtractJob(err, raw)
 }

--- a/openstack/dds/v3/instances/ModifyInternalIp.go
+++ b/openstack/dds/v3/instances/ModifyInternalIp.go
@@ -20,5 +20,5 @@ func ModifyInternalIp(client *golangsdk.ServiceClient, opts ModifyInternalIpOpts
 	raw, err := client.Post(client.ServiceURL("instances", opts.InstanceId, "modify-internal-ip"), b, nil, &golangsdk.RequestOpts{
 		OkCodes: []int{200, 202},
 	})
-	return extractJob(err, raw)
+	return ExtractJob(err, raw)
 }

--- a/openstack/dds/v3/instances/ModifyPort.go
+++ b/openstack/dds/v3/instances/ModifyPort.go
@@ -19,5 +19,5 @@ func ModifyPort(client *golangsdk.ServiceClient, opts ModifyPortOpt) (*string, e
 	raw, err := client.Post(client.ServiceURL("instances", opts.InstanceId, "modify-port"), b, nil, &golangsdk.RequestOpts{
 		OkCodes: []int{200, 202},
 	})
-	return extractJob(err, raw)
+	return ExtractJob(err, raw)
 }

--- a/openstack/dds/v3/instances/ModifySG.go
+++ b/openstack/dds/v3/instances/ModifySG.go
@@ -19,5 +19,5 @@ func ModifySG(client *golangsdk.ServiceClient, opts ModifySGOpt) (*string, error
 	raw, err := client.Post(client.ServiceURL("instances", opts.InstanceId, "modify-security-group"), b, nil, &golangsdk.RequestOpts{
 		OkCodes: []int{200, 202},
 	})
-	return extractJob(err, raw)
+	return ExtractJob(err, raw)
 }

--- a/openstack/dds/v3/instances/ModifySpec.go
+++ b/openstack/dds/v3/instances/ModifySpec.go
@@ -21,5 +21,5 @@ func ModifySpec(client *golangsdk.ServiceClient, opts ModifySpecOpt) (*string, e
 	raw, err := client.Post(client.ServiceURL("instances", opts.InstanceId, "resize"), b, nil, &golangsdk.RequestOpts{
 		OkCodes: []int{200, 202},
 	})
-	return extractJob(err, raw)
+	return ExtractJob(err, raw)
 }

--- a/openstack/dds/v3/instances/Restart.go
+++ b/openstack/dds/v3/instances/Restart.go
@@ -31,5 +31,5 @@ func Restart(client *golangsdk.ServiceClient, opts RestartOpts) (*string, error)
 
 	// POST https://{Endpoint}/v3/{project_id}/instances/{instance_id}/restart
 	raw, err := client.Post(client.ServiceURL("instances", opts.InstanceId, "restart"), b, nil, nil)
-	return extractJob(err, raw)
+	return ExtractJob(err, raw)
 }

--- a/openstack/dds/v3/instances/RestoreToNew.go
+++ b/openstack/dds/v3/instances/RestoreToNew.go
@@ -1,0 +1,78 @@
+package instances
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type RestoreOpts struct {
+	// Specifies the DB instance name. Instance name, which can be the same as an existing name.
+	//
+	// The instance name must contain 4 to 64 characters and must start with a letter. It is case sensitive and can contain letters, digits, hyphens (-), and underscores (_). It cannot contain other special characters.
+	Name string `json:"name" required:"true"`
+	// Specifies the AZ ID. You can select multiple AZs to create a cross-AZ cluster based on az_status returned by the API described in Querying Database Specifications.
+	AvailabilityZone string `json:"availability_zone" required:"true"`
+	// Specifies the VPC ID.
+	VpcId string `json:"vpc_id" required:"true"`
+	// Specifies the network ID of the subnet.
+	SubnetId string `json:"subnet_id" required:"true"`
+	// Specifies the security group ID.
+	SecurityGroupId string `json:"security_group_id" required:"true"`
+	// Specifies the database password.
+	// The value must be 8 to 32 characters in length and contain uppercase letters (A to Z), lowercase letters (a to z), digits (0 to 9), and special characters, such as ~!@#%^*-_=+?
+	// Enter a strong password to improve security, preventing security risks such as brute force cracking.
+	Password string `json:"password,omitempty"`
+	// Specifies the key ID used for disk encryption. The string must comply with UUID regular expression rules.
+	// If this parameter is not transferred, disk encryption is not performed.
+	DiskEncryptionId string `json:"disk_encryption_id,omitempty"`
+	// Specifies the instance specifications.
+	Flavor []Flavor `json:"flavor" required:"true"`
+	// Specifies the advanced backup policy.
+	BackupStrategy BackupStrategy `json:"backup_strategy,omitempty"`
+	// Specifies whether to enable or disable SSL.
+	// Valid value:
+	// The value 0 indicates that SSL is disabled by default.
+	// The value 1 indicates that SSL is enabled by default.
+	// If this parameter is not transferred, SSL is enabled by default.
+	Ssl string `json:"ssl_option,omitempty"`
+	// Specifies the advanced backup policy.
+	RestorePoint RestorePoint `json:"restore_point" required:"true"`
+}
+
+type RestorePoint struct {
+	// Specifies the instance ID, which can be obtained by calling the API for querying instances.
+	// If you do not have an instance, you can call the API used for creating an instance.
+	// This parameter is optional when type is set to backup.
+	// This parameter is mandatory when type is set to timestamp.
+	InstanceId string `json:"instance_id,omitempty"`
+	// Specifies the recovery mode. The enumerated values are as follows:
+	// backup: indicates restoration from backup files. In this mode, backup_id is mandatory when type is optional.
+	// timestamp: indicates point-in-time restoration. In this mode, restore_time is mandatory when type is mandatory.
+	Type string `json:"type,omitempty"`
+	// Specifies the ID of the backup to be restored.
+	// This parameter must be specified when the backup file is used for restoration.
+	BackupId string `json:"backup_id,omitempty"`
+	// Specifies the time point of data restoration in the UNIX timestamp.
+	// The unit is millisecond and the time zone is UTC.
+	RestoreTime int `json:"restore_time,omitempty"`
+}
+
+func RestoreToNew(client *golangsdk.ServiceClient, opts RestoreOpts) (*Instance, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST https://{Endpoint}/v3/{project_id}/instances
+	raw, err := client.Post(client.ServiceURL("instances"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res Instance
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/dds/v3/instances/RestoreToOriginal.go
+++ b/openstack/dds/v3/instances/RestoreToOriginal.go
@@ -1,0 +1,50 @@
+package instances
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type RestoreToOriginalOpts struct {
+	// Specifies the instance from which the backup was created
+	Source Source `json:"source" required:"true"`
+	// Specifies the instance to which the backup is restored.
+	Target Target `json:"target" required:"true"`
+}
+
+type Source struct {
+	// Specifies the instance ID, which can be obtained by calling the API for querying instances.
+	InstanceId string `json:"instance_id,omitempty"`
+	// Specifies the recovery mode. The enumerated values are as follows:
+	// backup: indicates restoration from backup files. In this mode, backup_id is mandatory when type is optional.
+	// timestamp: indicates point-in-time restoration. In this mode, restore_time is mandatory when type is mandatory.
+	Type string `json:"type,omitempty"`
+	// Specifies the ID of the backup to be restored.
+	// This parameter must be specified when the backup file is used for restoration.
+	BackupId string `json:"backup_id,omitempty"`
+	// Specifies the time point of data restoration in the UNIX timestamp.
+	// The unit is millisecond and the time zone is UTC.
+	RestoreTime *int `json:"restore_time,omitempty"`
+}
+
+type Target struct {
+	// Specifies ID of the DB instance to be restored from a backup.
+	InstanceId string `json:"instance_id,omitempty"`
+}
+
+func RestoreToOriginal(client *golangsdk.ServiceClient, opts RestoreToOriginalOpts) (*string, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST https://{Endpoint}/v3/{project_id}/instances/recovery
+	raw, err := client.Post(client.ServiceURL("instances", "recovery"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ExtractJob(err, raw)
+}

--- a/openstack/dds/v3/instances/RestoreToPIT.go
+++ b/openstack/dds/v3/instances/RestoreToPIT.go
@@ -1,0 +1,47 @@
+package instances
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type RestoreToPITOpts struct {
+	// Specifies the database information.
+	RestoreCollections []RestoreCollections `json:"restore_collections" required:"true"`
+}
+
+type RestoreCollections struct {
+	// Specifies the database name.
+	Database string `json:"database" required:"true"`
+	// Specifies the collection information.
+	Collections []Collections `json:"collections,omitempty"`
+	// Specifies the database restoration time point.
+	RestoreDatabaseTime string `json:"restore_database_time,omitempty"`
+}
+
+type Collections struct {
+	// Specifies the original table name before the restoration.
+	OldName string `json:"old_name" required:"true"`
+	// Specifies the table name after the restoration.
+	NewName string `json:"new_name,omitempty"`
+	// Specifies the collection restoration time point.
+	// The value is a UNIX timestamp, in milliseconds. The time zone is UTC.
+	RestoreCollectionTime string `json:"restore_collection_time,omitempty"`
+}
+
+func RestoreToPIT(client *golangsdk.ServiceClient, opts RestoreToPITOpts) (*string, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST https://{Endpoint}/v3/{project_id}/instances
+	raw, err := client.Post(client.ServiceURL("instances"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ExtractJob(err, raw)
+}

--- a/openstack/dds/v3/instances/ScaleStorage.go
+++ b/openstack/dds/v3/instances/ScaleStorage.go
@@ -31,5 +31,5 @@ func ScaleStorage(client *golangsdk.ServiceClient, opts ScaleStorageOpt) (*strin
 	raw, err := client.Post(client.ServiceURL("instances", opts.InstanceId, "enlarge-volume"), b, nil, &golangsdk.RequestOpts{
 		OkCodes: []int{200, 202},
 	})
-	return extractJob(err, raw)
+	return ExtractJob(err, raw)
 }

--- a/openstack/dds/v3/instances/SetRecyclePolicy.go
+++ b/openstack/dds/v3/instances/SetRecyclePolicy.go
@@ -1,0 +1,33 @@
+package instances
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type RecyclePolicyOpts struct {
+	// CIDR block where the client is located
+	RecyclePolicy *RecyclePolicy `json:"recycle_policy" required:"true"`
+}
+
+type RecyclePolicy struct {
+	// The recycling policy is enabled and cannot be disabled.
+	// true: The recycling policy is enabled.
+	Enabled *bool `json:"enabled" required:"true"`
+	// Policy retention duration (1 to 7 days).
+	// The value is a positive integer. If this parameter is left blank, the policy is retained for 7 days by default.
+	RetentionPeriodInDays int `json:"retention_period_in_days,omitempty"`
+}
+
+func SetRecyclePolicy(client *golangsdk.ServiceClient, instanceId string, opts RecyclePolicyOpts) (err error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	// PUT https://{Endpoint}/v3/{project_id}/instances/recycle-policy
+	_, err = client.Put(client.ServiceURL("instances", "recycle-policy"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/openstack/dds/v3/instances/Switchover.go
+++ b/openstack/dds/v3/instances/Switchover.go
@@ -6,5 +6,5 @@ func Switchover(client *golangsdk.ServiceClient, instanceId string) (*string, er
 	raw, err := client.Post(client.ServiceURL("instances", instanceId, "switchover"), nil, nil, &golangsdk.RequestOpts{
 		OkCodes: []int{200, 202},
 	})
-	return extractJob(err, raw)
+	return ExtractJob(err, raw)
 }

--- a/openstack/dds/v3/instances/UnbindEIP.go
+++ b/openstack/dds/v3/instances/UnbindEIP.go
@@ -9,5 +9,5 @@ func UnBindEIP(client *golangsdk.ServiceClient, nodeId string) (*string, error) 
 		OkCodes:     []int{200, 202},
 		MoreHeaders: map[string]string{"Content-Type": "application/json"},
 	})
-	return extractJob(err, raw)
+	return ExtractJob(err, raw)
 }

--- a/openstack/dds/v3/instances/job.go
+++ b/openstack/dds/v3/instances/job.go
@@ -10,7 +10,7 @@ type JobId struct {
 	JobId string `json:"job_id"`
 }
 
-func extractJob(err error, raw *http.Response) (*string, error) {
+func ExtractJob(err error, raw *http.Response) (*string, error) {
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
Acceptance tests:
```
=== RUN   TestDdsBackupLifeCycle
    backups_test.go:29: Attempting to create DDSv3 backup for instance: 00ea86cb93cd441aaa309812ea64675bin02
    backups_test.go:41: DDSv3 backup successfully created
    backups_test.go:52: Attempting to list DDSv3 backups for instance: 00ea86cb93cd441aaa309812ea64675bin02
    backups_test.go:59: Attempting to get download links for DDSv3 backup: a9fb8e82ce4c4c31991f5a0fef6c7150br02
    backups_test.go:67: Attempting to set backup policy for DDSv3 instance: 00ea86cb93cd441aaa309812ea64675bin02
    backups_test.go:78: Attempting to get backup policy for DDSv3 instance: 00ea86cb93cd441aaa309812ea64675bin02
    backups_test.go:85: Attempting to modify backup policy for DDSv3 instance: 00ea86cb93cd441aaa309812ea64675bin02
    backups_test.go:96: Attempting to get again backup policy for DDSv3 instance: 00ea86cb93cd441aaa309812ea64675bin02
    backups_test.go:45: Attempting to delete DDSv3 backup: a9fb8e82ce4c4c31991f5a0fef6c7150br02
    backups_test.go:49: Deleted DDSv3 backup: a9fb8e82ce4c4c31991f5a0fef6c7150br02
--- PASS: TestDdsBackupLifeCycle (140.74s)
PASS

Process finished with the exit code 0

=== RUN   TestDdsRestoreLifeCycle
    restore_test.go:24: Attempting to create DDSv3 backup for instance: 00ea86cb93cd441aaa309812ea64675bin02
    restore_test.go:36: DDSv3 backup successfully created
    restore_test.go:47: Attempting to restore DDSv3 instance to Original: 00ea86cb93cd441aaa309812ea64675bin02
    restore_test.go:40: Attempting to delete DDSv3 backup: 42cc132361764a22b4dd6c9a133ad429br02
    restore_test.go:44: Deleted DDSv3 backup: 42cc132361764a22b4dd6c9a133ad429br02
--- PASS: TestDdsRestoreLifeCycle (341.06s)
PASS

Process finished with the exit code 0

=== RUN   TestDdsConfigurationLifeCycle
    configuration_test.go:22: Attempting to get DDSv3 instance config
    configuration_test.go:27: Attempting to list DDSv3 template configurations
    configuration_test.go:32: Attempting to get DDSv3 template configuration
    configuration_test.go:37: Attempting to apply DDSv3 template configuration
--- PASS: TestDdsConfigurationLifeCycle (8.62s)
PASS

Process finished with the exit code 0


=== RUN   TestDdsList
--- PASS: TestDdsList (0.78s)
=== RUN   TestDdsSingleLifeCycle
    instances_test.go:34: Attempting to create DDSv3 single instance
    instances_test.go:278: DDSv3 replica set instance successfully created
    instances_test.go:44: {fc6f7ca2dc64489f9f43da83db9a282ain02 dds-acc-whXvM0aI  normal 8635 Single eu-de {DDS-Community 4.0 } wiredTiger 2024-08-16T16:23:53 2024-08-16T16:23:52 rwuser 0 16dbd25d-c55c-405b-9e56-11b03e7e7dc1 44ed75f0-65df-4865-b4d9-4565fc56e2f1 88a47a36-1b69-41b5-bef8-f74a2a85933f {08:00-09:00 0x14000010a90 } 14:00-18:00 [{single    {20 0.293701171875} [{275a349516724d538b3628601c474d4cno02 dds-acc-whXvM0aI_single_node_1 normal Primary 10.0.239.179  dds.mongodb.s2.medium.4.single eu-de-03}]}]   [] 0 []}
    instances_test.go:125: Update name
    helpers.go:59: Attempting to create eip/bandwidth
    helpers.go:75: Waiting for eip 98230841-8f01-4bd6-a808-4e64f3cad3d1 to be active
    helpers.go:82: Created eip/bandwidth: 98230841-8f01-4bd6-a808-4e64f3cad3d1
    instances_test.go:145: AttachEip
    instances_test.go:157: UnbindEip
    instances_test.go:167: Enable the SSL
    instances_test.go:174: Modify instance internal IP
    instances_test.go:184: Modify instance port
    instances_test.go:193: Modify instance SG
    instances_test.go:202: Modify instance specs
    instances_test.go:220: Modify instance volume size
    instances_test.go:415: Attempting to delete DDSv3 instance: fc6f7ca2dc64489f9f43da83db9a282ain02
    instances_test.go:425: DDSv3 instance deleted successfully: fc6f7ca2dc64489f9f43da83db9a282ain02
    helpers.go:88: Attempting to delete eip/bandwidth: 98230841-8f01-4bd6-a808-4e64f3cad3d1
    helpers.go:94: Waitting for eip 98230841-8f01-4bd6-a808-4e64f3cad3d1 to be deleted
    helpers.go:99: Deleted eip/bandwidth: 98230841-8f01-4bd6-a808-4e64f3cad3d1
--- PASS: TestDdsSingleLifeCycle (1155.97s)
PASS

=== RUN   TestDdsClusterLifeCycle
    instances_test.go:50: Attempting to create DDSv3 cluster instance
    instances_test.go:405: DDSv3 replica set instance successfully created: f80a1b98b44b416b8c3352247fd53658in02
    instances_test.go:60: {f80a1b98b44b416b8c3352247fd53658in02 dds-acc-K4ahauce  normal 8635 Sharding eu-de {DDS-Community 3.4 } wiredTiger 2024-08-16T13:56:10 2024-08-16T13:56:10 rwuser 0 16dbd25d-c55c-405b-9e56-11b03e7e7dc1 44ed75f0-65df-4865-b4d9-4565fc56e2f1 88a47a36-1b69-41b5-bef8-f74a2a85933f {08:00-09:00 0x140003ce500 } 14:00-18:00 [{mongos    { } [{3ccba8091383436b987599392a8c9846no02 dds-acc-K4ahauce_mongos_node_1 normal master 10.0.144.63  dds.mongodb.s2.medium.4.mongos eu-de-03} {75a9035944dd4de2afd8d2689bce8728no02 dds-acc-K4ahauce_mongos_node_2 normal master 10.0.20.187  dds.mongodb.s2.medium.4.mongos eu-de-03}]} {shard 449ab5912ea74011a9fb786817a4eafegr02 shard_1 normal {20 0.29344940185546875} [{02d508978fa54633943311c61ea07353no02 dds-acc-K4ahauce_shard_1_node_2 normal Primary   dds.mongodb.s2.medium.4.shard eu-de-03} {7f1237da662244a6a804fb68ce1e2203no02 dds-acc-K4ahauce_shard_1_node_3 normal Hidden   dds.mongodb.s2.medium.4.shard eu-de-03} {ea9cd414409a47de969239de93bf4296no02 dds-acc-K4ahauce_shard_1_node_1 normal Secondary   dds.mongodb.s2.medium.4.shard eu-de-03}]} {shard b0eab22ccf364718a2ab790b09415d13gr02 shard_2 normal {20 0.2937164306640625} [{35ae29e175a74a9c98e97f136ff1d371no02 dds-acc-K4ahauce_shard_2_node_2 normal Primary   dds.mongodb.s2.medium.4.shard eu-de-03} {3816d46e141f49ba868f866ebbcf9855no02 dds-acc-K4ahauce_shard_2_node_3 normal Hidden   dds.mongodb.s2.medium.4.shard eu-de-03} {6bf9957f9f5b4da6bb625bac826e4528no02 dds-acc-K4ahauce_shard_2_node_1 normal Secondary   dds.mongodb.s2.medium.4.shard eu-de-03}]} {config e9a7c78aa6f447ec855c5a2c9dfc0fb3gr02 config normal {20 0.29378509521484375} [{07ad0c6918554e50ab937d3f507d59cfno02 dds-acc-K4ahauce_config_node_1 normal Secondary   dds.mongodb.s2.large.2.config eu-de-03} {bbfa90c625f04a37a6e510f8f23dae8cno02 dds-acc-K4ahauce_config_node_3 normal Hidden   dds.mongodb.s2.large.2.config eu-de-03} {c6e38ef16ad6414cac4ac7879f42f2f7no02 dds-acc-K4ahauce_config_node_2 normal Primary   dds.mongodb.s2.large.2.config eu-de-03}]}]   [] 0 [{muh2 kuh2} {muh kuh}]}
    instances_test.go:62: Attempting to add 2 mongo nodes to cluster
    instances_test.go:73: Attempting to add 2 shard nodes to cluster
    instances_test.go:87: Enable config IP
    instances_test.go:410: Attempting to delete DDSv3 instance: f80a1b98b44b416b8c3352247fd53658in02
    instances_test.go:420: DDSv3 instance deleted successfully: f80a1b98b44b416b8c3352247fd53658in02
--- PASS: TestDdsClusterLifeCycle (1085.70s)
=== RUN   TestDdsReplicaLifeCycle
    instances_test.go:278: Attempting to create DDSv3 replica set instance
    instances_test.go:335: DDSv3 replica set instance successfully created
    instances_test.go:111: {05cc266bcfb74acdaa50c92c9e4df611in02 dds-acc-L6bk7AlX  normal 8635 ReplicaSet eu-de {DDS-Community 3.4 } wiredTiger 2024-08-16T14:14:32 2024-08-16T14:14:31 rwuser 0 16dbd25d-c55c-405b-9e56-11b03e7e7dc1 44ed75f0-65df-4865-b4d9-4565fc56e2f1 88a47a36-1b69-41b5-bef8-f74a2a85933f {08:00-09:00 0x140000aba20 } 14:00-18:00 [{replica    {20 0.2934150695800781} [{294bccc7a95e4737a9c9112889a5f0cbno02 dds-acc-L6bk7AlX_replica_node_3 normal Hidden 10.0.78.81  dds.mongodb.s2.medium.4.repset eu-de-03} {8c7514810c8343038a555a4ad9d73d63no02 dds-acc-L6bk7AlX_replica_node_1 normal Secondary 10.0.199.221  dds.mongodb.s2.medium.4.repset eu-de-03} {c26b87ed1cca4fefb94879b7c23a91a5no02 dds-acc-L6bk7AlX_replica_node_2 normal Primary 10.0.191.0  dds.mongodb.s2.medium.4.repset eu-de-03}]}]   [] 0 [{muh2 kuh2} {muh kuh}]}
    instances_test.go:410: Attempting to delete DDSv3 instance: 05cc266bcfb74acdaa50c92c9e4df611in02
    instances_test.go:420: DDSv3 instance deleted successfully: 05cc266bcfb74acdaa50c92c9e4df611in02
--- PASS: TestDdsReplicaLifeCycle (356.96s)
PASS

Process finished with the exit code 0
```