### PR TITLE
RDS: Fix attach method

### DIFF
--- a/acceptance/openstack/rds/v3/helpers.go
+++ b/acceptance/openstack/rds/v3/helpers.go
@@ -32,8 +32,8 @@ func CreateRDS(t *testing.T, client *golangsdk.ServiceClient, region string) *in
 	createRdsOpts := instances.CreateRdsOpts{
 		Name:             rdsName,
 		Port:             "8635",
-		Password:         "acc-test-password1!",
-		FlavorRef:        "rds.pg.c2.medium",
+		Password:         "Postgres!120521",
+		FlavorRef:        "rds.pg.n1.large.2",
 		Region:           region,
 		AvailabilityZone: az,
 		VpcId:            vpcID,
@@ -42,12 +42,12 @@ func CreateRDS(t *testing.T, client *golangsdk.ServiceClient, region string) *in
 		DiskEncryptionId: kmsID,
 
 		Volume: &instances.Volume{
-			Type: "COMMON",
+			Type: "CLOUDSSD",
 			Size: 100,
 		},
 		Datastore: &instances.Datastore{
 			Type:    "PostgreSQL",
-			Version: "11",
+			Version: "15",
 		},
 		UnchangeableParam: &instances.Param{
 			LowerCaseTableNames: "0",

--- a/acceptance/openstack/rds/v3/rds_test.go
+++ b/acceptance/openstack/rds/v3/rds_test.go
@@ -139,7 +139,7 @@ func TestRdsLifecycle(t *testing.T) {
 
 	resize, err := instances.Resize(client, instances.ResizeOpts{
 		InstanceId: rds.Id,
-		SpecCode:   "rds.pg.c2.large",
+		SpecCode:   "rds.pg.n1.large.4",
 	})
 	th.AssertNoErr(t, err)
 	err = instances.WaitForJobCompleted(client, 600, *resize)
@@ -168,18 +168,25 @@ func TestRdsLifecycle(t *testing.T) {
 
 	t.Log("AttachEip")
 
-	err = instances.AttachEip(client, instances.AttachEipOpts{
+	jobId, err := instances.AttachEip(client, instances.AttachEipOpts{
 		InstanceId: rds.Id,
 		PublicIp:   elasticIP.PublicAddress,
 		PublicIpId: elasticIP.ID,
 		IsBind:     pointerto.Bool(true),
 	})
 	th.AssertNoErr(t, err)
+
+	err = instances.WaitForJobCompleted(client, 600, *jobId)
+	th.AssertNoErr(t, err)
+
 	t.Cleanup(func() {
-		err = instances.AttachEip(client, instances.AttachEipOpts{
+		jobId, err = instances.AttachEip(client, instances.AttachEipOpts{
 			InstanceId: rds.Id,
 			IsBind:     pointerto.Bool(false),
 		})
+		th.AssertNoErr(t, err)
+
+		err = instances.WaitForJobCompleted(client, 600, *jobId)
 		th.AssertNoErr(t, err)
 	})
 

--- a/openstack/rds/v3/instances/AttachEip.go
+++ b/openstack/rds/v3/instances/AttachEip.go
@@ -20,15 +20,15 @@ type AttachEipOpts struct {
 	IsBind *bool `json:"is_bind" required:"true"`
 }
 
-func AttachEip(client *golangsdk.ServiceClient, opts AttachEipOpts) (err error) {
+func AttachEip(client *golangsdk.ServiceClient, opts AttachEipOpts) (*string, error) {
 	b, err := build.RequestBody(opts, "")
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	// PUT https://{Endpoint}/v3/{project_id}/instances/{instance_id}/public-ip
-	_, err = client.Put(client.ServiceURL("instances", opts.InstanceId, "public-ip"), b, nil, &golangsdk.RequestOpts{
+	raw, err := client.Put(client.ServiceURL("instances", opts.InstanceId, "public-ip"), b, nil, &golangsdk.RequestOpts{
 		OkCodes: []int{200},
 	})
-	return
+	return extraJob(err, raw)
 }


### PR DESCRIPTION
### What this PR does / why we need it
Add `job_id` response which is going to be added to documentation sometime soon

### Acceptance tests
```
=== RUN   TestRdsLifecycle
    rds_test.go:28: Creating instance
    helpers.go:16: Attempting to create RDSv3
    helpers.go:61: Created RDSv3: d0e12e61d5c54751ab9fd01b2ac81f40in03
    helpers.go:59: Attempting to create eip/bandwidth
    helpers.go:75: Waiting for eip 54149eca-b7b2-4e52-8336-54ebacc6557c to be active
    helpers.go:82: Created eip/bandwidth: 54149eca-b7b2-4e52-8336-54ebacc6557c
    rds_test.go:165: AttachEip
    helpers.go:88: Attempting to delete eip/bandwidth: 54149eca-b7b2-4e52-8336-54ebacc6557c
    helpers.go:94: Waitting for eip 54149eca-b7b2-4e52-8336-54ebacc6557c to be deleted
    helpers.go:99: Deleted eip/bandwidth: 54149eca-b7b2-4e52-8336-54ebacc6557c
    helpers.go:113: Attempting to delete RDSv3: d0e12e61d5c54751ab9fd01b2ac81f40in03
    helpers.go:124: RDSv3 instance deleted: d0e12e61d5c54751ab9fd01b2ac81f40in03
--- PASS: TestRdsLifecycle (385.22s)
PASS

Process finished with the exit code 0

```