### PR TITLE
[Feat.] CCE: timezone parameter

### DIFF
--- a/acceptance/openstack/cce/helpers.go
+++ b/acceptance/openstack/cce/helpers.go
@@ -59,7 +59,8 @@ func CreateTurboCluster(t *testing.T, vpcID, subnetID string, eniSubnetID string
 		Kind:       "Cluster",
 		ApiVersion: "v3",
 		Metadata: clusters.CreateMetaData{
-			Name: strings.ToLower(tools.RandomString("cce-gopher-turbo-", 4)),
+			Name:     strings.ToLower(tools.RandomString("cce-gopher-turbo-", 4)),
+			Timezone: "Pacific/Auckland",
 		},
 		Spec: clusters.Spec{
 			Category: "Turbo",

--- a/acceptance/openstack/cce/v3/clusters_test.go
+++ b/acceptance/openstack/cce/v3/clusters_test.go
@@ -47,6 +47,7 @@ func TestCluster(t *testing.T) {
 	clusterGet, err := clusters.Get(client, clusterID)
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, cluster.Metadata.Name, clusterGet.Metadata.Name)
+	th.AssertEquals(t, cluster.Metadata.Timezone, clusterGet.Metadata.Timezone)
 
 	if clusterID != "" {
 		cce.DeleteCluster(t, clusterID)

--- a/openstack/cce/v3/clusters/Create.go
+++ b/openstack/cce/v3/clusters/Create.go
@@ -26,6 +26,8 @@ type CreateMetaData struct {
 	Labels map[string]string `json:"labels,omitempty"`
 	// Cluster annotation, key/value pair format
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// Cluster timezone
+	Timezone string `json:"timezone,omitempty"`
 }
 
 // Create accepts a CreateOpts struct and uses the values to create a new

--- a/openstack/cce/v3/clusters/common.go
+++ b/openstack/cce/v3/clusters/common.go
@@ -25,6 +25,8 @@ type MetaData struct {
 	Labels map[string]string `json:"labels,omitempty"`
 	// Cluster annotation, key/value pair format
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// Cluster timezone
+	Timezone string `json:"timezone,omitempty"`
 }
 
 // Specifications to create a cluster


### PR DESCRIPTION
### Acceptance tests
```
=== RUN   TestCluster
--- PASS: TestCluster (362.77s)
PASS

Process finished with the exit code 0

```
