### PR TITLE
[Feat.] CSS certificate download

### DIFF
--- a/acceptance/openstack/css/v1/certificates_test.go
+++ b/acceptance/openstack/css/v1/certificates_test.go
@@ -1,0 +1,17 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	c "github.com/opentelekomcloud/gophertelekomcloud/openstack/css/v1/certifcates"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestCertificateDownload(t *testing.T) {
+	t.Skip("No need to run this test in CI not secure")
+	client, err := clients.NewCssV1Client()
+	th.AssertNoErr(t, err)
+	_, err = c.Get(client)
+	th.AssertNoErr(t, err)
+}

--- a/openstack/css/v1/certifcates/Get.go
+++ b/openstack/css/v1/certifcates/Get.go
@@ -1,0 +1,35 @@
+package clusters
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+func Get(client *golangsdk.ServiceClient) (*string, error) {
+	raw, err := client.Get(client.ServiceURL("cer", "download"), nil, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"Accept":       "*/*",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ExtractCert(err, raw)
+}
+
+func ExtractCert(err error, response *http.Response) (*string, error) {
+	if err != nil {
+		return nil, err
+	}
+	bodyBytes, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+	cert := string(bodyBytes)
+	return &cert, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
This API is used to download the HTTPS certificate of the server.

Closes #752
```

=== RUN   TestCertificateDownload
--- PASS: TestCertificateDownload (34.37s)
PASS

Process finished with the exit code 0
```