### PR TITLE
[Fix.] WAFD: fix antileakage rules

### DIFF
--- a/acceptance/openstack/waf-premium/v1/rule_test.go
+++ b/acceptance/openstack/waf-premium/v1/rule_test.go
@@ -538,6 +538,9 @@ func TestWafPremiumInformationLeakageProtectionRuleWorkflow(t *testing.T) {
 		Category:    "sensitive",
 		Contents:    []string{"id_card"},
 		Description: "desc",
+		Action: &rules.LeakageAction{
+			Category: "block",
+		},
 	}
 	t.Logf("Attempting to Create WAF Premium information leakage protection rule")
 	ilp, err := rules.CreateAntiLeakage(client, policy.ID, ilpOpts)

--- a/openstack/waf-premium/v1/rules/CreateAntiLeakage.go
+++ b/openstack/waf-premium/v1/rules/CreateAntiLeakage.go
@@ -21,6 +21,15 @@ type CreateAntiLeakageOpts struct {
 	Contents []string `json:"contents" required:"true"`
 	// Rule description.
 	Description string `json:"description"`
+	// Protective action of the antileakage rule
+	Action *LeakageAction `json:"action,omitempty"`
+}
+
+type LeakageAction struct {
+	// Protection type
+	// block: WAF blocks attacks.
+	// log: WAF only logs discovered attacks.
+	Category string `json:"category" required:"true"`
 }
 
 // CreateAntiLeakage will create an information leakage protection rule on the values in CreateOpts.

--- a/openstack/waf-premium/v1/rules/GetAntiLeakage.go
+++ b/openstack/waf-premium/v1/rules/GetAntiLeakage.go
@@ -8,7 +8,11 @@ import (
 // GetAntiLeakage is used to query an information leakage prevention rule by ID.
 func GetAntiLeakage(client *golangsdk.ServiceClient, policyId, ruleId string) (*AntiLeakageRule, error) {
 	// GET /v1/{project_id}/waf/policy/{policy_id}/antileakage/{rule_id}
-	raw, err := client.Get(client.ServiceURL("waf", "policy", policyId, "antileakage", ruleId), nil, nil)
+	raw, err := client.Get(client.ServiceURL("waf", "policy", policyId, "antileakage", ruleId), nil, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/openstack/waf-premium/v1/rules/ListAntiLeakage.go
+++ b/openstack/waf-premium/v1/rules/ListAntiLeakage.go
@@ -23,7 +23,11 @@ func ListAntiLeakage(client *golangsdk.ServiceClient, policyId string, opts List
 
 	// GET /v1/{project_id}/waf/policy/{policy_id}/antileakage
 	url := client.ServiceURL("waf", "policy", policyId, "antileakage") + query.String()
-	raw, err := client.Get(url, nil, nil)
+	raw, err := client.Get(url, nil, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What this PR does / why we need it
API's been changed and additional headers are required.

### Acceptance tests
```
=== RUN   TestWafPremiumInformationLeakageProtectionRuleWorkflow
    rule_test.go:545: Attempting to Create WAF Premium information leakage protection rule
    rule_test.go:559: Attempting to List WAF Premium information leakage protection rule
    rule_test.go:566: Attempting to Update WAF Premium information leakage protection rule: 488ef037b94e4d139c2cacf960ca450d
    rule_test.go:575: Attempting to Get WAF Premium information leakage protection rule: 5e9247be72f14ad9bb612193e3b488b8
    rule_test.go:554: Attempting to delete WAF Premium information leakage protection rule: 5e9247be72f14ad9bb612193e3b488b8
    rule_test.go:556: Deleted WAF Premium information leakage protection rule: 5e9247be72f14ad9bb612193e3b488b8
    rule_test.go:532: Attempting to delete WAF Premium policy: 488ef037b94e4d139c2cacf960ca450d
    rule_test.go:534: Deleted WAF Premium policy: 488ef037b94e4d139c2cacf960ca450d
--- PASS: TestWafPremiumInformationLeakageProtectionRuleWorkflow (5.59s)
PASS

Process finished with the exit code 0
```
