### PR TITLE
[Feat.] random az support for instance creation

### DIFF
--- a/acceptance/openstack/common.go
+++ b/acceptance/openstack/common.go
@@ -172,7 +172,7 @@ func GetCloudServerCreateOpts(t *testing.T) cloudservers.CreateOpts {
 				},
 			},
 		},
-		AvailabilityZone: az,
+		AvailabilityZone: &az,
 	}
 
 	return createOpts

--- a/acceptance/openstack/ecs/v1/cloudservers_test.go
+++ b/acceptance/openstack/ecs/v1/cloudservers_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ecs/v1/cloudservers"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ims/v2/images"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
 
@@ -16,6 +18,78 @@ func TestCloudServerLifecycle(t *testing.T) {
 
 	// Get ECSv1 createOpts
 	createOpts := openstack.GetCloudServerCreateOpts(t)
+
+	// Check ECSv1 createOpts
+	openstack.DryRunCloudServerConfig(t, client, createOpts)
+	t.Logf("CreateOpts are ok for creating a cloudServer")
+
+	// Create ECSv1 instance
+	ecs := openstack.CreateCloudServer(t, client, createOpts)
+	defer openstack.DeleteCloudServer(t, client, ecs.ID)
+
+	tagsList := []tags.ResourceTag{
+		{
+			Key:   "TestKey",
+			Value: "TestValue",
+		},
+		{
+			Key:   "empty",
+			Value: "",
+		},
+	}
+	err = tags.Create(client, "cloudservers", ecs.ID, tagsList).ExtractErr()
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, ecs)
+}
+
+func TestCloudServersRandomAzLifecycle(t *testing.T) {
+	client, err := clients.NewComputeV1Client()
+	th.AssertNoErr(t, err)
+
+	prefix := "ecs-"
+	ecsName := tools.RandomString(prefix, 3)
+	imageName := "Standard_Debian_11_latest"
+	flavorID := "s3.large.2"
+
+	vpcID := clients.EnvOS.GetEnv("VPC_ID")
+	subnetID := clients.EnvOS.GetEnv("NETWORK_ID")
+
+	imageV2Client, err := clients.NewIMSV2Client()
+	th.AssertNoErr(t, err)
+
+	image, err := images.ListImages(imageV2Client, images.ListImagesOpts{
+		Name: imageName,
+	})
+	th.AssertNoErr(t, err)
+	if len(image) == 0 {
+		t.Skip("Change image query filter, no results returned")
+	}
+	if vpcID == "" || subnetID == "" {
+		t.Skip("One of OS_VPC_ID, OS_NETWORK_ID env vars is missing but ECSv1 test requires")
+	}
+
+	// Get ECSv1 createOpts
+	createOpts := cloudservers.CreateOpts{
+		ImageRef:  image[0].Id,
+		FlavorRef: flavorID,
+		Name:      ecsName,
+		VpcId:     vpcID,
+		Nics: []cloudservers.Nic{
+			{
+				SubnetId: subnetID,
+			},
+		},
+		RootVolume: cloudservers.RootVolume{
+			VolumeType: "SSD",
+		},
+		DataVolumes: []cloudservers.DataVolume{
+			{
+				VolumeType: "SSD",
+				Size:       20,
+			},
+		},
+	}
 
 	// Check ECSv1 createOpts
 	openstack.DryRunCloudServerConfig(t, client, createOpts)

--- a/acceptance/openstack/networking/v1/routetables_test.go
+++ b/acceptance/openstack/networking/v1/routetables_test.go
@@ -205,7 +205,7 @@ func TestRouteTablesLifecycle(t *testing.T) {
 					Size:       40,
 				},
 			},
-			AvailabilityZone: az,
+			AvailabilityZone: &az,
 		}
 		t.Logf("Attempting to create cloud server: %s", sererName)
 		ecs := openstack.CreateCloudServer(t, clientCompute, createEcsOpts)

--- a/openstack/ecs/v1/cloudservers/requests.go
+++ b/openstack/ecs/v1/cloudservers/requests.go
@@ -49,7 +49,7 @@ type CreateOpts struct {
 	SecurityGroups []SecurityGroup `json:"security_groups,omitempty"`
 
 	// AvailabilityZone specifies name of the AZ where the ECS is located.
-	AvailabilityZone string `json:"availability_zone" required:"true"`
+	AvailabilityZone *string `json:"availability_zone,omitempty"`
 
 	// ExtendParam provides the supplementary information about the ECS to be created.
 	ExtendParam *ServerExtendParam `json:"extendparam,omitempty"`
@@ -64,6 +64,9 @@ type CreateOpts struct {
 	Tags []string `json:"tags,omitempty"`
 
 	ServerTags []ServerTags `json:"server_tags,omitempty"`
+
+	// Specifies whether ECSs can be deployed in multiple random AZs. The default value is false.
+	CreateInMultiAz *bool `json:"batch_create_in_multi_az,omitempty"`
 }
 
 // CreateOptsBuilder allows extensions to add additional parameters to the


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
AZ now optional, If this parameter is not specified, the system automatically selects an AZ.
Added batch_create_in_multi_az parameter

### What this PR does / why we need it

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
=== RUN   TestCloudServerLifecycle
    common.go:182: Attempting to check ECSv1 createOpts
    cloudservers_test.go:24: CreateOpts are ok for creating a cloudServer
    cloudservers_test.go:27: Attempting to create ECSv1
    cloudservers_test.go:27: Created ECSv1 instance: dce2e0a4-28a0-4802-a35b-1d35aad8f8f9
    common.go:208: Attempting to delete ECSv1: dce2e0a4-28a0-4802-a35b-1d35aad8f8f9
    common.go:225: ECSv1 instance deleted: dce2e0a4-28a0-4802-a35b-1d35aad8f8f9
--- PASS: TestCloudServerLifecycle (110.81s)
=== RUN   TestCloudServersRandomAzLifecycle
    common.go:182: Attempting to check ECSv1 createOpts
    cloudservers_test.go:96: CreateOpts are ok for creating a cloudServer
    cloudservers_test.go:99: Attempting to create ECSv1
    cloudservers_test.go:99: Created ECSv1 instance: 9215e4df-6be1-46e3-b0e2-6f7737f322c4
    common.go:208: Attempting to delete ECSv1: 9215e4df-6be1-46e3-b0e2-6f7737f322c4
    common.go:225: ECSv1 instance deleted: 9215e4df-6be1-46e3-b0e2-6f7737f322c4
--- PASS: TestCloudServersRandomAzLifecycle (123.80s)
PASS

Process finished with the exit code 0