### PR TITLE
[Fix] Fix required param in AS group create

### DIFF
--- a/acceptance/openstack/autoscaling/v1/groups_test.go
+++ b/acceptance/openstack/autoscaling/v1/groups_test.go
@@ -27,8 +27,6 @@ func TestGroupsList(t *testing.T) {
 }
 
 func TestGroupLifecycle(t *testing.T) {
-	client, err := clients.NewAutoscalingV1Client()
-	th.AssertNoErr(t, err)
 
 	asGroupCreateName := tools.RandomString("as-group-create-", 3)
 	networkID := clients.EnvOS.GetEnv("NETWORK_ID")
@@ -36,6 +34,9 @@ func TestGroupLifecycle(t *testing.T) {
 	if networkID == "" {
 		t.Skip("OS_NETWORK_ID or OS_VPC_ID env vars are missing but AS Group test requires")
 	}
+
+	client, err := clients.NewAutoscalingV1Client()
+	th.AssertNoErr(t, err)
 
 	secGroupID := openstack.CreateSecurityGroup(t)
 	t.Cleanup(func() {

--- a/openstack/autoscaling/v1/groups/create.go
+++ b/openstack/autoscaling/v1/groups/create.go
@@ -1,7 +1,7 @@
 package groups
 
 import (
-	"github.com/opentelekomcloud/gophertelekomcloud"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 )
@@ -10,7 +10,7 @@ type CreateOpts struct {
 	// Specifies the AS group name. The name contains only letters, digits, underscores (_), and hyphens (-), and cannot exceed 64 characters.
 	Name string `json:"scaling_group_name" required:"true"`
 	// Specifies the AS configuration ID, which can be obtained using the API for querying AS configurations.
-	ConfigurationID string `json:"scaling_configuration_id,omitempty"`
+	ConfigurationID string `json:"scaling_configuration_id" required:"true"`
 	// Specifies the expected number of instances. The default value is the minimum number of instances.
 	// The value ranges from the minimum number of instances to the maximum number of instances.
 	DesireInstanceNumber int `json:"desire_instance_number,omitempty"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Fixes API change in AS  groups. Configuration is now a required parameter for AS group creation.

### Tests

```
    tools.go:74: {
          "scaling_group_name": "as-group-update-NuR",
          "scaling_group_id": "c679320d-679f-4c50-8901-51b4ffb41f53",
          "scaling_group_status": "PAUSED",
          "scaling_configuration_id": "e4137147-df09-4776-9cb6-a590da78a872",
          "scaling_configuration_name": "as-create-WWd",
          "current_instance_number": 0,
          "desire_instance_number": 0,
          "min_instance_number": 0,
          "max_instance_number": 0,
          "cool_down_time": 300,
          "lb_listener_id": "",
          "lbaas_listeners": [],
          "available_zones": [
            "eu-de-02",
            "eu-de-01",
            "eu-de-03"
          ],
          "networks": [
            {
              "id": "4b0f754c-1897-4d53-a128-6e21645a4c51"
            }
          ],
          "security_groups": [
            {
              "id": "027a1906-b4bb-44d5-98fd-cf9fcbcd29dc"
            }
          ],
          "create_time": "2024-10-08T11:24:39Z",
          "vpc_id": "21344f69-3a0e-4950-8746-e8aa68d6b7bb",
          "detail": "",
          "is_scaling": false,
          "health_periodic_audit_method": "NOVA_AUDIT",
          "health_periodic_audit_time": 5,
          "health_periodic_audit_grace_period": 600,
          "instance_terminate_policy": "OLD_CONFIG_OLD_INSTANCE",
          "notifications": null,
          "delete_publicip": false,
          "delete_volume": true,
          "cloud_location_id": "",
          "enterprise_project_id": "0",
          "activity_type": "",
          "multi_az_priority_policy": "EQUILIBRIUM_DISTRIBUTE",
          "description": ""
        }
    helpers.go:60: Attempting to delete AutoScaling Group
    helpers.go:65: Deleted AutoScaling Group: c679320d-679f-4c50-8901-51b4ffb41f53
    helpers.go:103: Attempting to delete AutoScaling Configuration
    helpers.go:106: Deleted AutoScaling Configuration: e4137147-df09-4776-9cb6-a590da78a872
    common.go:77: Security group 027a1906-b4bb-44d5-98fd-cf9fcbcd29dc was deleted
--- PASS: TestGroupLifecycle (12.18s)
PASS
```
