### PR TITLE
[Feat.] ER list quotas

### DIFF
--- a/acceptance/openstack/er/quota_test.go
+++ b/acceptance/openstack/er/quota_test.go
@@ -1,0 +1,23 @@
+package er
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/quota"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestQuotasList(t *testing.T) {
+	client, err := clients.NewERClient()
+	th.AssertNoErr(t, err)
+
+	listOpts := quota.ListOpts{}
+	quotas, err := quota.List(client, listOpts)
+	th.AssertNoErr(t, err)
+
+	for _, q := range quotas {
+		tools.PrintResource(t, q)
+	}
+}

--- a/openstack/er/v3/quota/List.go
+++ b/openstack/er/v3/quota/List.go
@@ -1,0 +1,58 @@
+package quota
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListOpts struct {
+	// You can query the quotas of the following resources:
+	// er_instance: total and used quotas of enterprise routers
+	// vpc_attachment: total and used quotas of VPC attachments
+	// route_table: total and used quotas of route tables
+	// static_route: total and used quotas of static routes
+	// vpc_er: total and used quotas of enterprise routers that a VPC can be attached to
+	// flow_log: total and used quotas of flow logs that can be created for each attachment
+	// dc_attachment: total and used quotas of Direct Connect gateway attachments
+	// vpn_attachment: total and used quotas of VPN gateway attachments
+	// connect_attachment: total and used quotas of Connect gateway attachments. This type of attachments is not supported now.
+	// peering_attachment: total and used quotas of peering connection attachments. This type of attachments is not supported now.
+	// can_attachment: total and used quotas of intelligent access gateway attachments. This type of attachments is not supported now.
+	Type []string `q:"type"`
+	// Enterprise router ID
+	InstanceID string `q:"erId"`
+	// Route table ID
+	RouteTableID string `q:"routeTableId"`
+	// VPC ID
+	VpcID string `q:"vpcId"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]QuotaResponse, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("enterprise-router", "quotas").
+		WithQueryParams(&opts).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res []QuotaResponse
+	err = extract.IntoSlicePtr(raw.Body, &res, "quotas")
+	return res, err
+}
+
+type QuotaResponse struct {
+	// Quota type
+	Type string `json:"quota_key"`
+	// Available quota. The value -1 indicates that there is no quota limit.
+	AvailableQuota int64 `json:"quota_limit"`
+	// Used quota
+	UsedQuota int64 `json:"used"`
+	// Measurement unit of used quotas
+	Unit string `json:"unit"`
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Implements: https://docs.otc.t-systems.com/enterprise-router/api-ref/apis/quota_management/querying_quotas.html#showquotas
### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
```
=== RUN   TestQuotasList
    tools.go:75: {
          "quota_key": "can_attachment",
          "quota_limit": 10,
          "used": 0,
          "unit": "count"
        }
    tools.go:75: {
          "quota_key": "connect_attachment",
          "quota_limit": 20,
          "used": 0,
          "unit": "count"
        }
    tools.go:75: {
          "quota_key": "dc_attachment",
          "quota_limit": 10,
          "used": 0,
          "unit": "count"
        }
    tools.go:75: {
          "quota_key": "er_instance",
          "quota_limit": 1,
          "used": 0,
          "unit": "count"
        }
    tools.go:75: {
          "quota_key": "flow_log",
          "quota_limit": 20,
          "used": 0,
          "unit": "count"
        }
    tools.go:75: {
          "quota_key": "multicast_domain",
          "quota_limit": 20,
          "used": 0,
          "unit": "count"
        }
    tools.go:75: {
          "quota_key": "multicast_domain_association",
          "quota_limit": 200,
          "used": 0,
          "unit": "count"
        }
    tools.go:75: {
          "quota_key": "peering_attachment",
          "quota_limit": 10,
          "used": 0,
          "unit": "count"
        }
    tools.go:75: {
          "quota_key": "route_table",
          "quota_limit": 20,
          "used": 0,
          "unit": "count"
        }
    tools.go:75: {
          "quota_key": "static_route",
          "quota_limit": 500,
          "used": 0,
          "unit": "count"
        }
    tools.go:75: {
          "quota_key": "vpc_attachment",
          "quota_limit": 300,
          "used": 0,
          "unit": "count"
        }
    tools.go:75: {
          "quota_key": "vpn_attachment",
          "quota_limit": 10,
          "used": 0,
          "unit": "count"
        }
--- PASS: TestQuotasList (0.57s)
PASS

Process finished with the exit code 0
```