### PR TITLE
[Fix] Fix return assignment error in DRS

### DIFF
--- a/acceptance/openstack/drs/v3/tasks_test.go
+++ b/acceptance/openstack/drs/v3/tasks_test.go
@@ -65,7 +65,7 @@ func TestDrsTaskLifecycle(t *testing.T) {
 
 	t.Log("AttachEip")
 
-	err = instances.AttachEip(rdsClient, instances.AttachEipOpts{
+	_, err = instances.AttachEip(rdsClient, instances.AttachEipOpts{
 		InstanceId: rdsSource.Id,
 		PublicIp:   elasticIP.PublicAddress,
 		PublicIpId: elasticIP.ID,
@@ -73,7 +73,7 @@ func TestDrsTaskLifecycle(t *testing.T) {
 	})
 	th.AssertNoErr(t, err)
 	t.Cleanup(func() {
-		err = instances.AttachEip(rdsClient, instances.AttachEipOpts{
+		_, err = instances.AttachEip(rdsClient, instances.AttachEipOpts{
 			InstanceId: rdsSource.Id,
 			IsBind:     pointerto.Bool(false),
 		})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it

Changes to RDS causes DRS test and golang lint to fail. 
RDS instances.AttachEIP returns 2 values. 

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
