### PR TITLE
CBR: vault lock

### DIFF
--- a/acceptance/openstack/cbr/v3/vaults_test.go
+++ b/acceptance/openstack/cbr/v3/vaults_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cbr/v3/policies"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cbr/v3/vaults"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
 
@@ -25,6 +26,7 @@ func TestVaultLifecycle(t *testing.T) {
 		Description: "gophertelemocloud testing vault",
 		Name:        tools.RandomString("cbr-test-", 5),
 		Resources:   []vaults.ResourceCreate{},
+		Locked:      pointerto.Bool(true),
 	}
 	vault, err := vaults.Create(client, opts)
 	th.AssertNoErr(t, err)

--- a/openstack/cbr/v3/vaults/Create.go
+++ b/openstack/cbr/v3/vaults/Create.go
@@ -74,6 +74,8 @@ type CreateOpts struct {
 	// Whether to automatically expand the vault capacity.
 	// Only pay-per-use vaults support this function.
 	AutoExpand bool `json:"auto_expand,omitempty"`
+	// Whether the vault is locked. A locked vault cannot be unlocked.
+	Locked *bool `json:"locked,omitempty"`
 }
 
 func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*Vault, error) {

--- a/openstack/cbr/v3/vaults/Update.go
+++ b/openstack/cbr/v3/vaults/Update.go
@@ -22,6 +22,7 @@ type UpdateOpts struct {
 	AutoBind   *bool           `json:"auto_bind,omitempty"`
 	BindRules  *VaultBindRules `json:"bind_rules,omitempty"`
 	AutoExpand *bool           `json:"auto_expand,omitempty"`
+	Locked     *bool           `json:"locked,omitempty"`
 }
 
 func Update(client *golangsdk.ServiceClient, id string, opts UpdateOpts) (*Vault, error) {

--- a/openstack/cbr/v3/vaults/results.go
+++ b/openstack/cbr/v3/vaults/results.go
@@ -46,4 +46,5 @@ type Vault struct {
 	UserID      string             `json:"user_id"`
 	CreatedAt   string             `json:"created_at"`
 	AutoExpand  bool               `json:"auto_expand"`
+	Locked      bool               `json:"locked"`
 }


### PR DESCRIPTION
### Acceptance tests
```
=== RUN   TestVaultLifecycle
--- PASS: TestVaultLifecycle (3.37s)
PASS

Process finished with the exit code 0
```
