### PR TITLE
[Feat.] Network: Add Private NAT gateway service APIs

### DIFF
--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -504,6 +504,18 @@ func NewNatV2Client() (*golangsdk.ServiceClient, error) {
 	})
 }
 
+// NewNatV3Client returns authenticated NAT v2 client
+func NewNatV3Client() (*golangsdk.ServiceClient, error) {
+	cc, err := CloudAndClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return openstack.NewNatV3(cc.ProviderClient, golangsdk.EndpointOpts{
+		Region: cc.RegionName,
+	})
+}
+
 // NewPeerNetworkV2Client returns a *ServiceClient for making calls to the
 // OpenStack Networking v2 API for Peer. An error will be returned if authentication
 // or client creation was not possible.

--- a/acceptance/openstack/networking/v3/privatenat/natgateway_test.go
+++ b/acceptance/openstack/networking/v3/privatenat/natgateway_test.go
@@ -1,0 +1,68 @@
+package privatenat
+
+import (
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v3/privatenat/natgateway"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestPrivateNatGatewayLifecycle(t *testing.T) {
+	client, err := clients.NewNatV3Client()
+	th.AssertNoErr(t, err)
+
+	natGateway := createPrivateNatGateway(t, client)
+	t.Cleanup(func() {
+		deletePrivateNatGateway(t, client, natGateway.Id)
+	})
+
+	getResponse, err := natgateway.Get(client, natGateway.Id)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, natGateway.Name, getResponse.Gateway.Name)
+
+	updateResponse, err := natgateway.Update(client, natGateway.Id, natgateway.UpdateGatewayOpts{
+		Description: "updated",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "updated", updateResponse.Gateway.Description)
+}
+
+func createPrivateNatGateway(t *testing.T, client *golangsdk.ServiceClient) *natgateway.PrivateNATGateway {
+	t.Logf("Attempting to create Private Nat Gateway")
+	natGatewayName := tools.RandomString("create-private-nat-", 8)
+
+	networkID := clients.EnvOS.GetEnv("NETWORK_ID")
+	if networkID == "" {
+		t.Skip("OS_NETWORK_ID is missing but test requires using existing network")
+	}
+
+	createNatGatewayOpts := natgateway.CreateGatewayOpts{
+		Name:        natGatewayName,
+		Description: "created",
+		Spec:        "Small",
+		DownlinkVpcs: []natgateway.DownlinkVpcOption{
+			{
+				VirSubnetID: networkID,
+			},
+		},
+	}
+
+	createResp, err := natgateway.Create(client, createNatGatewayOpts)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "created", createResp.Gateway.Description)
+
+	t.Logf("Created Nat Gateway: %s", createResp.Gateway.Id)
+
+	return &createResp.Gateway
+}
+
+func deletePrivateNatGateway(t *testing.T, client *golangsdk.ServiceClient, natGatewayID string) {
+	t.Logf("Attempting to delete Private Nat Gateway: %s", natGatewayID)
+
+	th.AssertNoErr(t, natgateway.Delete(client, natGatewayID))
+
+	t.Logf("Private Nat Gateway is deleted: %s", natGatewayID)
+}

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -694,6 +694,11 @@ func NewNatV2(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*gol
 	return initClientOpts(client, eo, "nat")
 }
 
+// NewNatV3 creates a ServiceClient that may be used with the v3 nat package.
+func NewNatV3(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	return initClientOpts(client, eo, "natv3")
+}
+
 // NewMapReduceV1 creates a ServiceClient that may be used with the v1 MapReduce service.
 func NewMapReduceV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
 	sc, err := initClientOpts(client, eo, "mrs")

--- a/openstack/networking/v3/privatenat/natgateway/Common.go
+++ b/openstack/networking/v3/privatenat/natgateway/Common.go
@@ -1,0 +1,64 @@
+package natgateway
+
+// ########## COMMON RESPONSE STRUCTS ###########
+
+type GatewayCommonResponse struct {
+	// Specifies the response body for the private NAT gateway.
+	Gateway PrivateNATGateway `json:"gateway"`
+	// Request ID
+	RequestID string `json:"request_id"`
+}
+
+type PrivateNATGateway struct {
+	// Specifies the private NAT gateway ID.
+	Id string `json:"id"`
+	// Project ID
+	ProjectId string `json:"project_id"`
+	// Specifies the private NAT gateway name.
+	// Only digits, letters, underscores (_), and hyphens (-) are allowed.
+	Name string `json:"name"`
+	// Provides supplementary information about the private NAT gateway.
+	// The description can contain up to 255 characters and cannot contain angle brackets (<>).
+	Description string `json:"description"`
+	// Specifies the private NAT gateway specifications.
+	// The value can be: Small, Medium, Large, Extra-large.
+	// Default value: Small.
+	Spec string `json:"spec"`
+	// Specifies the private NAT gateway status.
+	// The value can be:
+	// ACTIVE: The private NAT gateway is running properly.
+	// FROZEN: The private NAT gateway is frozen.
+	Status string `json:"status"`
+	// Specifies the time when the private NAT gateway was created. It is a UTC time in yyyy-mm-ddThh:mm:ssZ format.
+	CreatedAt string `json:"created_at"`
+	// Specifies the time when the private NAT gateway was updated. It is a UTC time in yyyy-mm-ddThh:mm:ssZ format.
+	UpdatedAt string `json:"updated_at"`
+	// Specifies the VPC where the private NAT gateway works.
+	DownlinkVpcs []DownlinkVpc `json:"downlink_vpcs"`
+	// Specifies the tag list.
+	Tags []Tag `json:"tags"`
+	// Specifies the ID of the enterprise project associated with the private NAT gateway.
+	// Default value: 0.
+	EnterpriseProjectID string `json:"enterprise_project_id"`
+	// Specifies the maximum number of rules. Value range: 0-65535
+	RuleMax int `json:"rule_max"`
+	// Specifies the maximum number of transit IP addresses in a transit IP address pool. Value range: 1-100
+	TransitIpPoolSizeMax int `json:"transit_ip_pool_size_max"`
+}
+
+type DownlinkVpc struct {
+	// VPC ID
+	VpcId string `json:"vpc_id"`
+	// Specifies the ID of the subnet where the private NAT gateway works.
+	VirSubnetID string `json:"virsubnet_id"`
+	// Specifies the private IP address of the private NAT gateway.
+	NgPortIPAddress string `json:"ngport_ip_address"`
+}
+
+type Tag struct {
+	// Specifies the tag key. A key can contain up to 128 Unicode characters.
+	// Key cannot be left blank.
+	Key string `json:"key"`
+	// Specifies the tag value. Each value can contain up to 255 Unicode characters.
+	Value string `json:"value"`
+}

--- a/openstack/networking/v3/privatenat/natgateway/Create.go
+++ b/openstack/networking/v3/privatenat/natgateway/Create.go
@@ -1,0 +1,62 @@
+package natgateway
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateGatewayOpts struct {
+	// Specifies the private NAT gateway name.
+	// Only digits, letters, underscores (_), and hyphens (-) are allowed.
+	Name string `json:"name" required:"true"`
+	// Provides supplementary information about the private NAT gateway.
+	// The description can contain up to 255 characters and cannot contain angle brackets (<>).
+	Description string `json:"description,omitempty"`
+	// Specifies the private NAT gateway specifications.
+	// The value can be: Small, Medium, Large, Extra-large.
+	// Default value: Small.
+	Spec string `json:"spec,omitempty"`
+	// Specifies the VPC where the private NAT gateway works.
+	DownlinkVpcs []DownlinkVpcOption `json:"downlink_vpcs" required:"true"`
+	// Specifies the tag list.
+	Tags []TagOptions `json:"tags,omitempty"`
+	// Specifies the ID of the enterprise project associated with the private NAT gateway.
+	// Default value: 0.
+	EnterpriseProjectID string `json:"enterprise_project_id,omitempty"`
+}
+
+type DownlinkVpcOption struct {
+	// Specifies the ID of the subnet where the private NAT gateway works.
+	VirSubnetID string `json:"virsubnet_id" required:"true"`
+	// Specifies the private IP address of the private NAT gateway.
+	NgPortIPAddress string `json:"ngport_ip_address,omitempty"`
+}
+
+type TagOptions struct {
+	// Specifies the tag key. A key can contain up to 128 Unicode characters.
+	// Key cannot be left blank.
+	Key string `json:"key" required:"true"`
+	// Specifies the tag value. Each value can contain up to 255 Unicode characters.
+	Value string `json:"value" required:"true"`
+}
+
+// This function is used to create a Private NAT gateway.
+func CreateACLRule(client *golangsdk.ServiceClient, opts CreateGatewayOpts) (*GatewayCommonResponse, error) {
+	b, err := build.RequestBody(opts, "gateway")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST /v3/{project_id}/private-nat/gateways
+	raw, err := client.Post(client.ServiceURL("private-nat", "gateways"), b, nil, &golangsdk.RequestOpts{
+		OkCodes:     []int{200, 201},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res GatewayCommonResponse
+	return &res, extract.Into(raw.Body, &res)
+}

--- a/openstack/networking/v3/privatenat/natgateway/Create.go
+++ b/openstack/networking/v3/privatenat/natgateway/Create.go
@@ -42,7 +42,7 @@ type TagOptions struct {
 }
 
 // This function is used to create a Private NAT gateway.
-func CreateACLRule(client *golangsdk.ServiceClient, opts CreateGatewayOpts) (*GatewayCommonResponse, error) {
+func Create(client *golangsdk.ServiceClient, opts CreateGatewayOpts) (*GatewayCommonResponse, error) {
 	b, err := build.RequestBody(opts, "gateway")
 	if err != nil {
 		return nil, err

--- a/openstack/networking/v3/privatenat/natgateway/Delete.go
+++ b/openstack/networking/v3/privatenat/natgateway/Delete.go
@@ -1,0 +1,12 @@
+package natgateway
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+// This function is used to delete a private NAT gateway.
+func Delete(client *golangsdk.ServiceClient, gatewayId string) error {
+	// DELETE /v3/{project_id}/private-nat/gateways/{gateway_id}
+	_, err := client.Delete(client.ServiceURL("private-nat", "gateways", gatewayId), &golangsdk.RequestOpts{
+		OkCodes: []int{200, 204},
+	})
+	return err
+}

--- a/openstack/networking/v3/privatenat/natgateway/Get.go
+++ b/openstack/networking/v3/privatenat/natgateway/Get.go
@@ -1,0 +1,19 @@
+package natgateway
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// This function is used to query details about a specified private NAT gateway.
+func Get(client *golangsdk.ServiceClient, gatewayId string) (*GatewayCommonResponse, error) {
+	// GET /v3/{project_id}/private-nat/gateways/{gateway_id}
+	raw, err := client.Get(client.ServiceURL("private-nat", "gateways", gatewayId), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res GatewayCommonResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/networking/v3/privatenat/natgateway/List.go
+++ b/openstack/networking/v3/privatenat/natgateway/List.go
@@ -1,0 +1,81 @@
+package natgateway
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListGatewaysQueryParams struct {
+	// Specifies the number of records displayed on each page.
+	// The value ranges from 1 to 2000. Default value: 2000
+	Limit int `q:"limit"`
+	// Specifies the start resource ID of pagination query. If the parameter is left blank, only resources on the first page are queried.
+	// The value is obtained from next_marker or previous_marker in PageInfo queried last time.
+	Marker string `q:"marker"`
+	// Specifies whether to query resources on the previous page.
+	PageReverse bool `q:"page_reverse"`
+	// Specifies the private NAT gateway ID.
+	Id []string `q:"id"`
+	// Specifies the private NAT gateway name.
+	// Only digits, letters, underscores (_), and hyphens (-) are allowed.
+	Name []string `q:"name"`
+	// Provides supplementary information about the private NAT gateway.
+	// The description can contain up to 255 characters and cannot contain angle brackets (<>).
+	Description []string `q:"description"`
+	// Specifies the private NAT gateway specifications.
+	// The value can be: Small, Medium, Large, Extra-large.
+	// Default value: Small.
+	Spec []string `q:"spec"`
+	// Project ID
+	ProjectId []string `q:"project_id"`
+	// Specifies the private NAT gateway status.
+	// The value can be:
+	// ACTIVE: The private NAT gateway is running properly.
+	// FROZEN: The private NAT gateway is frozen.
+	Status []string `q:"status"`
+	// VPC ID
+	VpcId []string `q:"vpc_id"`
+	// Specifies the ID of the subnet where the private NAT gateway works.
+	VirSubnetID []string `q:"virsubnet_id"`
+	// Specifies the ID of the enterprise project that is associated with the private NAT gateway when the private NAT gateway is created.
+	EnterpriseProjectId []string `q:"enterprise_project_id"`
+}
+
+// This function is used to query private NAT gateways.
+func List(client *golangsdk.ServiceClient, opts ListGatewaysQueryParams) (*ListResponse, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("private-nat", "gateways").
+		WithQueryParams(opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	// GET /v3/{project_id}/private-nat/gateways
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListResponse struct {
+	// Specifies the response body for the private NAT gateways.
+	Gateways []PrivateNATGateway `json:"gateways"`
+	// Request ID
+	RequestID string `json:"request_id"`
+	// Specifies the pagination information.
+	PageInfo PageInfo `json:"page_info"`
+}
+
+type PageInfo struct {
+	// Specifies the ID of the last record in this query, which can be used in the next query.
+	NextMarker string `json:"next_marker"`
+	// Specifies the ID of the first record in the pagination query result.
+	// When page_reverse is set to true, this parameter is used together to query resources on the previous page.
+	PreviousMarker string `json:"previous_marker"`
+	// Specifies the ID of the last record in the pagination query result. It is usually used to query resources on the next page. Value range: 1-200
+	CurrentCount int `json:"current_count"`
+}

--- a/openstack/networking/v3/privatenat/natgateway/Update.go
+++ b/openstack/networking/v3/privatenat/natgateway/Update.go
@@ -1,0 +1,40 @@
+package natgateway
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type UpdateGatewayOpts struct {
+	// Specifies the private NAT gateway name.
+	// Only digits, letters, underscores (_), and hyphens (-) are allowed.
+	Name string `json:"name,omitempty"`
+	// Provides supplementary information about the private NAT gateway.
+	// The description can contain up to 255 characters and cannot contain angle brackets (<>).
+	Description string `json:"description,omitempty"`
+	// Specifies the private NAT gateway specifications.
+	// The value can be: Small, Medium, Large, Extra-large.
+	// Default value: Small.
+	Spec string `json:"spec,omitempty"`
+}
+
+// This function is used to create a Private NAT gateway.
+func Update(client *golangsdk.ServiceClient, gatewayId string, opts UpdateGatewayOpts) (*GatewayCommonResponse, error) {
+	b, err := build.RequestBody(opts, "gateway")
+	if err != nil {
+		return nil, err
+	}
+
+	// PUT /v3/{project_id}/private-nat/gateways/{gateway_id}
+	raw, err := client.Put(client.ServiceURL("private-nat", "gateways", gatewayId), b, nil, &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res GatewayCommonResponse
+	return &res, extract.Into(raw.Body, &res)
+}


### PR DESCRIPTION
### What this PR does / why we need it

Add new service [Private NAT gateway APIs](https://docs.otc.t-systems.com/nat-gateway/api-ref/apis_for_private_nat_gateways_v3.0/private_nat_gateways/index.html)

### Which issue this PR fixes
OTC Provider Issue [#3066](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3066)

### Tests
```
=== RUN   TestPrivateNatGatewayLifecycle
    natgateway_test.go:34: Attempting to create Private Nat Gateway
    natgateway_test.go:57: Created Nat Gateway: 56e602e2-3f2d-4ad7-ae0f-db301e4286ba
    natgateway_test.go:63: Attempting to delete Private Nat Gateway: 56e602e2-3f2d-4ad7-ae0f-db301e4286ba
    natgateway_test.go:67: Private Nat Gateway is deleted: 56e602e2-3f2d-4ad7-ae0f-db301e4286ba
--- PASS: TestPrivateNatGatewayLifecycle (12.66s)
PASS
```
