### PR TITLE
CSS: Public access management

### DIFF
--- a/acceptance/openstack/css/v1/clusters_test.go
+++ b/acceptance/openstack/css/v1/clusters_test.go
@@ -100,3 +100,88 @@ func TestClusterWorkflow(t *testing.T) {
 
 	th.AssertNoErr(t, clusters.WaitForClusterToExtend(client, created.ID, timeout))
 }
+
+func TestClusterPublicAccess(t *testing.T) {
+	client, err := clients.NewCssV1Client()
+	th.AssertNoErr(t, err)
+
+	vpcID := clients.EnvOS.GetEnv("VPC_ID")
+	subnetID := clients.EnvOS.GetEnv("NETWORK_ID")
+
+	if vpcID == "" || subnetID == "" {
+		t.Skip("Both `VPC_ID` and `NETWORK_ID` need to be defined")
+	}
+
+	sgID := openstack.DefaultSecurityGroup(t)
+
+	opts := clusters.CreateOpts{
+		Name: tools.RandomString("css-cluster-", 4),
+		Instance: &clusters.InstanceSpec{
+			Flavor: "css.medium.8",
+
+			Volume: &clusters.Volume{
+				Type: "COMMON",
+				Size: 40,
+			},
+			Nics: &clusters.Nics{
+				VpcID:           vpcID,
+				SubnetID:        subnetID,
+				SecurityGroupID: sgID,
+			},
+			AvailabilityZone: "eu-de-02",
+		},
+		InstanceNum: 1,
+		DiskEncryption: &clusters.DiskEncryption{
+			Encrypted: "0",
+		},
+		HttpsEnabled:     "true",
+		AuthorityEnabled: true,
+		AdminPassword:    "Test123!@#",
+		Datastore: &clusters.Datastore{
+			Version: "7.6.2",
+			Type:    "elasticsearch",
+		},
+	}
+	created, err := clusters.Create(client, opts)
+	th.AssertNoErr(t, err)
+
+	defer func() {
+		err = clusters.Delete(client, created.ID)
+		th.AssertNoErr(t, err)
+	}()
+
+	got, err := clusters.Get(client, created.ID)
+	th.AssertNoErr(t, err)
+
+	log.Printf("Creating cluster, ID: %s", got.ID)
+	th.AssertEquals(t, created.ID, got.ID)
+	th.AssertEquals(t, created.Name, got.Name)
+
+	th.CheckNoErr(t, clusters.WaitForClusterOperationSucces(client, created.ID, timeout))
+
+	managePublicOpts := clusters.ManagePublicAccessOpts{
+		ClusterId: got.ID,
+		Size:      5,
+	}
+
+	res, err := clusters.EnablePublicAccess(client, managePublicOpts)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, res, "bindZone")
+
+	err = clusters.WaitForCluster(client, managePublicOpts.ClusterId, timeout)
+	th.AssertNoErr(t, err)
+
+	managePublicOpts.Size = 10
+	err = clusters.UpdatePublicAccess(client, managePublicOpts)
+	th.AssertNoErr(t, err)
+
+	err = clusters.WaitForCluster(client, managePublicOpts.ClusterId, timeout)
+	th.AssertNoErr(t, err)
+
+	res, err = clusters.DisablePublicAccess(client, managePublicOpts)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, res, "unbindZone")
+
+	err = clusters.WaitForCluster(client, managePublicOpts.ClusterId, timeout)
+	th.AssertNoErr(t, err)
+}

--- a/openstack/css/v1/clusters/DisablePublicAccess.go
+++ b/openstack/css/v1/clusters/DisablePublicAccess.go
@@ -1,0 +1,36 @@
+package clusters
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// DisablePublicAccess function is used to disable public network access
+func DisablePublicAccess(client *golangsdk.ServiceClient, opts ManagePublicAccessOpts) (string, error) {
+	rawOpts := PublicAccessOpts{
+		Eip: Eip{
+			Bandwidth: Bandwidth{
+				Size: opts.Size,
+			},
+		},
+	}
+
+	b, err := build.RequestBody(rawOpts, "")
+	if err != nil {
+		return "", err
+	}
+
+	raw, err := client.Put(client.ServiceURL("clusters", opts.ClusterId, "public", "close"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var res struct {
+		Action string `json:"action"`
+	}
+	err = extract.IntoStructPtr(raw.Body, &res, "")
+	return res.Action, err
+}

--- a/openstack/css/v1/clusters/DisablePublicWhitelist.go
+++ b/openstack/css/v1/clusters/DisablePublicWhitelist.go
@@ -1,0 +1,11 @@
+package clusters
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+// DisablePublicWhitelist function is used to disable whitelist for a single ip
+func DisablePublicWhitelist(client *golangsdk.ServiceClient, clusterID string) error {
+	_, err := client.Put(client.ServiceURL("clusters", clusterID, "public", "whitelist", "close"), nil, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return err
+}

--- a/openstack/css/v1/clusters/EnablePublicAccess.go
+++ b/openstack/css/v1/clusters/EnablePublicAccess.go
@@ -1,0 +1,53 @@
+package clusters
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ManagePublicAccessOpts struct {
+	ClusterId string `json:"-"`
+	Size      int    `json:"-" required:"true"`
+}
+
+// EnablePublicAccess function is used to enable public network access
+func EnablePublicAccess(client *golangsdk.ServiceClient, opts ManagePublicAccessOpts) (string, error) {
+	rawOpts := PublicAccessOpts{
+		Eip: Eip{
+			Bandwidth: Bandwidth{
+				Size: opts.Size,
+			},
+		},
+	}
+
+	b, err := build.RequestBody(rawOpts, "")
+	if err != nil {
+		return "", err
+	}
+
+	raw, err := client.Post(client.ServiceURL("clusters", opts.ClusterId, "public", "open"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var res struct {
+		Action string `json:"action"`
+	}
+	err = extract.IntoStructPtr(raw.Body, &res, "")
+	return res.Action, err
+}
+
+type PublicAccessOpts struct {
+	Eip Eip `json:"eip"`
+}
+
+type Eip struct {
+	Bandwidth Bandwidth `json:"bandWidth" required:"true"`
+}
+
+type Bandwidth struct {
+	Size int `json:"size" required:"true"`
+}

--- a/openstack/css/v1/clusters/EnablePublicWhitelist.go
+++ b/openstack/css/v1/clusters/EnablePublicWhitelist.go
@@ -1,0 +1,23 @@
+package clusters
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+// EnablePublicWhitelist function is used to enable public whitelist
+func EnablePublicWhitelist(client *golangsdk.ServiceClient, clusterId, whitelist string) error {
+	opts := struct {
+		WhiteList string `json:"whiteList"`
+	}{whitelist}
+
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Post(client.ServiceURL("clusters", clusterId, "public", "whitelist", "update"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return err
+}

--- a/openstack/css/v1/clusters/UpdatePublicAccess.go
+++ b/openstack/css/v1/clusters/UpdatePublicAccess.go
@@ -1,0 +1,25 @@
+package clusters
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+// UpdatePublicAccess function is used to enable public network access
+func UpdatePublicAccess(client *golangsdk.ServiceClient, opts ManagePublicAccessOpts) error {
+	rawOpts := Eip{
+		Bandwidth: Bandwidth{
+			Size: opts.Size,
+		},
+	}
+
+	b, err := build.RequestBody(rawOpts, "")
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Post(client.ServiceURL("clusters", opts.ClusterId, "public", "bandwidth"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return err
+}


### PR DESCRIPTION
### Acceptance tests
```
=== RUN   TestClusterPublicAccess
2025/02/10 15:49:41 Creating cluster, ID: a74e5875-452a-4f6d-bd78-ea01b5048c9c
--- PASS: TestClusterPublicAccess (897.48s)
PASS

Process finished with the exit code 0
```
