### PR TITLE
[Fix] add ttl_in_days in query response

### DIFF
--- a/acceptance/openstack/lts/v2/lts_test.go
+++ b/acceptance/openstack/lts/v2/lts_test.go
@@ -64,7 +64,7 @@ func TestLtsLifecycle(t *testing.T) {
 	update, err := streams.Update(client, streams.UpdateLogStreamOpts{
 		GroupId:   created,
 		StreamId:  stream,
-		TTLInDays: 7,
+		TTLInDays: 6,
 	})
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, stream, update.LogStreamId)

--- a/openstack/lts/v2/streams/List.go
+++ b/openstack/lts/v2/streams/List.go
@@ -40,4 +40,6 @@ type LogStream struct {
 	Tag map[string]string `json:"tag,omitempty"`
 	// Whether to add a log stream to favorites.
 	IsFavorite bool `json:"is_favorite,omitempty"`
+	// Log retention duration, in days (fixed to 7 days).
+	TTLInDays int `json:"ttl_in_days"`
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
ttl_in_days not documented but returned by api

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
```
=== RUN   TestLtsLifecycle
    lts_test.go:22: Attempting to Create Log Group
    lts_test.go:32: Attempting to Update Log Group
    lts_test.go:40: Attempting to List Log Groups
    tools.go:75: [
          {
            "creation_time": 1742980843230,
            "log_group_name": "test-group-tbR",
            "log_group_id": "d96904a6-729d-4880-8bb6-89be451d3ed4",
            "ttl_in_days": 3,
            "tag": {
              "_sys_enterprise_project_id": "0"
            }
          }
        ]
    lts_test.go:46: Attempting to Create Log Stream
    lts_test.go:63: Attempting to Update Log Stream
    lts_test.go:72: Attempting to List Log Streams
    tools.go:75: [
          {
            "creation_time": 1742980844196,
            "log_stream_name": "test-stream-B8A",
            "log_stream_id": "354a7cbd-2c3a-4425-bfcf-c35cbac30fa5",
            "filter_count": 0,
            "tag": {
              "_sys_enterprise_project_id": "0"
            },
            "ttl_in_days": 6
          }
        ]
    lts_test.go:55: Attempting to Delete Log Stream
    lts_test.go:27: Attempting to Delete Log Group
--- PASS: TestLtsLifecycle (6.43s)
PASS
```