### PR TITLE
[Feat.] Enterprise VPN Connection Monitoring and EVPN Tags

### DIFF
--- a/openstack/evpn/v5/connection-monitoring/Create.go
+++ b/openstack/evpn/v5/connection-monitoring/Create.go
@@ -1,0 +1,50 @@
+package connection_monitoring
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateOpts struct {
+	// Specifies the ID of the VPN connection to be monitored.
+	ConnectionID string `json:"vpn_connection_id" required:"true"`
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*Monitor, error) {
+	b, err := build.RequestBody(opts, "connection_monitor")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Post(client.ServiceURL("connection-monitors"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{202, 201},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res Monitor
+	return &res, extract.IntoStructPtr(raw.Body, &res, "connection_monitor")
+}
+
+type Monitor struct {
+	// Specifies the ID of a VPN connection monitor.
+	ID string `json:"id"`
+	// Specifies the ID of the VPN connection to be monitored.
+	ConnectionId string `json:"vpn_connection_id"`
+	// Specifies the type of objects to be monitored.
+	Type string `json:"type"`
+	// Specifies the source address to be monitored.
+	SourceIp string `json:"source_ip"`
+	// Specifies the destination address to be monitored.
+	DestinationIp string `json:"destination_ip"`
+	// Specifies the protocol used by NQA.
+	ProtoType string `json:"proto_type"`
+	// Specifies the status of the VPN connection monitor.
+	// Value range:
+	// ACTIVE: normal
+	// PENDING_CREATE: creating
+	// PENDING_DELETE: deleting
+	Status string `json:"status"`
+}

--- a/openstack/evpn/v5/connection-monitoring/Delete.go
+++ b/openstack/evpn/v5/connection-monitoring/Delete.go
@@ -1,0 +1,10 @@
+package connection_monitoring
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+func Delete(client *golangsdk.ServiceClient, id string) (err error) {
+	_, err = client.Delete(client.ServiceURL("connection-monitors", id), nil)
+	return
+}

--- a/openstack/evpn/v5/connection-monitoring/Get.go
+++ b/openstack/evpn/v5/connection-monitoring/Get.go
@@ -1,0 +1,17 @@
+package connection_monitoring
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Get(client *golangsdk.ServiceClient, monitorId string) (*Monitor, error) {
+	raw, err := client.Get(client.ServiceURL("connection-monitors", monitorId), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res Monitor
+	err = extract.IntoStructPtr(raw.Body, &res, "connection_monitor")
+	return &res, err
+}

--- a/openstack/evpn/v5/connection-monitoring/List.go
+++ b/openstack/evpn/v5/connection-monitoring/List.go
@@ -1,0 +1,28 @@
+package connection_monitoring
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListOpts struct {
+	// Specifies a VPN connection ID.
+	ConnectionId string `q:"vpn_connection_id"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]Monitor, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("connection-monitors").WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res []Monitor
+	err = extract.IntoSlicePtr(raw.Body, &res, "connection_monitors")
+	return res, err
+}

--- a/openstack/evpn/v5/gateway/Create.go
+++ b/openstack/evpn/v5/gateway/Create.go
@@ -139,6 +139,8 @@ type Gateway struct {
 	NetworkType string `json:"network_type"`
 	// Specifies the association mode.
 	AttachmentType string `json:"attachment_type"`
+	// Specifies the AZ where the VPN gateway is deployed.
+	AvailabilityZoneIds string `json:"availability_zone_ids"`
 	// Specifies the ID of the enterprise router instance to which the VPN gateway connects.
 	// This parameter is available only when attachment_type is set to er.
 	ErId string `json:"er_id"`

--- a/openstack/evpn/v5/quota/Get.go
+++ b/openstack/evpn/v5/quota/Get.go
@@ -1,0 +1,40 @@
+package quota
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Get(client *golangsdk.ServiceClient) (*Quota, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("vpn", "quotas").Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res Quota
+	err = extract.IntoStructPtr(raw.Body, &res, "quotas")
+	return &res, err
+}
+
+type Quota struct {
+	Resources []Info `json:"resources"`
+}
+
+type Info struct {
+	// Specifies a resource type.
+	// Value range:
+	// customer_gateway: customer gateway
+	// vpn_connection: Enterprise Edition VPN connection
+	// vpn_gateway: Enterprise Edition VPN gateway
+	Type string `json:"type"`
+	// Specifies the quota upper limit.
+	Quota int `json:"quota"`
+	// Specifies the number of resources in use.
+	Used int `json:"used"`
+}

--- a/openstack/evpn/v5/tags/Create.go
+++ b/openstack/evpn/v5/tags/Create.go
@@ -1,0 +1,28 @@
+package tags
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
+)
+
+type TagsOpts struct {
+	// Specifies a tag list.
+	// A maximum of 20 tags can be specified.
+	Tags []tags.ResourceTag `json:"tags" required:"true"`
+}
+
+// Create creates tags
+// resourceType Specifies the resource type.
+// The value can be vpn-gateway, customer-gateway, or vpn-connection.
+func Create(client *golangsdk.ServiceClient, resourceType, resourceId string, opts TagsOpts) error {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+	_, err = client.Post(client.ServiceURL(resourceType, resourceId, "tags", "create"), b, nil, &golangsdk.RequestOpts{
+		OkCodes:     []int{204},
+		MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+	})
+	return err
+}

--- a/openstack/evpn/v5/tags/Delete.go
+++ b/openstack/evpn/v5/tags/Delete.go
@@ -1,0 +1,18 @@
+package tags
+
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+func Delete(client *golangsdk.ServiceClient, resourceType, resourceId string, opts TagsOpts) error {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+	_, err = client.Post(client.ServiceURL(resourceType, resourceId, "tags", "delete"), b, nil, &golangsdk.RequestOpts{
+		OkCodes:     []int{204},
+		MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+	})
+	return err
+}

--- a/openstack/evpn/v5/tags/List.go
+++ b/openstack/evpn/v5/tags/List.go
@@ -1,0 +1,24 @@
+package tags
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
+)
+
+func List(client *golangsdk.ServiceClient, resourceType, resourceId string) ([]tags.ResourceTag, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints(resourceType, resourceId, "tags").Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res []tags.ResourceTag
+	err = extract.IntoSlicePtr(raw.Body, &res, "tags")
+	return res, err
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Implements https://docs.otc.t-systems.com/virtual-private-network/api-ref/api_reference_enterprise_edition_vpn/apis_of_enterprise_edition_vpn/vpn_connection_monitoring/index.html
https://docs.otc.t-systems.com/virtual-private-network/api-ref/api_reference_enterprise_edition_vpn/apis_of_enterprise_edition_vpn/tags/index.html
https://docs.otc.t-systems.com/virtual-private-network/api-ref/api_reference_enterprise_edition_vpn/apis_of_enterprise_edition_vpn/quota/index.html
### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->
Part of #724 

### Special notes for your reviewer
```
=== RUN   TestConnectionLifecycle
    connection_test.go:189: Attempting to CREATE EIP 1
    connection_test.go:197: Attempting to CREATE EIP 2
    connection_test.go:221: Attempting to CREATE Enterprise VPN Gateway: acc_evpn_gateway_9sE3F
    connection_test.go:174: Attempting to CREATE Enterprise VPN Customer Gateway: acc_evpn_cgw_f9PAY
    connection_test.go:70: Attempting to CREATE Enterprise VPN Connection: acc_evpn_connection_1cd
    connection_test.go:81: Attempting to GET Enterprise VPN Connection: e353293f-c6c3-4892-a1ef-91f85b0a1f85
    connection_test.go:88: Attempting to UPDATE Enterprise VPN Connection: e353293f-c6c3-4892-a1ef-91f85b0a1f85
    connection_test.go:105: Attempting to LIST Enterprise VPN Connections
    connection_test.go:112: Attempting to CREATE Enterprise VPN Connection Monitoring
    connection_test.go:124: Attempting to GET Enterprise VPN Connection Monitor: 70376d91-d75c-4c13-a332-bf8645574a3b
    connection_test.go:129: Attempting to LIST Enterprise VPN Connection Monitor: 70376d91-d75c-4c13-a332-bf8645574a3b
    connection_test.go:134: Attempting to GET Enterprise VPN Quotas: 70376d91-d75c-4c13-a332-bf8645574a3b
    connection_test.go:145: Attempting to CREATE Enterprise VPN Connection Tag: [{One gopher}]
    connection_test.go:153: Attempting to LIST Enterprise VPN Connection Tags: e353293f-c6c3-4892-a1ef-91f85b0a1f85
    connection_test.go:150: Attempting to DELETE Enterprise VPN Connection Tag: [{One gopher}]
    connection_test.go:119: Attempting to DELETE Enterprise VPN Connection Monitoring: 70376d91-d75c-4c13-a332-bf8645574a3b
    connection_test.go:76: Attempting to DELETE Enterprise VPN Connection: 270fac6b-c4df-488e-8123-66782977983b
    connection_test.go:179: Attempting to DELETE Enterprise VPN Customer Gateway: 5ac989d7-22e1-42d7-8b9a-4e2c9de2b88e
    connection_test.go:227: Attempting to DELETE Enterprise VPN Gateway: 270fac6b-c4df-488e-8123-66782977983b
    connection_test.go:201: Attempting to DELETE EIP 2: 1d16bea3-b486-45ad-9c3c-d6553a0906af
    connection_test.go:193: Attempting to DELETE EIP 1: ff36b36f-a46f-439f-9cdc-26ae1820f4d3
--- PASS: TestConnectionLifecycle (336.75s)
PASS

Process finished with the exit code 0
```