### PR TITLE
[Feat.] CCE: cluster public access

### DIFF
--- a/acceptance/openstack/cce/helpers.go
+++ b/acceptance/openstack/cce/helpers.go
@@ -87,6 +87,12 @@ func CreateTurboCluster(t *testing.T, vpcID, subnetID string, eniSubnetID string
 					AvailabilityZone: "eu-de-01",
 				},
 			},
+			PublicAccess: &clusters.PublicAccess{
+				Cidrs: []string{
+					"192.168.45.0/24",
+					"10.234.128.0/20",
+				},
+			},
 		},
 	})
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/cce/v3/clusters_test.go
+++ b/acceptance/openstack/cce/v3/clusters_test.go
@@ -49,6 +49,7 @@ func TestCluster(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, cluster.Metadata.Name, clusterGet.Metadata.Name)
 	th.AssertEquals(t, cluster.Metadata.Timezone, clusterGet.Metadata.Timezone)
+	th.AssertEquals(t, cluster.Spec.PublicAccess.Cidrs[0], "192.168.45.0/24")
 
 	computeClient, err := clients.NewComputeV2Client()
 	th.AssertNoErr(t, err)

--- a/openstack/cce/v3/clusters/common.go
+++ b/openstack/cce/v3/clusters/common.go
@@ -49,6 +49,8 @@ type Spec struct {
 	ContainerNetwork ContainerNetworkSpec `json:"containerNetwork" required:"true"`
 	// ENI network parameters
 	EniNetwork *EniNetworkSpec `json:"eniNetwork,omitempty"`
+	// Cluster API access control
+	PublicAccess *PublicAccess `json:"publicAccess,omitempty"`
 	// Authentication parameters
 	Authentication AuthenticationSpec `json:"authentication,omitempty"`
 	// Charging mode of the cluster, which is 0 (on demand)
@@ -105,6 +107,11 @@ type EniNetworkSpec struct {
 	SubnetId string `json:"eniSubnetId" required:"true"`
 	// Eni network cidr
 	Cidr string `json:"eniSubnetCIDR" required:"true"`
+}
+
+type PublicAccess struct {
+	// Trustlist of network CIDRs that are allowed to access cluster APIs.
+	Cidrs []string `json:"cidrs,omitempty"`
 }
 
 // Authentication parameters


### PR DESCRIPTION
### Acceptance tests
```
=== RUN   TestCluster
--- PASS: TestCluster (351.17s)
PASS

Process finished with the exit code 0
```