### PR TITLE
[CTS]: Filter parameter

### DIFF
--- a/acceptance/openstack/cts/v3/keyevents_test.go
+++ b/acceptance/openstack/cts/v3/keyevents_test.go
@@ -52,6 +52,16 @@ func TestKeyEventLifecycle(t *testing.T) {
 				TraceNames:   []string{"deleteBucket"},
 			},
 		},
+		Filter: &keyevent.Filter{
+			IsSupportFilter: true,
+			Condition:       "OR",
+			Rule: []string{
+				"code != 200",
+				"api_version = v1.0",
+				"trace_rating = normal",
+				"trace_type != ApiCall",
+			},
+		},
 	})
 	th.AssertNoErr(t, err)
 	tools.PrintResource(t, update)

--- a/openstack/cts/v3/keyevent/Create.go
+++ b/openstack/cts/v3/keyevent/Create.go
@@ -25,6 +25,14 @@ type CreateNotificationOpts struct {
 	// To obtain the topic_urn, call the SMN API for querying topics.
 	// Example URN: urn:smn:regionId:f96188c7ccaf4ffba0c9aa149ab2bd57:test_topic_v2
 	TopicId string `json:"topic_id,omitempty"`
+	// Advanced filter of key event notifications.
+	Filter *Filter `json:"filter,omitempty"`
+}
+
+type Filter struct {
+	Condition       string   `json:"condition"`
+	IsSupportFilter bool     `json:"is_support_filter"`
+	Rule            []string `json:"rule"`
 }
 
 type Operations struct {

--- a/openstack/cts/v3/keyevent/List.go
+++ b/openstack/cts/v3/keyevent/List.go
@@ -62,4 +62,6 @@ type NotificationResponse struct {
 	ProjectId string `json:"project_id,omitempty"`
 	// Time when a notification rule was created.
 	CreateTime int64 `json:"create_time,omitempty"`
+	// Advanced filter of key event notifications.
+	Filter Filter `json:"filter,omitempty"`
 }

--- a/openstack/cts/v3/keyevent/Update.go
+++ b/openstack/cts/v3/keyevent/Update.go
@@ -35,6 +35,8 @@ type UpdateNotificationOpts struct {
 	TopicId string `json:"topic_id,omitempty"`
 	// Notification ID.
 	NotificationId string `json:"notification_id"`
+	// Advanced filter of key event notifications.
+	Filter *Filter `json:"filter,omitempty"`
 }
 
 func Update(client *golangsdk.ServiceClient, opts UpdateNotificationOpts) (*NotificationResponse, error) {


### PR DESCRIPTION
### Acceptance tests
```
=== RUN   TestKeyEventLifecycle
    tools.go:75: [
          {
            "notification_name": "keyevent_test_eK9",
            "operation_type": "customized",
            "operations": [
              {
                "service_type": "OBS",
                "resource_type": "bucket",
                "trace_names": [
                  "createBucket"
                ]
              }
            ],
            "status": "disabled",
            "notification_id": "b5c7be73-795e-4f39-9b47-814fb1d47b08",
            "notification_type": "smn",
            "project_id": "a720688fb87f4575a4c000d818061eae",
            "create_time": 1738578250206,
            "filter": {
              "condition": "",
              "is_support_filter": false,
              "rule": null
            }
          }
        ]
    tools.go:75: {
          "notification_name": "keyevent_test_update",
          "operation_type": "customized",
          "operations": [
            {
              "service_type": "OBS",
              "resource_type": "bucket",
              "trace_names": [
                "deleteBucket"
              ]
            }
          ],
          "status": "disabled",
          "notification_id": "b5c7be73-795e-4f39-9b47-814fb1d47b08",
          "notification_type": "smn",
          "project_id": "a720688fb87f4575a4c000d818061eae",
          "create_time": 1738578250206,
          "filter": {
            "condition": "OR",
            "is_support_filter": true,
            "rule": [
              "code != 200",
              "api_version = v1.0",
              "trace_rating = normal",
              "trace_type != ApiCall"
            ]
          }
        }
--- PASS: TestKeyEventLifecycle (2.53s)
PASS

Process finished with the exit code 0
```