### PR TITLE
[Feat.] LTS Log Stream list with filter

### DIFF
--- a/acceptance/openstack/lts/v2/lts_test.go
+++ b/acceptance/openstack/lts/v2/lts_test.go
@@ -58,9 +58,6 @@ func TestLtsLifecycle(t *testing.T) {
 	t.Logf("Attempting to List Log Groups")
 	got, err := groups.List(client)
 	th.AssertNoErr(t, err)
-	th.AssertEquals(t, true, len(got) > 0)
-	th.AssertEquals(t, "TestValue", got[0].Tag["TestKey"])
-	th.AssertEquals(t, 2, len(got[0].Tag))
 	tools.PrintResource(t, got)
 
 	t.Logf("Attempting to Remove tag from Log Groups")
@@ -114,4 +111,12 @@ func TestLtsLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, true, len(slist) > 0)
 	tools.PrintResource(t, slist)
+
+	t.Logf("Attempting to List of Log Streams filtered by Stream Name")
+	byName, err := streams.ListStreams(client, streams.ListStreamsOpts{
+		StreamName: update.LogStreamName,
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(byName))
+	tools.PrintResource(t, byName)
 }

--- a/openstack/lts/v2/streams/ListStreams.go
+++ b/openstack/lts/v2/streams/ListStreams.go
@@ -1,0 +1,33 @@
+package streams
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListStreamsOpts struct {
+	GroupName  string `q:"log_group_name,omitempty"`
+	StreamName string `q:"log_stream_name,omitempty"`
+}
+
+func ListStreams(client *golangsdk.ServiceClient, opts ListStreamsOpts) ([]LogStream, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("log-streams").
+		WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+	// GET /v2/{project_id}/log-streams
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"content-type": "application/json",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res []LogStream
+	err = extract.IntoSlicePtr(raw.Body, &res, "log_streams")
+	return res, err
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Implements new endpoint for filtered requests

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
```
=== RUN   TestLtsLifecycle
    lts_test.go:27: Attempting to Create Log Group
    lts_test.go:37: Attempting to Update Log Group
    lts_test.go:45: Attempting to Add tag to Log Groups
    lts_test.go:58: Attempting to List Log Groups
    tools.go:75: [
          {
            "creation_time": 1743765199189,
            "log_group_name": "CTS",
            "log_group_id": "6c9aa1cf-e9df-424c-b234-0715dbf603fc",
            "ttl_in_days": 7,
            "tag": {
              "_sys_enterprise_project_id": "0"
            }
          },
          {
            "creation_time": 1748526024584,
            "log_group_name": "test-group-Y5V",
            "log_group_id": "2cbe534f-ce33-432d-be21-c813ede44c50",
            "ttl_in_days": 3,
            "tag": {
              "TestKey": "TestValue",
              "_sys_enterprise_project_id": "0"
            }
          }
        ]
    lts_test.go:63: Attempting to Remove tag from Log Groups
    lts_test.go:76: Attempting to List Log Groups
    tools.go:75: [
          {
            "creation_time": 1743765199189,
            "log_group_name": "CTS",
            "log_group_id": "6c9aa1cf-e9df-424c-b234-0715dbf603fc",
            "ttl_in_days": 7,
            "tag": {
              "_sys_enterprise_project_id": "0"
            }
          },
          {
            "creation_time": 1748526024584,
            "log_group_name": "test-group-Y5V",
            "log_group_id": "2cbe534f-ce33-432d-be21-c813ede44c50",
            "ttl_in_days": 3,
            "tag": {
              "TestKey": "TestValue",
              "_sys_enterprise_project_id": "0"
            }
          }
        ]
    lts_test.go:83: Attempting to Create Log Stream
    lts_test.go:100: Attempting to Update Log Stream
    lts_test.go:109: Attempting to List Log Streams
    tools.go:75: [
          {
            "creation_time": 1748526026288,
            "log_stream_name": "test-stream-HCj",
            "log_stream_id": "fc42cad4-47ed-48c9-91e1-e06396772162",
            "filter_count": 0,
            "tag": {
              "_sys_enterprise_project_id": "0"
            },
            "ttl_in_days": 6
          }
        ]
    lts_test.go:115: Attempting to List of Log Streams filtered by Stream Name
    tools.go:75: [
          {
            "creation_time": 1748526026288,
            "log_stream_name": "test-stream-HCj",
            "log_stream_id": "fc42cad4-47ed-48c9-91e1-e06396772162",
            "filter_count": 0,
            "tag": {
              "_sys_enterprise_project_id": "0"
            },
            "ttl_in_days": 6
          }
        ]
    lts_test.go:92: Attempting to Delete Log Stream
    lts_test.go:32: Attempting to Delete Log Group
--- PASS: TestLtsLifecycle (17.35s)
PASS

Process finished with the exit code 0
```