### PR TITLE
[Fix] Fix SDRS Update Protected Instances

### DIFF
--- a/acceptance/openstack/sdrs/v1/protectedinstances_test.go
+++ b/acceptance/openstack/sdrs/v1/protectedinstances_test.go
@@ -66,6 +66,7 @@ func TestSDRSInstanceLifecycle(t *testing.T) {
 
 	instance, err := protectedinstances.Get(client, jobEntity.(string))
 	th.AssertNoErr(t, err)
+
 	defer func() {
 		t.Logf("Attempting to delete SDRS protected instance: %s", instance.ID)
 		deleteServer := false
@@ -83,6 +84,14 @@ func TestSDRSInstanceLifecycle(t *testing.T) {
 	}()
 	th.AssertEquals(t, createName, instance.Name)
 	th.AssertEquals(t, createDescription, instance.Description)
+
+	updatedName := tools.RandomString("sdrs-instance-", 4)
+	updateOpts := protectedinstances.UpdateOpts{
+		Name: updatedName,
+	}
+	instance, err = protectedinstances.Update(client, instance.ID, updateOpts)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, updatedName, instance.Name)
 
 	t.Logf("Created SDRS protected instance: %s", instance.ID)
 

--- a/openstack/sdrs/v1/protectedinstances/Update.go
+++ b/openstack/sdrs/v1/protectedinstances/Update.go
@@ -16,7 +16,7 @@ type UpdateOpts struct {
 
 // Update accepts a UpdateOpts struct and uses the values to update an Instance.The response code from api is 200
 func Update(client *golangsdk.ServiceClient, instanceId string, opts UpdateOpts) (*Instance, error) {
-	b, err := build.RequestBody(opts, "")
+	b, err := build.RequestBody(opts, "protected_instance")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Fixes SDRS Update function

### Tests Performed
```
=== RUN   TestSDRSInstanceList
--- PASS: TestSDRSInstanceList (0.88s)
=== RUN   TestSDRSInstanceLifecycle
    helpers.go:14: Attempting to create SDRS protection group
    helpers.go:34: Waiting for SDRS group job ff808082814d99eb01924760b4b66fa9
    helpers.go:44: Created SDRS protection group: d0adf929-6b80-4474-b2d7-b4b62ec356be
    protectedinstances_test.go:44: Attempting to create ECSv1
    protectedinstances_test.go:44: Created ECSv1 instance: 31575916-b8c8-43ae-872a-0ae776924c0b
    protectedinstances_test.go:49: Attempting to create SDRS protected instance
    protectedinstances_test.go:96: Created SDRS protected instance: db3a71b9-9729-466f-b6d4-71bf2d390d48
    protectedinstances_test.go:101: Waiting for SDRS group enabling job ff808082814d99e101924764349b6aec
    protectedinstances_test.go:112: Waiting for SDRS group disabling job ff808082814d99eb0192476483796fab
    protectedinstances_test.go:71: Attempting to delete SDRS protected instance: db3a71b9-9729-466f-b6d4-71bf2d390d48
    protectedinstances_test.go:83: Deleted SDRS protected instance: db3a71b9-9729-466f-b6d4-71bf2d390d48
    common.go:208: Attempting to delete ECSv1: 31575916-b8c8-43ae-872a-0ae776924c0b
    common.go:225: ECSv1 instance deleted: 31575916-b8c8-43ae-872a-0ae776924c0b
    helpers.go:50: Attempting to delete SDRS protection group: d0adf929-6b80-4474-b2d7-b4b62ec356be
    helpers.go:58: Deleted SDRS protection group: d0adf929-6b80-4474-b2d7-b4b62ec356be
--- PASS: TestSDRSInstanceLifecycle (342.67s)
PASS
```
