### PR TITLE
[Feat.] LTS Log Stream for DDS instance

### DIFF
--- a/acceptance/openstack/dds/v3/instances_test.go
+++ b/acceptance/openstack/dds/v3/instances_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dds/v3/instances"
 	ddsjob "github.com/opentelekomcloud/gophertelekomcloud/openstack/dds/v3/job"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dds/v3/logs"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/lts/v2/groups"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/lts/v2/streams"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/subnets"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
@@ -26,10 +29,100 @@ func TestDdsList(t *testing.T) {
 	th.AssertNoErr(t, err)
 }
 
-func TestDdsSingleLifeCycle(t *testing.T) {
+func TestDdsLtsLifeCycle(t *testing.T) {
 	client, err := clients.NewDdsV3Client()
 	th.AssertNoErr(t, err)
 
+	ltsclient, err := clients.NewLtsV2Client()
+	th.AssertNoErr(t, err)
+
+	name := tools.RandomString("test-group-", 3)
+	createOpts := groups.CreateOpts{
+		LogGroupName: name,
+		TTLInDays:    7,
+	}
+	t.Logf("Attempting to Create Log Group")
+	gr, err := groups.Create(ltsclient, createOpts)
+	th.AssertNoErr(t, err)
+
+	t.Cleanup(func() {
+		t.Logf("Attempting to Delete Log Group")
+		err = groups.Delete(ltsclient, gr)
+		th.AssertNoErr(t, err)
+	})
+
+	t.Logf("Attempting to Create Log Stream")
+	sname := tools.RandomString("test-stream-", 3)
+	stream, err := streams.Create(ltsclient, streams.CreateOpts{
+		GroupId:       gr,
+		LogStreamName: sname,
+	})
+	th.AssertNoErr(t, err)
+
+	t.Cleanup(func() {
+		t.Logf("Attempting to Delete Log Stream")
+		err = streams.Delete(ltsclient, streams.DeleteOpts{
+			GroupId:  gr,
+			StreamId: stream,
+		})
+		th.AssertNoErr(t, err)
+	})
+
+	t.Logf("Attempting to create DDSv3 single instance")
+	ddsInstance := createDdsSingleInstance(t, client)
+	t.Cleanup(func() {
+		deleteDdsInstance(t, client, ddsInstance.Id)
+	})
+
+	listOpts := instances.ListInstanceOpts{Id: ddsInstance.Id}
+	newDdsInstance, err := instances.List(client, listOpts)
+	th.AssertNoErr(t, err)
+	if newDdsInstance.TotalCount == 0 {
+		t.Fatalf("No DDSv3 instance was found: %s", err)
+	}
+	t.Log(newDdsInstance.Instances[0])
+
+	t.Logf("Attempting to Enable LTS logs for instance: %s", ddsInstance.Id)
+	logOpts := logs.CreateOpts{
+		LtsConfigs: []logs.Configs{
+			{
+				InstanceID:  ddsInstance.Id,
+				LogType:     "audit_log",
+				LtsGroupId:  gr,
+				LtsStreamId: stream,
+			},
+		},
+	}
+	err = logs.Create(client, logOpts)
+	th.AssertNoErr(t, err)
+
+	err = waitForInstanceAvailable(client, 600, ddsInstance.Id)
+	th.AssertNoErr(t, err)
+
+	t.Cleanup(func() {
+		t.Logf("Attempting to Disable LTS logs for instance: %s", ddsInstance.Id)
+		err = logs.Delete(client, logs.DeleteOpts{
+			LtsConfigs: []logs.LtsConfig{
+				{
+					InstanceID: ddsInstance.Id,
+					LogType:    "audit_log",
+				},
+			},
+		})
+		th.AssertNoErr(t, err)
+
+		err = waitForInstanceAvailable(client, 600, ddsInstance.Id)
+		th.AssertNoErr(t, err)
+	})
+	t.Logf("Attempting to List LTS logs for DDS instances")
+	list, err := logs.List(client, logs.ListOpts{})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, len(list.InstanceLtsConfigs) > 0)
+}
+
+func TestDdsSingleLifeCycle(t *testing.T) {
+	client, err := clients.NewDdsV3Client()
+	th.AssertNoErr(t, err)
 	t.Logf("Attempting to create DDSv3 single instance")
 	ddsInstance := createDdsSingleInstance(t, client)
 	defer deleteDdsInstance(t, client, ddsInstance.Id)

--- a/openstack/dds/v3/logs/Create.go
+++ b/openstack/dds/v3/logs/Create.go
@@ -1,0 +1,42 @@
+package logs
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type CreateOpts struct {
+	// Each item indicates an LTS configuration for the instance.
+	LtsConfigs []Configs `json:"lts_configs" required:"true"`
+}
+
+type Configs struct {
+	// DDS Instance ID, which can be obtained by calling the API for querying instances and details.
+	// If there are no instances available, create one by calling the API used for creating an instance.
+	InstanceID string `json:"instance_id" required:"true"`
+	// LTS log type. This parameter cannot be left empty.
+	// The only supported option is audit_log.
+	LogType string `json:"log_type" required:"true"`
+	// LTS log group ID.
+	// You can obtain the value using the LTS API for querying all log groups under an account.
+	LtsGroupId string `json:"lts_group_id" required:"true"`
+	// LTS log stream ID.
+	// You can obtain the value using the LTS API for querying all log streams in a specified log group.
+	LtsStreamId string `json:"lts_stream_id" required:"true"`
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (err error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	// POST https://{Endpoint}/v3/{project_id}/instances/logs/lts-configs
+	_, err = client.Post(client.ServiceURL("instances", "logs", "lts-configs"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	if err != nil {
+		return err
+	}
+	return
+}

--- a/openstack/dds/v3/logs/Delete.go
+++ b/openstack/dds/v3/logs/Delete.go
@@ -1,0 +1,37 @@
+package logs
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type DeleteOpts struct {
+	// List of LTS configurations to be disabled.
+	// To disable multiple log configurations for an instance, you need to specify multiple items.
+	LtsConfigs []LtsConfig `json:"lts_configs" required:"true"`
+}
+
+type LtsConfig struct {
+	// DDS Instance ID, which can be obtained by calling the API for querying instances and details.
+	// If there are no instances available, create one by calling the API used for creating an instance.
+	InstanceID string `json:"instance_id" required:"true"`
+	// LTS log type. This parameter cannot be left empty.
+	// The only supported option is audit_log.
+	LogType string `json:"log_type" required:"true"`
+}
+
+func Delete(client *golangsdk.ServiceClient, opts DeleteOpts) (err error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	// DELETE https://{Endpoint}/v3/{project_id}/instances/logs/lts-configs
+	_, err = client.DeleteWithBody(client.ServiceURL("instances", "logs", "lts-configs"), b, &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	if err != nil {
+		return err
+	}
+	return
+}

--- a/openstack/dds/v3/logs/List.go
+++ b/openstack/dds/v3/logs/List.go
@@ -1,0 +1,94 @@
+package logs
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListOpts struct {
+	// Index offset. If offset is set to N, the resource query starts from the N+1 piece of data.
+	// The default value is 0, indicating that the query starts from the first piece of data.
+	// The value must be a positive integer.
+	Offset *int `q:"offset"`
+	// Number of records to be queried. The value ranges from 0 to 50.
+	// If this parameter is not transferred,
+	// the log configurations of the first 50 DB instances are queried by default.
+	Limit *int `q:"limit"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListConfigs, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("instances", "logs", "lts-configs").
+		WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	// GET https://{Endpoint}/v3/{project_id}/instances/logs/lts-configs
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListConfigs
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListConfigs struct {
+	// LTS log configuration and brief information about each instance.
+	InstanceLtsConfigs []InstanceLtsConfigs `json:"instance_lts_configs"`
+	// Total number of cloud service log configurations that can be queried,
+	// which is equal to the total number of DDS instances.
+	TotalCount int `json:"total_count"`
+}
+
+type InstanceLtsConfigs struct {
+	// Brief information about an instance.
+	Instance *Instance `json:"instance"`
+	// LTS log configuration details. If no LTS log stream is configured, no response is returned for this field.
+	LtsConfigs []LtsConfigs `json:"lts_configs"`
+}
+
+type Instance struct {
+	// DDS Instance ID, which can be obtained by calling the API for querying instances and details.
+	// If there are no instances available, create one by calling the API used for creating an instance.
+	ID string `json:"id"`
+	// DDS Instance name.
+	Name string `json:"name"`
+	// Instance type, which can be single node, replica set, or cluster.
+	// Enumerated values:
+	// ReplicaSingle
+	// ReplicaSet
+	// Sharding
+	Mode string `json:"mode"`
+	// DB engine and version of the DB instance.
+	Datastore *Datastore `json:"datastore"`
+	// Instance status.
+	Status string `json:"status"`
+	// ID of the enterprise project to which the instance belongs.
+	// For the default enterprise project, the value is 0.
+	// For other enterprise projects, see Enterprise Management User Guide.
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// All actions that are being executed on an instance.
+	Actions []string `json:"actions"`
+}
+
+type LtsConfigs struct {
+	// LTS log type. This parameter cannot be left empty.
+	// The only supported option is audit_log.
+	LogType string `json:"log_type"`
+	// LTS log group ID.
+	LtsGroupId string `json:"lts_group_id"`
+	// LTS log stream ID.
+	LtsStreamId string `json:"lts_stream_id"`
+	// Indicates whether to upload logs to LTS.
+	Enabled bool `json:"enabled"`
+}
+
+type Datastore struct {
+	// DB engine. The value is mongodb.
+	Type string `json:"type"`
+	// Database major version.
+	Version string `json:"version"`
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Implements: 
https://docs.otc.t-systems.com/document-database-service/api-ref/apis_v3.0_recommended/db_instance_management/associating_an_instance_with_an_lts_log_stream.html

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
```
=== RUN   TestDdsLtsLifeCycle
    instances_test.go:44: Attempting to Create Log Group
    instances_test.go:54: Attempting to Create Log Stream
    instances_test.go:71: Attempting to create DDSv3 single instance
    instances_test.go:370: DDSv3 replica set instance successfully created
    instances_test.go:83: {74d64f1c234941b7943c4860f7701d62in02 dds-acc-l8swIcsZ  normal 8635 Single eu-de {DDS-Community 4.0 } wiredTiger 2025-05-20T08:01:09 2025-05-20T08:01:08 rwuser 0 e08d64a9-3c6e-494d-a1eb-20c2446b8a28 a2d7c9f1-7fd9-4943-af53-352538943ab3 e76e5a0f-0b2b-4b2f-b2a4-641f494cd51f {08:00-09:00 0x140003a2250 } 14:00-18:00 [{single    {20 0.2934303283691406} [{4141aeae357142628f120681ca2409bcno02 dds-acc-l8swIcsZ_single_node_1 normal Primary 10.0.53.185  dds.mongodb.s2.medium.4.single eu-de-03}]}]   [] 0 []}
    instances_test.go:85: Attempting to Enable LTS logs for instance: 74d64f1c234941b7943c4860f7701d62in02
    instances_test.go:117: Attempting to List LTS logs for DDS instances
    instances_test.go:103: Attempting to Disable LTS logs for instance: 74d64f1c234941b7943c4860f7701d62in02
    instances_test.go:507: Attempting to delete DDSv3 instance: 74d64f1c234941b7943c4860f7701d62in02
    instances_test.go:517: DDSv3 instance deleted successfully: 74d64f1c234941b7943c4860f7701d62in02
    instances_test.go:63: Attempting to Delete Log Stream
    instances_test.go:49: Attempting to Delete Log Group
--- PASS: TestDdsLtsLifeCycle (332.20s)
PASS

Process finished with the exit code 0
```