### PR TITLE
OBS: change optional fields logic

### DIFF
--- a/acceptance/openstack/obs/v1/bucket/obs_inventory_test.go
+++ b/acceptance/openstack/obs/v1/bucket/obs_inventory_test.go
@@ -46,10 +46,8 @@ func TestOBSInventories(t *testing.T) {
 				Prefix: "test",
 			},
 			IncludedObjectVersions: "All",
-			OptionalFields: []obs.InventoryOptionalFields{
-				{
-					Field: "Size",
-				},
+			OptionalFields: obs.InventoryOptionalFields{
+				Field: []string{"Size", "EncryptionStatus"},
 			},
 		},
 	}
@@ -62,6 +60,7 @@ func TestOBSInventories(t *testing.T) {
 		InventoryConfigId: configId,
 	})
 	th.AssertNoErr(t, err)
+	th.AssertEquals(t, len(getResp.OptionalFields.Field), 2)
 
 	tools.PrintResource(t, getResp)
 

--- a/openstack/obs/convert.go
+++ b/openstack/obs/convert.go
@@ -1001,10 +1001,10 @@ func ConvertInventoryConfigurationToXml(input BucketInventoryConfiguration, retu
 	inclVersions := XmlTranscoding(input.IncludedObjectVersions)
 	xml = append(xml, fmt.Sprintf("<IncludedObjectVersions>%s</IncludedObjectVersions>", inclVersions))
 
-	if len(input.OptionalFields) > 0 {
+	if len(input.OptionalFields.Field) > 0 {
 		xml = append(xml, "<OptionalFields>")
-		for _, field := range input.OptionalFields {
-			xml = append(xml, fmt.Sprintf("<Field>%s</Field>", XmlTranscoding(field.Field)))
+		for _, field := range input.OptionalFields.Field {
+			xml = append(xml, fmt.Sprintf("<Field>%s</Field>", XmlTranscoding(field)))
 		}
 		xml = append(xml, "</OptionalFields>")
 	}

--- a/openstack/obs/model_base.go
+++ b/openstack/obs/model_base.go
@@ -374,14 +374,14 @@ type BucketWormPolicy struct {
 
 // BucketInventoryConfiguration defines the bucket inventory configuration
 type BucketInventoryConfiguration struct {
-	XMLName                xml.Name                  `xml:"InventoryConfiguration"`
-	Id                     string                    `xml:"Id"`
-	IsEnabled              bool                      `xml:"IsEnabled"`
-	Filter                 InventoryFilter           `xml:"Filter,omitempty"`
-	Schedule               InventorySchedule         `xml:"Schedule"`
-	Destination            InventoryDestination      `xml:"Destination"`
-	IncludedObjectVersions string                    `xml:"IncludedObjectVersions"`
-	OptionalFields         []InventoryOptionalFields `xml:"OptionalFields,omitempty"`
+	XMLName                xml.Name                `xml:"InventoryConfiguration"`
+	Id                     string                  `xml:"Id"`
+	IsEnabled              bool                    `xml:"IsEnabled"`
+	Filter                 InventoryFilter         `xml:"Filter,omitempty"`
+	Schedule               InventorySchedule       `xml:"Schedule"`
+	Destination            InventoryDestination    `xml:"Destination"`
+	IncludedObjectVersions string                  `xml:"IncludedObjectVersions"`
+	OptionalFields         InventoryOptionalFields `xml:"OptionalFields,omitempty"`
 }
 
 type InventoryFilter struct {
@@ -399,5 +399,5 @@ type InventoryDestination struct {
 }
 
 type InventoryOptionalFields struct {
-	Field string `xml:"Field"`
+	Field []string `xml:"Field"`
 }


### PR DESCRIPTION
### Why we need this pr
This pr fixes `optionalfields` logic.

### Acceptance tests
```
=== RUN   TestOBSInventories
    tools.go:75: {
          "StatusCode": 200,
          "request_id": "00000195AD8BDC60606B374554E918E9",
          "ResponseHeaders": {
            "content-length": [
              "525"
            ],
            "content-type": [
              "application/xml"
            ],
            "date": [
              "Wed, 19 Mar 2025 08:36:19 GMT"
            ],
            "id-2": [
              "32AAAQAAEAABAAAQAAEAABAAAQAAEAABCSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
            ],
            "request-id": [
              "00000195AD8BDC60606B374554E918E9"
            ],
            "server": [
              "OBS"
            ]
          },
          "XMLName": {
            "Space": "",
            "Local": ""
          },
          "Id": "test-id",
          "IsEnabled": true,
          "Filter": {
            "Prefix": "test"
          },
          "Schedule": {
            "Frequency": "Daily"
          },
          "Destination": {
            "Format": "CSV",
            "Bucket": "obs-sdk-test-dhb6e",
            "Prefix": "test"
          },
          "IncludedObjectVersions": "All",
          "OptionalFields": {
            "Field": [
              "Size",
              "EncryptionStatus"
            ]
          }
        }
--- PASS: TestOBSInventories (1.64s)
PASS

Process finished with the exit code 0
```