### PR TITLE
[Fix] Enterprise VPN Gateway fix response types

### DIFF
--- a/acceptance/openstack/evpn/gateway_test.go
+++ b/acceptance/openstack/evpn/gateway_test.go
@@ -34,7 +34,7 @@ func TestGatewaysAZsList(t *testing.T) {
 }
 
 func TestGatewayVPCLifecycle(t *testing.T) {
-	t.Skip("unstable creation of gateway")
+	// t.Skip("unstable creation of gateway")
 	subnetId := os.Getenv("OS_SUBNET_ID")
 	vpcId := os.Getenv("OS_VPC_ID")
 

--- a/acceptance/openstack/evpn/gateway_test.go
+++ b/acceptance/openstack/evpn/gateway_test.go
@@ -34,7 +34,7 @@ func TestGatewaysAZsList(t *testing.T) {
 }
 
 func TestGatewayVPCLifecycle(t *testing.T) {
-	// t.Skip("unstable creation of gateway")
+	t.Skip("unstable creation of gateway")
 	subnetId := os.Getenv("OS_SUBNET_ID")
 	vpcId := os.Getenv("OS_VPC_ID")
 

--- a/openstack/evpn/v5/gateway/Create.go
+++ b/openstack/evpn/v5/gateway/Create.go
@@ -140,7 +140,7 @@ type Gateway struct {
 	// Specifies the association mode.
 	AttachmentType string `json:"attachment_type"`
 	// Specifies the AZ where the VPN gateway is deployed.
-	AvailabilityZoneIds string `json:"availability_zone_ids"`
+	AvailabilityZoneIds []string `json:"availability_zone_ids"`
 	// Specifies the ID of the enterprise router instance to which the VPN gateway connects.
 	// This parameter is available only when attachment_type is set to er.
 	ErId string `json:"er_id"`
@@ -212,7 +212,7 @@ type IkePolicyResp struct {
 	// Specifies an authentication algorithm.
 	AuthenticationAlgorithm string `json:"authentication_algorithm,omitempty"`
 	// Specifies the SA lifetime. When the lifetime expires, an IKE SA is automatically updated.
-	LifetimeSeconds string `json:"lifetime_seconds,omitempty"`
+	LifetimeSeconds *int `json:"lifetime_seconds,omitempty"`
 }
 
 type IpsecPolicyResp struct {
@@ -223,7 +223,7 @@ type IpsecPolicyResp struct {
 	// Specifies an authentication algorithm.
 	AuthenticationAlgorithm string `json:"authentication_algorithm,omitempty"`
 	// Specifies the lifetime of a tunnel established over an IPsec connection.
-	LifetimeSeconds string `json:"lifetime_seconds,omitempty"`
+	LifetimeSeconds *int `json:"lifetime_seconds,omitempty"`
 }
 
 type EipResp struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->
Wrong types for some attributes

### Special notes for your reviewer
```
=== RUN   TestGatewaysList
--- PASS: TestGatewaysList (0.62s)
=== RUN   TestGatewaysAZsList
    tools.go:74: {
          "basic": {
            "vpc": [
              "eu-de-02",
              "eu-de-01"
            ],
            "er": []
          },
          "professional1": {
            "vpc": [
              "eu-de-02",
              "eu-de-01"
            ],
            "er": [
              "eu-de-02",
              "eu-de-01"
            ]
          },
          "Professional1-NonFixedIP": {
            "vpc": [
              "eu-de-02",
              "eu-de-01"
            ],
            "er": [
              "eu-de-02",
              "eu-de-01"
            ]
          },
          "professional2": {
            "vpc": [
              "eu-de-02",
              "eu-de-01"
            ],
            "er": [
              "eu-de-02",
              "eu-de-01"
            ]
          },
          "Professional2-NonFixedIP": {
            "vpc": [
              "eu-de-02",
              "eu-de-01"
            ],
            "er": [
              "eu-de-02",
              "eu-de-01"
            ]
          },
          "gm": {
            "vpc": [],
            "er": []
          }
        }
--- PASS: TestGatewaysAZsList (0.70s)
=== RUN   TestGatewayVPCLifecycle
    gateway_test.go:57: Attempting to CREATE EIP 1
    gateway_test.go:65: Attempting to CREATE EIP 2
    gateway_test.go:89: Attempting to CREATE Enterprise VPN Gateway: acc_evpn_gateway_NYxoY
    gateway_test.go:99: Attempting to GET Enterprise VPN Gateway: 6a567f2f-fb08-44a1-8606-2ba8199fcc4c
    gateway_test.go:105: Attempting to UPDATE Enterprise VPN Gateway: 6a567f2f-fb08-44a1-8606-2ba8199fcc4c
    gateway_test.go:113: Attempting to LIST Enterprise VPN Gateways: 6a567f2f-fb08-44a1-8606-2ba8199fcc4c
    gateway_test.go:95: Attempting to DELETE Enterprise VPN Gateway: 6a567f2f-fb08-44a1-8606-2ba8199fcc4c
    gateway_test.go:69: Attempting to DELETE EIP 2: b3a04c7b-24bf-4904-ae93-f211a2560ce6
    gateway_test.go:61: Attempting to DELETE EIP 1: 037d56b0-3dea-4b24-88e8-74bcc165f307
--- PASS: TestGatewayVPCLifecycle (185.21s)
PASS

Process finished with the exit code 0
```
