### PR TITLE
[Feat] ECS: Add Ipv6Enable to ECS create opts

### DIFF
--- a/acceptance/openstack/ecs/v1/cloudservers_test.go
+++ b/acceptance/openstack/ecs/v1/cloudservers_test.go
@@ -114,3 +114,71 @@ func TestCloudServersRandomAzLifecycle(t *testing.T) {
 
 	tools.PrintResource(t, ecs)
 }
+
+func TestCloudServersIPV6(t *testing.T) {
+	client, err := clients.NewComputeV1Client()
+	th.AssertNoErr(t, err)
+
+	prefix := "ecs-"
+	ecsName := tools.RandomString(prefix, 3)
+	imageName := "Standard_Debian_11_latest"
+	flavorID := "s3.large.2"
+
+	vpcID := clients.EnvOS.GetEnv("VPC_ID")
+	subnetID := clients.EnvOS.GetEnv("IPV6_ENABLED_NETWORK_ID")
+
+	imageV2Client, err := clients.NewIMSV2Client()
+	th.AssertNoErr(t, err)
+
+	image, err := images.ListImages(imageV2Client, images.ListImagesOpts{
+		Name: imageName,
+	})
+	th.AssertNoErr(t, err)
+	if len(image) == 0 {
+		t.Skip("Change image query filter, no results returned")
+	}
+	if vpcID == "" || subnetID == "" {
+		t.Skip("One of OS_VPC_ID, OS_IPV6_ENABLED_NETWORK_ID env vars is missing but ECSv1 test requires")
+	}
+
+	// Get ECSv1 createOpts
+	createOpts := cloudservers.CreateOpts{
+		ImageRef:  image[0].Id,
+		FlavorRef: flavorID,
+		Name:      ecsName,
+		VpcId:     vpcID,
+		Nics: []cloudservers.Nic{
+			{
+				SubnetId:   subnetID,
+				Ipv6Enable: true,
+			},
+		},
+		RootVolume: cloudservers.RootVolume{
+			VolumeType: "SSD",
+		},
+		DataVolumes: []cloudservers.DataVolume{
+			{
+				VolumeType: "SSD",
+				Size:       20,
+			},
+		},
+	}
+
+	// Check ECSv1 createOpts
+	openstack.DryRunCloudServerConfig(t, client, createOpts)
+	t.Logf("CreateOpts are ok for creating a cloudServer")
+
+	// Create ECSv1 instance
+	ecs := openstack.CreateCloudServer(t, client, createOpts)
+	defer openstack.DeleteCloudServer(t, client, ecs.ID)
+
+	ipv6enabled := false
+	for _, addresses := range ecs.Addresses {
+		for _, addr := range addresses {
+			if addr.Version == "6" {
+				ipv6enabled = true
+			}
+		}
+	}
+	th.AssertEquals(t, true, ipv6enabled)
+}

--- a/openstack/ecs/v1/cloudservers/requests.go
+++ b/openstack/ecs/v1/cloudservers/requests.go
@@ -3,7 +3,7 @@ package cloudservers
 import (
 	"encoding/base64"
 
-	"github.com/opentelekomcloud/gophertelekomcloud"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 )
 
 type CreateOpts struct {
@@ -109,6 +109,12 @@ type Nic struct {
 
 	// ExtraDhcpOpts indicates extended DHCP options.
 	ExtraDhcpOpts []ExtraDhcpOpts `json:"extra_dhcp_opts,omitempty"`
+
+	// Specifies whether to support IPv6 addresses. If this parameter is set to true, the NIC supports IPv6 addresses.
+	Ipv6Enable bool `json:"ipv6_enable,omitempty"`
+
+	// Specifies the bound shared bandwidth
+	Ipv6Bandwidth Ipv6Bandwidth `json:"ipv6_bandwidth,omitempty"`
 }
 
 type BindingProfile struct {
@@ -122,6 +128,11 @@ type ExtraDhcpOpts struct {
 
 	// OptValue specifies the NIC MTU, which ranges from 1280 to 8888.
 	OptValue int `json:"opt_value" required:"true"`
+}
+
+type Ipv6Bandwidth struct {
+	// Specifies the ID of an IPv6 bandwidth.
+	Id string `json:"id,omitempty"`
 }
 
 type PublicIp struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it

Add option to enable ipv6 in ecs

### Tests

```
=== RUN   TestCloudServersIPV6
    common.go:190: Attempting to check ECSv1 createOpts
    cloudservers_test.go:169: CreateOpts are ok for creating a cloudServer
    cloudservers_test.go:172: Attempting to create ECSv1
    cloudservers_test.go:172: Created ECSv1 instance: 1b537ff2-eddd-4103-89ff-5cbee4e66e04
    common.go:216: Attempting to delete ECSv1: 1b537ff2-eddd-4103-89ff-5cbee4e66e04
    common.go:233: ECSv1 instance deleted: 1b537ff2-eddd-4103-89ff-5cbee4e66e04
--- PASS: TestCloudServersIPV6 (71.30s)
PASS
```