### PR TITLE
[Fix.] Enabling and Disabling of ProtectionGroup for SDRS

### DIFF
--- a/acceptance/openstack/common.go
+++ b/acceptance/openstack/common.go
@@ -112,7 +112,7 @@ func DeleteVolume(t *testing.T, id string) {
 }
 
 const (
-	imageName = "Standard_Debian_10_latest"
+	imageName = "Standard_Debian_11_latest"
 	flavorID  = "s3.large.2"
 )
 
@@ -138,7 +138,9 @@ func GetCloudServerCreateOpts(t *testing.T) cloudservers.CreateOpts {
 		Name: imageName,
 	})
 	th.AssertNoErr(t, err)
-
+	if len(image) == 0 {
+		t.Skip("Change image query filter, no results returned")
+	}
 	if vpcID == "" || subnetID == "" || az == "" {
 		t.Skip("One of OS_VPC_ID, OS_NETWORK_ID or OS_AVAILABILITY_ZONE env vars is missing but ECSv1 test requires")
 	}

--- a/acceptance/openstack/sdrs/v1/helpers.go
+++ b/acceptance/openstack/sdrs/v1/helpers.go
@@ -31,7 +31,7 @@ func createSDRSGroup(t *testing.T, client *golangsdk.ServiceClient, domainID str
 	job, err := protectiongroups.Create(client, createOpts)
 	th.AssertNoErr(t, err)
 
-	t.Logf("Waiting for SDRS group job %s", job)
+	t.Logf("Waiting for SDRS group job %s", job.JobID)
 	err = protectiongroups.WaitForJobSuccess(client, 600, job.JobID)
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/sdrs/v1/helpers.go
+++ b/acceptance/openstack/sdrs/v1/helpers.go
@@ -14,6 +14,7 @@ func createSDRSGroup(t *testing.T, client *golangsdk.ServiceClient, domainID str
 	t.Logf("Attempting to create SDRS protection group")
 
 	vpcID := clients.EnvOS.GetEnv("VPC_ID")
+	az := clients.EnvOS.GetEnv("AVAILABILITY_ZONE")
 	if vpcID == "" {
 		t.Skip("OS_VPC_ID env var is missing but SDRS group test requires")
 	}
@@ -21,7 +22,7 @@ func createSDRSGroup(t *testing.T, client *golangsdk.ServiceClient, domainID str
 	createOpts := protectiongroups.CreateOpts{
 		Name:        tools.RandomString("sdrs-group-", 3),
 		Description: "some interesting description",
-		SourceAZ:    "eu-de-02",
+		SourceAZ:    az,
 		TargetAZ:    "eu-de-01",
 		DomainID:    domainID,
 		SourceVpcID: vpcID,

--- a/acceptance/openstack/sdrs/v1/protectedinstances_test.go
+++ b/acceptance/openstack/sdrs/v1/protectedinstances_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/sdrs/v1/domains"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/sdrs/v1/protectedinstances"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/sdrs/v1/protectiongroups"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
 
@@ -87,4 +88,27 @@ func TestSDRSInstanceLifecycle(t *testing.T) {
 	th.AssertEquals(t, createDescription, instance.Description)
 
 	t.Logf("Created SDRS protected instance: %s", instance.ID)
+
+	jobEnable, err := protectiongroups.Enable(client, group.Id)
+	th.AssertNoErr(t, err)
+
+	t.Logf("Waiting for SDRS group enabling job %s", jobEnable.JobID)
+	err = protectiongroups.WaitForJobSuccess(client, 600, jobEnable.JobID)
+	th.AssertNoErr(t, err)
+
+	getEnablePg, err := protectiongroups.Get(client, group.Id)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "protected", getEnablePg.Status)
+
+	jobDisable, err := protectiongroups.Disable(client, group.Id)
+	th.AssertNoErr(t, err)
+
+	t.Logf("Waiting for SDRS group disabling job %s", jobDisable.JobID)
+	err = protectiongroups.WaitForJobSuccess(client, 600, jobDisable.JobID)
+	th.AssertNoErr(t, err)
+
+	getDisabledPg, err := protectiongroups.Get(client, group.Id)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "available", getDisabledPg.Status)
+
 }

--- a/openstack/sdrs/v1/protectiongroups/Disable.go
+++ b/openstack/sdrs/v1/protectiongroups/Disable.go
@@ -9,18 +9,12 @@ import (
 // DisableOpts contains all the values needed to disable protection for a Group.
 type DisableOpts struct {
 	// Disables protection for a protection group. The StopServerGroup is an empty object.
-	StopServerGroup StopServerGroupInfo `json:"stop-server-group" required:"true"`
-}
-
-type StopServerGroupInfo struct {
-	// Empty
+	StopServerGroup map[string]interface{} `json:"stop-server-group" required:"true"`
 }
 
 // Disable will Disable protection for a protection Group.
 func Disable(client *golangsdk.ServiceClient, ServerGroupId string) (*DisableResponse, error) {
-	opts := DisableOpts{
-		StopServerGroup: StopServerGroupInfo{},
-	}
+	opts := DisableOpts{StopServerGroup: map[string]interface{}{}}
 	b, err := build.RequestBody(opts, "")
 	if err != nil {
 		return nil, err

--- a/openstack/sdrs/v1/protectiongroups/Enable.go
+++ b/openstack/sdrs/v1/protectiongroups/Enable.go
@@ -9,18 +9,12 @@ import (
 // EnableOpts contains all the values needed to enable protection for a Group.
 type EnableOpts struct {
 	// Enables protection for a protection group. The StartServerGroup is an empty object.
-	StartServerGroup StartServerGroupInfo `json:"start-server-group" required:"true"`
-}
-
-type StartServerGroupInfo struct {
-	// Empty
+	StartServerGroup map[string]interface{} `json:"start-server-group" required:"true"`
 }
 
 // Enable will enable protection for a protection Group.
 func Enable(client *golangsdk.ServiceClient, ServerGroupId string) (*EnableResponse, error) {
-	opts := EnableOpts{
-		StartServerGroup: StartServerGroupInfo{},
-	}
+	opts := EnableOpts{StartServerGroup: map[string]interface{}{}}
 	b, err := build.RequestBody(opts, "")
 	if err != nil {
 		return nil, err

--- a/openstack/sdrs/v1/protectiongroups/results_job.go
+++ b/openstack/sdrs/v1/protectiongroups/results_job.go
@@ -66,5 +66,5 @@ func GetJobEntity(client *golangsdk.ServiceClient, jobId string, label string) (
 		}
 	}
 
-	return nil, fmt.Errorf("Unexpected conversion error in GetJobEntity.")
+	return nil, fmt.Errorf("unexpected conversion error in GetJobEntity")
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
There was an error of building opts for Enable and Disable, now fixed, tests also updated

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
=== RUN   TestSDRSInstanceLifecycle
    helpers.go:14: Attempting to create SDRS protection group
    helpers.go:34: Waiting for SDRS group job &{ff8080828ed1852401921f23244179b1}
    helpers.go:44: Created SDRS protection group: efae3993-20a6-4e4d-9e7b-0002bcde4693
    protectedinstances_test.go:47: Attempting to create ECSv1
    protectedinstances_test.go:47: Created ECSv1 instance: 57f492fc-23c3-47ad-8eff-ea0d754d18d0
    protectedinstances_test.go:52: Attempting to create SDRS protected instance
    protectedinstances_test.go:90: Created SDRS protected instance: ddb30aba-43fb-48e0-9662-c43c859a878c
    protectedinstances_test.go:95: Waiting for SDRS group enabling job ff808082814d99e101921f266f621578
    protectedinstances_test.go:106: Waiting for SDRS group disabling job ff8080828ed1852401921f26bfcf79e9
    protectedinstances_test.go:73: Attempting to delete SDRS protected instance: ddb30aba-43fb-48e0-9662-c43c859a878c
    protectedinstances_test.go:85: Deleted SDRS protected instance: ddb30aba-43fb-48e0-9662-c43c859a878c
    common.go:208: Attempting to delete ECSv1: 57f492fc-23c3-47ad-8eff-ea0d754d18d0
    common.go:225: ECSv1 instance deleted: 57f492fc-23c3-47ad-8eff-ea0d754d18d0
    helpers.go:50: Attempting to delete SDRS protection group: efae3993-20a6-4e4d-9e7b-0002bcde4693
    helpers.go:58: Deleted SDRS protection group: efae3993-20a6-4e4d-9e7b-0002bcde4693
--- PASS: TestSDRSInstanceLifecycle (329.58s)
PASS

Process  finished with the exit code 0