### PR TITLE
[Fix.] IsAutoRenew and IsAutoPay type changed to string

### DIFF
--- a/acceptance/openstack/cce/v3/nodepool_test.go
+++ b/acceptance/openstack/cce/v3/nodepool_test.go
@@ -30,6 +30,11 @@ func (s *testNodes) TestNodePoolLifecycle() {
 		Spec: nodepools.CreateSpec{
 			Type: "vm",
 			NodeTemplate: nodes.Spec{
+				ExtendParam: nodes.ExtendParam{
+					MaxPods:     55,
+					IsAutoRenew: "false",
+					IsAutoPay:   "false",
+				},
 				Flavor: "s2.large.2",
 				Az:     "eu-de-01",
 				Os:     "EulerOS 2.5",
@@ -108,8 +113,12 @@ func (s *testNodes) TestNodePoolLifecycle() {
 		return false, nil
 	}))
 
-	_, err = nodepools.Get(client, clusterId, nodeId).Extract()
+	pool, err := nodepools.Get(client, clusterId, nodeId).Extract()
 	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 55, pool.Spec.NodeTemplate.ExtendParam.MaxPods)
+	// Not supported params by now
+	// th.AssertEquals(t, "false", pool.Spec.NodeTemplate.ExtendParam.IsAutoPay)
+	// th.AssertEquals(t, "false", pool.Spec.NodeTemplate.ExtendParam.IsAutoRenew)
 
 	th.AssertNoErr(t, nodepools.Delete(client, clusterId, nodeId).ExtractErr())
 

--- a/openstack/cce/v3/nodepools/requests.go
+++ b/openstack/cce/v3/nodepools/requests.go
@@ -120,7 +120,7 @@ type CreateSpec struct {
 	NodeManagement NodeManagementSpec `json:"nodeManagement,omitempty"`
 }
 
-// Create accepts a CreateOpts struct and uses the values to create a new
+// CreateOptsBuilder Create accepts a CreateOpts struct and uses the values to create a new
 // logical Node Pool. When it is created, the Node Pool does not have an internal
 // interface
 type CreateOptsBuilder interface {

--- a/openstack/cce/v3/nodes/results.go
+++ b/openstack/cce/v3/nodes/results.go
@@ -173,9 +173,9 @@ type ExtendParam struct {
 	// Script required after the installation.
 	PostInstall string `json:"alpha.cce/postInstall,omitempty"`
 	// Whether auto-renew is enabled.
-	IsAutoRenew *bool `json:"isAutoRenew,omitempty"`
+	IsAutoRenew string `json:"isAutoRenew,omitempty"`
 	// Whether to deduct fees automatically.
-	IsAutoPay *bool `json:"isAutoPay,omitempty"`
+	IsAutoPay string `json:"isAutoPay,omitempty"`
 	// Available disk space of a single Docker container on the node using the device mapper.
 	DockerBaseSize int `json:"dockerBaseSize,omitempty"`
 	// ConfigMap of the Docker data disk.

--- a/openstack/compute/v2/extensions/keypairs/requests.go
+++ b/openstack/compute/v2/extensions/keypairs/requests.go
@@ -68,7 +68,7 @@ func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateRe
 		return
 	}
 	_, r.Err = client.Post(createURL(client), b, &r.Body, &golangsdk.RequestOpts{
-		OkCodes: []int{200},
+		OkCodes: []int{200, 201},
 	})
 	return
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
From custormer issue in tf https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/2654
Type of these attributes `IsAutoRenew` `IsAutoPay` was changed to string

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
=== RUN   TestNodePoolLifecycle
--- PASS: TestNodePoolLifecycle (259.30s)
PASS

Process finished with the exit code 0