### PR TITLE
[IAM]: change QueryGroupAllProjects.go

### DIFF
--- a/acceptance/openstack/identity/v3/groups_test.go
+++ b/acceptance/openstack/identity/v3/groups_test.go
@@ -18,7 +18,7 @@ func TestGroupCRUD(t *testing.T) {
 
 	createOpts := groups.CreateOpts{
 		Name:     "testgroup",
-		DomainID: "default",
+		DomainID: client.DomainID,
 		Extra: map[string]interface{}{
 			"email": "testgroup@example.com",
 		},
@@ -48,7 +48,7 @@ func TestGroupCRUD(t *testing.T) {
 	tools.PrintResource(t, newGroup.Extra)
 
 	listOpts := groups.ListOpts{
-		DomainID: "default",
+		DomainID: client.DomainID,
 	}
 
 	// List all Groups in default domain

--- a/acceptance/openstack/identity/v3/roles_test.go
+++ b/acceptance/openstack/identity/v3/roles_test.go
@@ -288,3 +288,24 @@ func TestRoleAssignToGroupOnProject(t *testing.T) {
 		tools.PrintResource(t, roleAssignment)
 	}
 }
+
+func TestRoleInheritAllProjects(t *testing.T) {
+	client, err := clients.NewIdentityV3AdminClient()
+	th.AssertNoErr(t, err)
+
+	role, err := FindRole(t, client)
+	th.AssertNoErr(t, err)
+
+	group, err := CreateGroup(t, client, nil)
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		DeleteGroup(t, client, group.ID)
+	})
+
+	err = roles.UpdateGroupAllProjects(client, client.DomainID, group.ID, role.ID)
+	th.AssertNoErr(t, err)
+
+	allInheritedRoles, err := roles.QueryGroupAllProjects(client, client.DomainID, group.ID)
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, allInheritedRoles)
+}

--- a/openstack/identity/v3/roles/QueryGroupAllProjects.go
+++ b/openstack/identity/v3/roles/QueryGroupAllProjects.go
@@ -3,19 +3,37 @@ package roles
 import (
 	"github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3/policies"
 )
 
-// QueryGroupAllProjects API not registered
-func QueryGroupAllProjects(client *golangsdk.ServiceClient, domainId, groupId, roleId string) (*policies.ListPolicy, error) {
-	// GET https://{Endpoint}/v3/OS-INHERIT/domains/{domain_id}/groups/{group_id}/roles/{role_id}/inherited_to_projects
-	raw, err := client.Get(client.ServiceURL("OS-INHERIT", "domains", domainId, "groups", groupId, "roles", roleId, "inherited_to_projects"),
+func QueryGroupAllProjects(client *golangsdk.ServiceClient, domainId, groupId string) ([]RoleList, error) {
+	// GET https://{Endpoint}/v3/OS-INHERIT/domains/{domain_id}/groups/{group_id}/roles/inherited_to_projects
+	raw, err := client.Get(client.ServiceURL("OS-INHERIT", "domains", domainId, "groups", groupId, "roles", "inherited_to_projects"),
 		nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var res policies.ListPolicy
+	var res []RoleList
 	err = extract.IntoSlicePtr(raw.Body, &res, "roles")
-	return &res, err
+	return res, err
+}
+
+type RoleList struct {
+	Flag        string `json:"flag"`
+	Catalog     string `json:"catalog"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Links       Links  `json:"links"`
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+	Type        string `json:"type"`
+	Policy      Policy `json:"policy"`
+	UpdatedTime string `json:"updated_time"`
+	CreatedTime string `json:"created_time"`
+}
+
+type Links struct {
+	Self     string `json:"self"`
+	Previous string `json:"previous"`
+	Next     string `json:"next"`
 }


### PR DESCRIPTION
Refers to: #820 

### Acceptance tests
```
=== RUN   TestRoleInheritAllProjects
    identity.go:306: Attempting to find a role
    identity.go:328: Successfully found a role system_all_47 with ID 04f313c749de42bba8f3081215be5819
    identity.go:78: Attempting to create group: ACPTTESTle691InN
    identity.go:94: Successfully created group ACPTTESTle691InN with ID 3640842cc72348829a37c2d21d613d8e
    tools.go:75: [
          {
            "flag": "fine_grained",
            "catalog": "VPC",
            "name": "system_all_47",
            "description": "The read-only permissions to all VPC resources, which can be used for statistics and survey.",
            "links": {
              "self": "https://iam.eu-de.otc.t-systems.com/v3/roles/04f313c749de42bba8f3081215be5819",
              "previous": "",
              "next": ""
            },
            "id": "04f313c749de42bba8f3081215be5819",
            "display_name": "VPC ReadOnlyAccess",
            "type": "XA",
            "policy": {
              "Statement": [
                {
                  "Action": [
                    "vpc:*:get",
                    "vpc:*:list",
                    "ecs:*:get*",
                    "ecs:*:list*"
                  ],
                  "Effect": "Allow"
                }
              ],
              "Version": "1.1"
            },
            "updated_time": "",
            "created_time": ""
          }
        ]
    identity.go:240: Deleted group: 3640842cc72348829a37c2d21d613d8e
--- PASS: TestRoleInheritAllProjects (2.39s)
PASS

Process finished with the exit code 0

=== RUN   TestGroupCRUD
    identity.go:78: Attempting to create group: ACPTTEST1Q5vXewf
    identity.go:94: Successfully created group ACPTTEST1Q5vXewf with ID de5f2b2cdfd44f408dce3f38dbee079b
    tools.go:75: {
          "description": "",
          "domain_id": "698f9bf85ca9437a9b2f41132ab3aa0e",
          "id": "de5f2b2cdfd44f408dce3f38dbee079b",
          "links": {
            "self": "https://iam.eu-de.otc.t-systems.com/v3/groups/de5f2b2cdfd44f408dce3f38dbee079b"
          },
          "name": "ACPTTEST1Q5vXewf"
        }
    tools.go:75: {
          "create_time": 1747049091527
        }
    tools.go:75: {
          "description": "Test Users",
          "domain_id": "698f9bf85ca9437a9b2f41132ab3aa0e",
          "id": "de5f2b2cdfd44f408dce3f38dbee079b",
          "links": {
            "self": "https://iam.eu-de.otc.t-systems.com/v3/groups/de5f2b2cdfd44f408dce3f38dbee079b"
          },
          "name": "ACPTTEST1Q5vXewf"
        }
    tools.go:75: {
          "create_time": 1747049091527
        }
    tools.go:75: {
          "description": "Test Users",
          "domain_id": "698f9bf85ca9437a9b2f41132ab3aa0e",
          "id": "de5f2b2cdfd44f408dce3f38dbee079b",
          "links": {
            "next": null,
            "previous": null,
            "self": "https://iam.eu-de.otc.t-systems.com/v3/groups/de5f2b2cdfd44f408dce3f38dbee079b"
          },
          "name": "ACPTTEST1Q5vXewf"
        }
    tools.go:75: {
          "create_time": 1747049091527
        }
    tools.go:75: {
          "description": "",
          "domain_id": "698f9bf85ca9437a9b2f41132ab3aa0e",
          "id": "eef743c2864c43acac4472feb659b459",
          "links": {
            "next": null,
            "previous": null,
            "self": "https://iam.eu-de.otc.t-systems.com/v3/groups/eef743c2864c43acac4472feb659b459"
          },
          "name": "OBS_WITHOUT_LIST"
        }
    tools.go:75: {
          "create_time": 1671537814845
        }
    tools.go:75: {
          "description": "",
          "domain_id": "698f9bf85ca9437a9b2f41132ab3aa0e",
          "id": "a09cf2b380f749f0ae7b783f7648aaf8",
          "links": {
            "next": null,
            "previous": null,
            "self": "https://iam.eu-de.otc.t-systems.com/v3/groups/a09cf2b380f749f0ae7b783f7648aaf8"
          },
          "name": "terra-group-ico6c"
        }
    tools.go:75: {
          "create_time": 1669315962586
        }
    tools.go:75: {
          "description": "",
          "domain_id": "698f9bf85ca9437a9b2f41132ab3aa0e",
          "id": "b0fb8fbda551442b909be01abbbfabfc",
          "links": {
            "next": null,
            "previous": null,
            "self": "https://iam.eu-de.otc.t-systems.com/v3/groups/b0fb8fbda551442b909be01abbbfabfc"
          },
          "name": "ECS viewer"
        }
    tools.go:75: {
          "create_time": 1667557014291
        }
    tools.go:75: {
          "description": "test-groupsdsa",
          "domain_id": "698f9bf85ca9437a9b2f41132ab3aa0e",
          "id": "c45a98d539524c1e92198d37089e6872",
          "links": {
            "next": null,
            "previous": null,
            "self": "https://iam.eu-de.otc.t-systems.com/v3/groups/c45a98d539524c1e92198d37089e6872"
          },
          "name": "test-polina-new"
        }
    tools.go:75: {
          "create_time": 1663792847545
        }
    tools.go:75: {
          "description": "",
          "domain_id": "698f9bf85ca9437a9b2f41132ab3aa0e",
          "id": "388829778d6746489066c72c436d68f0",
          "links": {
            "next": null,
            "previous": null,
            "self": "https://iam.eu-de.otc.t-systems.com/v3/groups/388829778d6746489066c72c436d68f0"
          },
          "name": "Readonly"
        }
    tools.go:75: {
          "create_time": 1658772128425
        }
    tools.go:75: {
          "description": "",
          "domain_id": "698f9bf85ca9437a9b2f41132ab3aa0e",
          "id": "1cfe6b5b01ff4e4fb128995f63af76ee",
          "links": {
            "next": null,
            "previous": null,
            "self": "https://iam.eu-de.otc.t-systems.com/v3/groups/1cfe6b5b01ff4e4fb128995f63af76ee"
          },
          "name": "IAM"
        }
    tools.go:75: {
          "create_time": 1657189322623
        }
    tools.go:75: {
          "description": "adminGroupDes",
          "domain_id": "698f9bf85ca9437a9b2f41132ab3aa0e",
          "id": "d59bd9055e58451498cdf2672012f7da",
          "links": {
            "next": null,
            "previous": null,
            "self": "https://iam.eu-de.otc.t-systems.com/v3/groups/d59bd9055e58451498cdf2672012f7da"
          },
          "name": "admin"
        }
    tools.go:75: {
          "create_time": 1594039411150
        }
    tools.go:75: {
          "description": "Test Users",
          "domain_id": "698f9bf85ca9437a9b2f41132ab3aa0e",
          "id": "de5f2b2cdfd44f408dce3f38dbee079b",
          "links": {
            "next": null,
            "previous": null,
            "self": "https://iam.eu-de.otc.t-systems.com/v3/groups/de5f2b2cdfd44f408dce3f38dbee079b"
          },
          "name": "ACPTTEST1Q5vXewf"
        }
    identity.go:240: Deleted group: de5f2b2cdfd44f408dce3f38dbee079b
--- PASS: TestGroupCRUD (3.15s)
PASS

Process finished with the exit code 0
```
