### PR TITLE
[OBS]: Implement `filter` option for lifecycle rules

### DIFF
--- a/acceptance/openstack/dis/v2/dis_test.go
+++ b/acceptance/openstack/dis/v2/dis_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestDISWorkflow(t *testing.T) {
-	t.Skip("Api error - net/http: TLS handshake timeout")
+	t.Skip("Servce reached EOL")
 	client, err := clients.NewDisV2Client()
 	th.AssertNoErr(t, err)
 	now := time.Now()
@@ -199,7 +199,7 @@ func TestDISWorkflow(t *testing.T) {
 }
 
 func TestDISDumpWorkflow(t *testing.T) {
-	t.Skip("Need to create dis_admin_agency first")
+	t.Skip("Servce reached EOL")
 	client, err := clients.NewDisV2Client()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/dis/v2/dis_test.go
+++ b/acceptance/openstack/dis/v2/dis_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestDISWorkflow(t *testing.T) {
+	t.Skip("Api error - net/http: TLS handshake timeout")
 	client, err := clients.NewDisV2Client()
 	th.AssertNoErr(t, err)
 	now := time.Now()

--- a/acceptance/openstack/obs/v1/bucket/obs_lifecycle_test.go
+++ b/acceptance/openstack/obs/v1/bucket/obs_lifecycle_test.go
@@ -10,7 +10,7 @@ import (
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
 
-func TestObsBucketLifecycleConfiguration(t *testing.T) {
+func TestObsBucketLifecycleConfigurationBasic(t *testing.T) {
 	client, err := clients.NewOBSClient()
 	th.AssertNoErr(t, err)
 
@@ -52,6 +52,71 @@ func TestObsBucketLifecycleConfiguration(t *testing.T) {
 	config, err := client.GetBucketLifecycleConfiguration(bucketName)
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, config.BucketLifecycleConfiguration.LifecycleRules[0].Expiration.Days, 60)
+
+	t.Cleanup(func() {
+		_, err := client.DeleteBucketLifecycleConfiguration(bucketName)
+		th.AssertNoErr(t, err)
+	})
+}
+
+func TestObsBucketLifecycleConfigurationFilter(t *testing.T) {
+	client, err := clients.NewOBSClient()
+	th.AssertNoErr(t, err)
+
+	bucketName := strings.ToLower(tools.RandomString("obs-sdk-test", 5))
+
+	_, err = client.CreateBucket(&obs.CreateBucketInput{
+		Bucket: bucketName,
+	})
+	t.Cleanup(func() {
+		_, err = client.DeleteBucket(bucketName)
+		th.AssertNoErr(t, err)
+	})
+	th.AssertNoErr(t, err)
+
+	_, err = client.SetBucketLifecycleConfiguration(
+		&obs.SetBucketLifecycleConfigurationInput{
+			Bucket: bucketName,
+			BucketLifecycleConfiguration: obs.BucketLifecycleConfiguration{
+				LifecycleRules: []obs.LifecycleRule{
+					{
+						Status: "Enabled",
+						Transitions: []obs.Transition{
+							{
+								Days:         30,
+								StorageClass: "COLD",
+							},
+						},
+						Expiration: obs.Expiration{
+							Days: 60,
+						},
+						Filter: obs.LifecycleFilter{
+							Prefix: "prefix",
+							Tags: []obs.Tag{
+								{
+									Key:   "tag1",
+									Value: "value1",
+								},
+								{
+									Key:   "tag2",
+									Value: "value2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	th.AssertNoErr(t, err)
+
+	config, err := client.GetBucketLifecycleConfiguration(bucketName)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, config.BucketLifecycleConfiguration.LifecycleRules[0].Expiration.Days, 60)
+	th.AssertEquals(t, config.BucketLifecycleConfiguration.LifecycleRules[0].Filter.Tags[0].Key, "tag1")
+	th.AssertEquals(t, config.BucketLifecycleConfiguration.LifecycleRules[0].Filter.Tags[0].Value, "value1")
+	th.AssertEquals(t, config.BucketLifecycleConfiguration.LifecycleRules[0].Filter.Tags[1].Key, "tag2")
+	th.AssertEquals(t, config.BucketLifecycleConfiguration.LifecycleRules[0].Filter.Tags[1].Value, "value2")
 
 	t.Cleanup(func() {
 		_, err := client.DeleteBucketLifecycleConfiguration(bucketName)

--- a/openstack/obs/convert.go
+++ b/openstack/obs/convert.go
@@ -313,6 +313,17 @@ func convertExpirationToXml(expiration Expiration) string {
 	return ""
 }
 
+func convertLifeCycleFilterToXML(filter LifecycleFilter) string {
+	if filter.Prefix == "" && len(filter.Tags) == 0 {
+		return ""
+	}
+	data, err := TransToXml(filter)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
 func convertNoncurrentVersionTransitionsToXml(noncurrentVersionTransitions []NoncurrentVersionTransition, isObs bool) string {
 	if length := len(noncurrentVersionTransitions); length > 0 {
 		xml := make([]string, 0, length)
@@ -346,25 +357,31 @@ func convertNoncurrentVersionExpirationToXml(noncurrentVersionExpiration Noncurr
 func ConvertLifecyleConfigurationToXml(input BucketLifecycleConfiguration, returnMd5 bool, isObs bool) (data string, md5 string) {
 	xml := make([]string, 0, 2+len(input.LifecycleRules)*9)
 	xml = append(xml, "<LifecycleConfiguration>")
-	for _, lifecyleRule := range input.LifecycleRules {
+	for _, lifecycleRule := range input.LifecycleRules {
 		xml = append(xml, "<Rule>")
-		if lifecyleRule.ID != "" {
-			lifecyleRuleID := XmlTranscoding(lifecyleRule.ID)
-			xml = append(xml, fmt.Sprintf("<ID>%s</ID>", lifecyleRuleID))
+		if lifecycleRule.ID != "" {
+			lifecycleRuleID := XmlTranscoding(lifecycleRule.ID)
+			xml = append(xml, fmt.Sprintf("<ID>%s</ID>", lifecycleRuleID))
 		}
-		lifecyleRulePrefix := XmlTranscoding(lifecyleRule.Prefix)
-		xml = append(xml, fmt.Sprintf("<Prefix>%s</Prefix>", lifecyleRulePrefix))
-		xml = append(xml, fmt.Sprintf("<Status>%s</Status>", lifecyleRule.Status))
-		if ret := convertTransitionsToXml(lifecyleRule.Transitions, isObs); ret != "" {
+		lifecycleRulePrefix := XmlTranscoding(lifecycleRule.Prefix)
+		lifecycleRuleFilter := convertLifeCycleFilterToXML(lifecycleRule.Filter)
+		if lifecycleRulePrefix != "" || lifecycleRuleFilter == "" {
+			xml = append(xml, fmt.Sprintf("<Prefix>%s</Prefix>", lifecycleRulePrefix))
+		}
+		if lifecycleRuleFilter != "" {
+			xml = append(xml, lifecycleRuleFilter)
+		}
+		xml = append(xml, fmt.Sprintf("<Status>%s</Status>", lifecycleRule.Status))
+		if ret := convertTransitionsToXml(lifecycleRule.Transitions, isObs); ret != "" {
 			xml = append(xml, ret)
 		}
-		if ret := convertExpirationToXml(lifecyleRule.Expiration); ret != "" {
+		if ret := convertExpirationToXml(lifecycleRule.Expiration); ret != "" {
 			xml = append(xml, ret)
 		}
-		if ret := convertNoncurrentVersionTransitionsToXml(lifecyleRule.NoncurrentVersionTransitions, isObs); ret != "" {
+		if ret := convertNoncurrentVersionTransitionsToXml(lifecycleRule.NoncurrentVersionTransitions, isObs); ret != "" {
 			xml = append(xml, ret)
 		}
-		if ret := convertNoncurrentVersionExpirationToXml(lifecyleRule.NoncurrentVersionExpiration); ret != "" {
+		if ret := convertNoncurrentVersionExpirationToXml(lifecycleRule.NoncurrentVersionExpiration); ret != "" {
 			xml = append(xml, ret)
 		}
 		xml = append(xml, "</Rule>")

--- a/openstack/obs/model_base.go
+++ b/openstack/obs/model_base.go
@@ -262,6 +262,13 @@ type LifecycleRule struct {
 	Expiration                   Expiration                    `xml:"Expiration,omitempty"`
 	NoncurrentVersionTransitions []NoncurrentVersionTransition `xml:"NoncurrentVersionTransition,omitempty"`
 	NoncurrentVersionExpiration  NoncurrentVersionExpiration   `xml:"NoncurrentVersionExpiration,omitempty"`
+	Filter                       LifecycleFilter               `xml:"Filter,omitempty"`
+}
+
+type LifecycleFilter struct {
+	XMLName xml.Name `xml:"Filter"`
+	Prefix  string   `xml:"And>Prefix,omitempty"`
+	Tags    []Tag    `xml:"And>Tag,omitempty"`
 }
 
 // BucketEncryptionConfiguration defines the bucket encryption configuration


### PR DESCRIPTION
Documentation: https://docs.otc.t-systems.com/object-storage-service/api-ref/apis/advanced_bucket_settings/configuring_bucket_lifecycle_rules.html#obs-04-0034

### Acceptance tests
```
=== RUN   TestObsBucketLifecycleConfigurationBasic
--- PASS: TestObsBucketLifecycleConfigurationBasic (1.98s)
=== RUN   TestObsBucketLifecycleConfigurationFilter
--- PASS: TestObsBucketLifecycleConfigurationFilter (1.87s)
PASS

Process finished with the exit code 0

```
