### PR TITLE
Css new funcs

### DIFF
--- a/acceptance/openstack/css/v1/cluster_logging_test.go
+++ b/acceptance/openstack/css/v1/cluster_logging_test.go
@@ -1,0 +1,132 @@
+package v1
+
+import (
+	"log"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/css/v1/clusters"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/css/v1/logs"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestCSSLoggingFullLifecycle(t *testing.T) {
+	clusterID := clients.EnvOS.GetEnv("CSS_CLUSTER_ID")
+	if clusterID == "" {
+		t.Skip("`OS_CSS_CLUSTER_ID` must be defined")
+	}
+	agency := clients.EnvOS.GetEnv("AGENCY_NAME")
+	if agency == "" {
+		t.Skipf("OS_AGENCY_NAME is required for this test")
+	}
+	bucketName := clients.EnvOS.GetEnv("BUCKET_NAME")
+	if bucketName == "" {
+		t.Skipf("OS_BUCKET_NAME is required for this test")
+	}
+	period := clients.EnvOS.GetEnv("LOG_STARTING_PERIOD")
+	if period == "" {
+		t.Skip("`OS_LOG_STARTING_PERIOD` must be defined")
+	}
+
+	client, err := clients.NewCssV1Client()
+	th.AssertNoErr(t, err)
+
+	got, err := logs.GetConfiguration(client, clusterID)
+	th.AssertNoErr(t, err)
+
+	log.Println("CSS log configuration:")
+
+	tools.PrintResource(t, got)
+
+	th.AssertNoErr(t, clusters.WaitForCluster(client, clusterID, timeout))
+
+	if got.LogSwitch {
+		log.Println("The logging has been already enabled.")
+
+	} else {
+
+		basicOpts := logs.EnableLogsOpts{
+			Agency:   agency,
+			Bucket:   bucketName,
+			BasePath: "css/log",
+		}
+
+		err = logs.EnableLogs(client, clusterID, basicOpts)
+		th.AssertNoErr(t, err)
+
+		log.Println("Cluster logging enabled.")
+
+		th.AssertNoErr(t, clusters.WaitForCluster(client, clusterID, timeout))
+	}
+
+	if got.AutoEnable {
+		log.Println("Cluster automatic backup for CSS logging has been already enabled.")
+	} else {
+
+		opts := logs.EnableAutomaticBackupOpts{
+			Period: period,
+		}
+
+		err = logs.EnableAutomaticBackups(client, clusterID, opts)
+		th.AssertNoErr(t, err)
+		log.Println("Cluster automatic backup for CSS logging enabled.")
+
+		th.AssertNoErr(t, clusters.WaitForCluster(client, clusterID, timeout))
+	}
+
+	err = logs.DisableAutomaticBackups(client, clusterID)
+	th.AssertNoErr(t, err)
+
+	log.Println("Cluster automatic backup for CSS logging disabled.")
+
+	th.AssertNoErr(t, clusters.WaitForCluster(client, clusterID, timeout))
+
+	err = logs.DisableLogs(client, clusterID)
+	th.AssertNoErr(t, err)
+
+	log.Println("Cluster logging disabled.")
+
+	th.AssertNoErr(t, clusters.WaitForCluster(client, clusterID, timeout))
+}
+
+func TestGetCSSLoggingConfiguration(t *testing.T) {
+	clusterID := clients.EnvOS.GetEnv("CSS_CLUSTER_ID")
+	if clusterID == "" {
+		t.Skip("`OS_CSS_CLUSTER_ID` must be defined")
+	}
+
+	client, err := clients.NewCssV1Client()
+	th.AssertNoErr(t, err)
+
+	got, err := logs.GetConfiguration(client, clusterID)
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, got)
+}
+
+func TestUpdateCSSLoggingConfigurations(t *testing.T) {
+	clusterID := clients.EnvOS.GetEnv("CSS_CLUSTER_ID")
+	if clusterID == "" {
+		t.Skip("`OS_CSS_CLUSTER_ID` must be defined")
+	}
+	agency := clients.EnvOS.GetEnv("AGENCY_NAME")
+	if agency == "" {
+		t.Skipf("OS_AGENCY_NAME is required for this test")
+	}
+	bucketName := clients.EnvOS.GetEnv("BUCKET_NAME")
+	if bucketName == "" {
+		t.Skipf("OS_BUCKET_NAME is required for this test")
+	}
+
+	client, err := clients.NewCssV1Client()
+	th.AssertNoErr(t, err)
+
+	updatedOpts := logs.UpdateLogConfigurationOpts{
+		Agency:   agency,
+		Bucket:   bucketName,
+		BasePath: "css/log",
+	}
+
+	err = logs.UpdateLogs(client, clusterID, updatedOpts)
+	th.AssertNoErr(t, err)
+}

--- a/acceptance/openstack/css/v1/vpcep_connections_test.go
+++ b/acceptance/openstack/css/v1/vpcep_connections_test.go
@@ -1,0 +1,66 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/css/v1/clusters"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/css/v1/vpc_endpoint"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestVpcepConnection(t *testing.T) {
+	clusterID := clients.EnvOS.GetEnv("CSS_CLUSTER_ID")
+	if clusterID == "" {
+		t.Skip("CSS_CLUSTER_ID must be defined")
+	}
+
+	client, err := clients.NewCssV1Client()
+	th.AssertNoErr(t, err)
+
+	enablePriv := true
+	err = vpc_endpoint.Enable(client, clusterID, vpc_endpoint.EnableOpts{
+		EndpointWithDnsName: &enablePriv,
+	})
+	th.AssertNoErr(t, err)
+
+	th.AssertNoErr(t, clusters.WaitForCluster(client, clusterID, 1200))
+
+	connections, err := vpc_endpoint.ListConnections(client, clusterID)
+	th.AssertNoErr(t, err)
+
+	if len(connections) == 0 {
+		t.Error("no VPC endpoint connections found")
+		return
+	}
+
+	if connections[0].ID == "" {
+		t.Error("first VPC endpoint connection has empty ID")
+		return
+	}
+
+	t.Logf("First VPC endpoint connection ID: %s\n", connections[0].ID)
+
+	err = vpc_endpoint.Action(client, clusterID, vpc_endpoint.ActionOpts{
+		Action:    "reject",
+		Endpoints: []string{connections[0].ID},
+	})
+	th.AssertNoErr(t, err)
+
+	err = vpc_endpoint.Action(client, clusterID, vpc_endpoint.ActionOpts{
+		Action:    "receive",
+		Endpoints: []string{connections[0].ID},
+	})
+	th.AssertNoErr(t, err)
+
+	// UpdateWhitelist
+	err = vpc_endpoint.UpdateWhitelist(client, clusterID, vpc_endpoint.UpdateWhitelistOpts{
+		Permissions: []string{"682024355ec84ae89cf872c42c25de76"},
+	})
+	th.AssertNoErr(t, err)
+
+	err = vpc_endpoint.Disable(client, clusterID)
+	th.AssertNoErr(t, err)
+
+	th.AssertNoErr(t, clusters.WaitForCluster(client, clusterID, 1200))
+}

--- a/openstack/css/v1/logs/DisableAutomaticBackup.go
+++ b/openstack/css/v1/logs/DisableAutomaticBackup.go
@@ -1,0 +1,13 @@
+package logs
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+// DisableAutomaticBackups function will disable the automatic log backup policy for a CSS cluster.
+func DisableAutomaticBackups(client *golangsdk.ServiceClient, clusterID string) error {
+	_, err := client.Put(client.ServiceURL("clusters", clusterID, "logs", "policy", "close"), nil, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return err
+}

--- a/openstack/css/v1/logs/DisableLogs.go
+++ b/openstack/css/v1/logs/DisableLogs.go
@@ -1,0 +1,13 @@
+package logs
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+// DisableLogs function will disable the log option for a CSS cluster.
+func DisableLogs(client *golangsdk.ServiceClient, clusterID string) error {
+	_, err := client.Put(client.ServiceURL("clusters", clusterID, "logs", "close"), nil, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return err
+}

--- a/openstack/css/v1/logs/EnableAutomaticBackup.go
+++ b/openstack/css/v1/logs/EnableAutomaticBackup.go
@@ -1,0 +1,31 @@
+package logs
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type EnableAutomaticBackupOpts struct {
+	// This parameter passed to the logs.EnableAutomaticBackups function.
+	// Period is the start time of a backup job.
+	Period string `json:"period" required:"true"`
+}
+
+// EnableAutomaticBackups will enable the automatic log backup policy for the cluster based on EnableAutomaticBackupOpts.
+func EnableAutomaticBackups(client *golangsdk.ServiceClient, clusterID string, opts EnableAutomaticBackupOpts) error {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	url := client.ServiceURL("clusters", clusterID, "logs", "policy", "update")
+
+	_, err = client.Post(url, b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	})
+
+	return err
+}

--- a/openstack/css/v1/logs/EnableLogs.go
+++ b/openstack/css/v1/logs/EnableLogs.go
@@ -1,0 +1,35 @@
+package logs
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type EnableLogsOpts struct {
+	// These parameters are passed to the logs.EnableLogs function.
+	// Agency is the agency name used for the css cluster.
+	Agency string `json:"agency" required:"true"`
+	// BasePath is the obs path where the logs should be stored for the css cluster.
+	BasePath string `json:"logBasePath" required:"true"`
+	// Bucket is the obs bucket name to store the logs for the css cluster.
+	Bucket string `json:"logBucket" required:"true"`
+}
+
+// EnableLogs function is used to enable the log switch of a CSS cluster base on EnableLogsOpts.
+func EnableLogs(client *golangsdk.ServiceClient, clusterID string, opts EnableLogsOpts) error {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	url := client.ServiceURL("clusters", clusterID, "logs", "open")
+
+	_, err = client.Post(url, b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	})
+
+	return err
+}

--- a/openstack/css/v1/logs/GetConfiguration.go
+++ b/openstack/css/v1/logs/GetConfiguration.go
@@ -1,0 +1,40 @@
+package logs
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type LogConfiguration struct {
+	// These parameters are passed to the logs.GetLogConfiguration function.
+	// Log backup ID.
+	ID string `json:"id"`
+	// CSS cluster ID.
+	ClusterID string `json:"clusterId"`
+	// The bucket where the logs should be stored.
+	ObsBucket string `json:"obsBucket"`
+	// The agency name.
+	Agency string `json:"agency"`
+	// Update time.
+	UpdateAt int `json:"updateAt"`
+	// Storage path of backup logs in the OBS bucket.
+	BasePath string `json:"basePath"`
+	// Indicates whether to enable automatic backup.
+	AutoEnable bool `json:"autoEnable"`
+	// Start time of automatic log backup.
+	Period string `json:"period"`
+	// Indicates whether to enable the log function.
+	LogSwitch bool `json:"logSwitch"`
+}
+
+// GetConfiguration function will query the details of CSS cluster logging and returns a LogConfiguration object.
+func GetConfiguration(client *golangsdk.ServiceClient, clusterID string) (*LogConfiguration, error) {
+	raw, err := client.Get(client.ServiceURL("clusters", clusterID, "logs", "settings"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res LogConfiguration
+	err = extract.IntoStructPtr(raw.Body, &res, "logConfiguration")
+	return &res, err
+}

--- a/openstack/css/v1/logs/UpdateLogs.go
+++ b/openstack/css/v1/logs/UpdateLogs.go
@@ -1,0 +1,29 @@
+package logs
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type UpdateLogConfigurationOpts struct {
+	// These parameters are passed to the logs.UpdateLogs function.
+	// Agency is the agency name used for the css cluster.
+	Agency string `json:"agency" required:"true"`
+	// BasePath is the obs path where the logs should be stored for the css cluster.
+	BasePath string `json:"logBasePath" required:"true"`
+	// Bucket is the obs bucket name to store the logs for the css cluster.
+	Bucket string `json:"logBucket" required:"true"`
+}
+
+// UpdateLogs will change the cluster logging configurations based on UpdateLogConfigurationOpts.
+func UpdateLogs(client *golangsdk.ServiceClient, clusterID string, opts UpdateLogConfigurationOpts) error {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Post(client.ServiceURL("clusters", clusterID, "logs", "settings"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return err
+}

--- a/openstack/css/v1/vpc_endpoint/Action.go
+++ b/openstack/css/v1/vpc_endpoint/Action.go
@@ -1,0 +1,35 @@
+package vpc_endpoint
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type ActionOpts struct {
+	// Specifies whether to accept or reject a VPC endpoint for a VPC endpoint service.
+	// receive: means to accept the VPC endpoint.
+	// reject: means to reject the VPC endpoint.
+	Action string `json:"action" required:"true"`
+	// Lists VPC endpoint IDs.
+	// Each request accepts or rejects only one VPC endpoint
+	Endpoints []string `json:"endpointIdList" required:"true"`
+}
+
+// Accept or Reject VPC Endpoint Connection
+func Action(client *golangsdk.ServiceClient, clusterID string, opts ActionOpts) error {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	url := client.ServiceURL("clusters", clusterID, "vpcepservice", "connections")
+
+	_, err = client.Post(url, b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	})
+
+	return err
+}

--- a/openstack/css/v1/vpc_endpoint/Disable.go
+++ b/openstack/css/v1/vpc_endpoint/Disable.go
@@ -1,0 +1,13 @@
+package vpc_endpoint
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+// EnableVpcEndpoint function is used to Disable VCP endpoint of the cluster.
+func Disable(client *golangsdk.ServiceClient, clusterID string) error {
+	_, err := client.Put(client.ServiceURL("clusters", clusterID, "vpcepservice", "close"), nil, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return err
+}

--- a/openstack/css/v1/vpc_endpoint/Enable.go
+++ b/openstack/css/v1/vpc_endpoint/Enable.go
@@ -1,0 +1,25 @@
+package vpc_endpoint
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type EnableOpts struct {
+	// Indicates whether to enable the internal DNS name .
+	EndpointWithDnsName *bool `json:"endpointWithDnsName"`
+}
+
+// EnableVpcEndpoint function is used to Enable VCP endpoint of the cluster.
+func Enable(client *golangsdk.ServiceClient, clusterID string, opts EnableOpts) error {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+	url := client.ServiceURL("clusters", clusterID, "vpcepservice", "open")
+	_, err = client.Post(url, b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return err
+}

--- a/openstack/css/v1/vpc_endpoint/List.go
+++ b/openstack/css/v1/vpc_endpoint/List.go
@@ -1,0 +1,28 @@
+package vpc_endpoint
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// List VPC Endpoint Connections
+func ListConnections(client *golangsdk.ServiceClient, id string) ([]ConnectionResp, error) {
+	raw, err := client.Get(client.ServiceURL("clusters", id, "vpcepservice", "connections"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res []ConnectionResp
+	err = extract.IntoSlicePtr(raw.Body, &res, "connections")
+	return res, err
+}
+
+type ConnectionResp struct {
+	ID                string `json:"id"`
+	Status            string `json:"status"`
+	MaxSession        string `json:"maxSession"`
+	SpecificationName string `json:"specificationName"`
+	CreatedAt         string `json:"created_at"`
+	UpdatedAt         string `json:"update_at"`
+	DomainId          string `json:"domain_id"`
+}

--- a/openstack/css/v1/vpc_endpoint/Whitelist.go
+++ b/openstack/css/v1/vpc_endpoint/Whitelist.go
@@ -1,0 +1,31 @@
+package vpc_endpoint
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type UpdateWhitelistOpts struct {
+	// List of Tenant IDs to whitelist
+	Permissions []string `json:"vpcPermissions" required:"true"`
+}
+
+// Modifying the VPC Endpoint Service Whitelist
+func UpdateWhitelist(client *golangsdk.ServiceClient, clusterID string, opts UpdateWhitelistOpts) error {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	// POST /v1.0/{project_id}/clusters/{cluster_id}/vpcepservice/permissions
+	url := client.ServiceURL("clusters", clusterID, "vpcepservice", "permissions")
+
+	_, err = client.Post(url, b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	})
+
+	return err
+}


### PR DESCRIPTION
Added CSS VPC Endpoint and Logging Functions.

Updates Files:

- openstack/css/v1/logs/DisableAutomaticBackup.go
- openstack/css/v1/logs/DisableLogs.go
- openstack/css/v1/logs/EnableAutomaticBackup.go
- openstack/css/v1/logs/EnableLogs.go
- openstack/css/v1/logs/GetConfiguration.go
- openstack/css/v1/logs/UpdateLogs.go
- openstack/css/v1/vpc_endpoint/Action.go
- openstack/css/v1/vpc_endpoint/Disable.go
- openstack/css/v1/vpc_endpoint/Enable.go
- openstack/css/v1/vpc_endpoint/List.go
- openstack/css/v1/vpc_endpoint/Whitelist.go

Tests:

- acceptance/openstack/css/v1/cluster_logging_test.go
- acceptance/openstack/css/v1/vpcep_connections_test.go
