### PR TITLE
[Feat.] Network: Add Private NAT DNAT rules service APIs

### DIFF
--- a/acceptance/openstack/networking/v3/privatenat/dnatrules_test.go
+++ b/acceptance/openstack/networking/v3/privatenat/dnatrules_test.go
@@ -1,0 +1,50 @@
+package privatenat
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v3/privatenat/dnatrules"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestPrivateNatDnatRulesLifecycle(t *testing.T) {
+	client, err := clients.NewNatV3Client()
+	th.AssertNoErr(t, err)
+	transitIpId := clients.EnvOS.GetEnv("TRANSIT_IP_ID")
+	networkInterfaceId := clients.EnvOS.GetEnv("NIC_ID")
+	if transitIpId == "" || networkInterfaceId == "" {
+		t.Skip("OS_TRANSIT_IP_ID or OS_NIC_ID is missing but test requires using existing network")
+	}
+
+	natGateway := createPrivateNatGateway(t, client)
+	t.Cleanup(func() {
+		deletePrivateNatGateway(t, client, natGateway.Id)
+	})
+
+	createOpts := dnatrules.CreatePrivateDnatOpts{
+		Description:        "created",
+		GatewayId:          natGateway.Id,
+		TransitIpId:        transitIpId,
+		NetworkInterfaceId: networkInterfaceId,
+	}
+	dnatCreateResp, err := dnatrules.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+	ruleId := dnatCreateResp.DnatRule.Id
+	t.Logf("Created DNAT rule: %s", ruleId)
+	t.Cleanup(func() {
+		t.Logf("Deleting DNAT rule: %s", ruleId)
+		th.AssertNoErr(t, dnatrules.Delete(client, ruleId))
+		t.Logf("Deleting DNAT rule: %s", ruleId)
+	})
+
+	getResponse, err := dnatrules.Get(client, ruleId)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "created", getResponse.DnatRule.Description)
+
+	updateResponse, err := dnatrules.Update(client, ruleId, dnatrules.UpdatePrivateDnatOpts{
+		Description: "updated",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "updated", updateResponse.DnatRule.Description)
+}

--- a/openstack/networking/v3/privatenat/dnatrules/Common.go
+++ b/openstack/networking/v3/privatenat/dnatrules/Common.go
@@ -1,0 +1,51 @@
+package dnatrules
+
+// ############# COMMON RESPONSE STRUCTS #############
+
+type DnatCommonResponse struct {
+	// Specifies the response body of the DNAT rule
+	DnatRule PrivateDnat `json:"dnat_rule"`
+	// Specifies the request ID
+	RequestId string `json:"request_id"`
+}
+
+type PrivateDnat struct {
+	// Specifies the DNAT rule ID
+	Id string `json:"id"`
+	// Specifies the project ID
+	ProjectId string `json:"project_id"`
+	// Provides supplementary information about the DNAT rule.
+	// The description can contain up to 255 characters and cannot contain angle brackets (<>).
+	Description string `json:"description"`
+	// Specifies the ID of the transit IP address
+	TransitIpId string `json:"transit_ip_id"`
+	// Specifies the private NAT gateway ID
+	GatewayId string `json:"gateway_id"`
+	// Specifies the network interface ID.
+	// Network interfaces of a compute instance, load balancer (v2 or v3), or virtual IP address are supported.
+	NetworkInterfaceId string `json:"network_interface_id"`
+	// Specifies the backend resource type of the DNAT rule.
+	// Enumeration values: COMPUTE, VIP, ELB, ELBv3, CUSTOMIZE
+	Type string `json:"type"`
+	// Specifies the protocol type.
+	// Enumeration values: tcp, udp, any
+	Protocol string `json:"protocol"`
+	// Specifies the port IP address that the NAT gateway uses.
+	// The resource can be a compute instance, load balancer (v2 or v3), or virtual IP address.
+	PrivateIpAddress string `json:"private_ip_address"`
+	// Specifies the port number of the resource (compute instance, load balancer, or virtual IP address).
+	// Value range: 0-65535, Default: 0
+	InternalServicePort string `json:"internal_service_port"`
+	// Specifies the port number of the transit IP address.
+	// Value range: 0-65535, Default: 0
+	TransitServicePort string `json:"transit_service_port"`
+	// Specifies the ID of the enterprise project that is associated with the DNAT rule when created
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// Specifies the time when the DNAT rule was created (UTC, yyyy-mm-ddThh:mm:ssZ)
+	CreatedAt string `json:"created_at"`
+	// Specifies the time when the DNAT rule was updated (UTC, yyyy-mm-ddThh:mm:ssZ)
+	UpdatedAt string `json:"updated_at"`
+	// Specifies the DNAT rule status of a private NAT gateway.
+	// Enumeration values: ACTIVE, FROZEN
+	Status string `json:"status"`
+}

--- a/openstack/networking/v3/privatenat/dnatrules/Create.go
+++ b/openstack/networking/v3/privatenat/dnatrules/Create.go
@@ -1,0 +1,55 @@
+package dnatrules
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreatePrivateDnatOpts struct {
+	// Provides supplementary information about the DNAT rule.
+	// The description can contain up to 255 characters and cannot contain angle brackets (<>).
+	Description string `json:"description,omitempty"`
+	// Specifies the ID of the transit IP address.
+	TransitIpId string `json:"transit_ip_id" required:"true"`
+	// Specifies the port ID of the resource that the NAT gateway is bound to.
+	// The resource can be a compute instance, load balancer (v2 or v3), or virtual IP address.
+	// Either this parameter or private_ip_address must be specified.
+	NetworkInterfaceId string `json:"network_interface_id,omitempty"`
+	// Specifies the private NAT gateway ID.
+	GatewayId string `json:"gateway_id" required:"true"`
+	// Specifies the port IP address that the NAT gateway uses.
+	// The resource can be a compute instance, load balancer (v2 or v3), or virtual IP address.
+	// Either this parameter or network_interface_id must be specified.
+	PrivateIpAddress string `json:"private_ip_address,omitempty"`
+	// Specifies the protocol type. TCP, UDP, and ANY are supported.
+	// Enumeration values: tcp, udp, any
+	Protocol string `json:"protocol,omitempty"`
+	// Specifies the port number of the resource, which can be a compute instance,
+	// load balancer (v2 or v3), or virtual IP address.
+	// Value range: 0-65535, Default: 0
+	InternalServicePort string `json:"internal_service_port,omitempty"`
+	// Specifies the port number of the transit IP address.
+	// Value range: 0-65535, Default: 0
+	TransitServicePort string `json:"transit_service_port,omitempty"`
+}
+
+// This function is used to create a DNAT rule.
+func Create(client *golangsdk.ServiceClient, opts CreatePrivateDnatOpts) (*DnatCommonResponse, error) {
+	b, err := build.RequestBody(opts, "dnat_rule")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST /v3/{project_id}/private-nat/dnat-rules
+	raw, err := client.Post(client.ServiceURL("private-nat", "dnat-rules"), b, nil, &golangsdk.RequestOpts{
+		OkCodes:     []int{200, 201},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res DnatCommonResponse
+	return &res, extract.Into(raw.Body, &res)
+}

--- a/openstack/networking/v3/privatenat/dnatrules/Delete.go
+++ b/openstack/networking/v3/privatenat/dnatrules/Delete.go
@@ -1,0 +1,12 @@
+package dnatrules
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+// This function is used to delete a specified DNAT rule.
+func Delete(client *golangsdk.ServiceClient, ruleId string) error {
+	// DELETE /v3/{project_id}/private-nat/dnat-rules/{dnat_rule_id}
+	_, err := client.Delete(client.ServiceURL("private-nat", "dnat-rules", ruleId), &golangsdk.RequestOpts{
+		OkCodes: []int{200, 204},
+	})
+	return err
+}

--- a/openstack/networking/v3/privatenat/dnatrules/Get.go
+++ b/openstack/networking/v3/privatenat/dnatrules/Get.go
@@ -1,0 +1,19 @@
+package dnatrules
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// This function is used to query details about a specified DNAT rule.
+func Get(client *golangsdk.ServiceClient, ruleId string) (*DnatCommonResponse, error) {
+	// GET /v3/{project_id}/private-nat/dnat-rules/{dnat_rule_id}
+	raw, err := client.Get(client.ServiceURL("private-nat", "dnat-rules", ruleId), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res DnatCommonResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/networking/v3/privatenat/dnatrules/List.go
+++ b/openstack/networking/v3/privatenat/dnatrules/List.go
@@ -1,0 +1,95 @@
+package dnatrules
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListDnatRulesQueryParams struct {
+	// Specifies the number of records displayed on each page.
+	// The value ranges from 1 to 2000. Default value: 2000
+	Limit int `q:"limit"`
+	// Specifies the start resource ID of pagination query. If the parameter is left blank, only resources on the first page are queried.
+	// The value is obtained from next_marker or previous_marker in PageInfo queried last time.
+	Marker string `q:"marker"`
+	// Specifies whether to query resources on the previous page.
+	PageReverse bool `q:"page_reverse"`
+	// Specifies the DNAT rule ID.
+	Id []string `q:"id"`
+	// Project ID
+	ProjectId []string `q:"project_id"`
+	// Specifies the ID of the enterprise project that is associated with the DNAT rule when the DNAT rule is created.
+	EnterpriseProjectId []string `q:"enterprise_project_id"`
+	// Provides supplementary information about the private NAT gateway.
+	// The description can contain up to 255 characters and cannot contain angle brackets (<>).
+	Description []string `q:"description"`
+	// Specifies the private NAT gateway ID.
+	GatewayId []string `q:"gateway_id"`
+	// Specifies the ID of the transit IP address.
+	TransitIpId []string `q:"transit_ip_id"`
+	// Specifies the transit IP address.
+	ExternalIpAddress []string `q:"external_ip_address"`
+	// Specifies the port ID of the resource that the NAT gateway is bound to. The resource can be a compute instance, load balancer (v2 or v3), or virtual IP address.
+	NetworkInterfaceId []string `q:"network_interface_id"`
+	// Specifies the backend resource type of the DNAT rule.
+	// The type can be:
+	// COMPUTE: The backend resource is a compute instance.
+	// VIP: The backend resource is a virtual IP address.
+	// ELB: The backend resource is a v2 load balancer.
+	// ELBv3: The backend resource is a v3 load balancer.
+	// CUSTOMIZE: The backend resource is a user-defined IP address.
+	Type []string `q:"type"`
+	// Specifies the port IP address that the NAT gateway uses. The resource can be a compute instance, load balancer (v2 or v3), or virtual IP address.
+	PrivateIpAddress []string `q:"private_ip_address"`
+	// Specifies the DNAT rule protocol type.
+	// TCP, UDP, and ANY are supported.
+	// The protocol number of TCP, UDP, and ANY are 6, 17, and 0, respectively.
+	Protocol []string `q:"protocol"`
+	// Specifies the port number of the resource, which can be a compute instance, load balancer (v2 or v3), or virtual IP address.
+	InternalServicePort []string `q:"internal_service_port"`
+	// Specifies the port number of the transit IP address.
+	TransitServicePort []string `q:"transit_service_port"`
+	// Specifies the time when the DNAT rule was created. It is a UTC time in yyyy-mm-ddThh:mm:ssZ format.
+	CreatedAt string `q:"created_at"`
+	// Specifies the time when the DNAT rule was updated. It is a UTC time in yyyy-mm-ddThh:mm:ssZ format.
+	UpdatedAt string `q:"updated_at"`
+}
+
+// This function is used to query DNAT rules.
+func List(client *golangsdk.ServiceClient, opts ListDnatRulesQueryParams) (*ListResponse, error) {
+	// GET /v3/{project_id}/private-nat/dnat-rules
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("private-nat", "dnat-rules").
+		WithQueryParams(opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListResponse struct {
+	// Specifies the response body for querying DNAT rules.
+	DnatRules []PrivateDnat `json:"dnat_rules"`
+	// Request ID
+	RequestID string `json:"request_id"`
+	// Specifies the pagination information.
+	PageInfo PageInfo `json:"page_info"`
+}
+
+type PageInfo struct {
+	// Specifies the ID of the last record in this query, which can be used in the next query.
+	NextMarker string `json:"next_marker"`
+	// Specifies the ID of the first record in the pagination query result.
+	// When page_reverse is set to true, this parameter is used together to query resources on the previous page.
+	PreviousMarker string `json:"previous_marker"`
+	// Specifies the ID of the last record in the pagination query result. It is usually used to query resources on the next page. Value range: 1-200
+	CurrentCount int `json:"current_count"`
+}

--- a/openstack/networking/v3/privatenat/dnatrules/Update.go
+++ b/openstack/networking/v3/privatenat/dnatrules/Update.go
@@ -1,0 +1,53 @@
+package dnatrules
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type UpdatePrivateDnatOpts struct {
+	// Provides supplementary information about the DNAT rule.
+	// The description can contain up to 255 characters and cannot contain angle brackets (<>).
+	Description string `json:"description,omitempty"`
+	// Specifies the ID of the transit IP address.
+	TransitIpId string `json:"transit_ip_id,omitempty"`
+	// Specifies the port ID of the resource that the NAT gateway is bound to.
+	// The resource can be a compute instance, load balancer (v2 or v3), or virtual IP address.
+	// Either this parameter or private_ip_address must be specified.
+	NetworkInterfaceId string `json:"network_interface_id,omitempty"`
+	// Specifies the port IP address that the NAT gateway uses.
+	// The resource can be a compute instance, load balancer (v2 or v3), or virtual IP address.
+	// Either this parameter or network_interface_id must be specified.
+	PrivateIpAddress string `json:"private_ip_address,omitempty"`
+	// Specifies the protocol type. TCP, UDP, and ANY are supported.
+	// Enumeration values: tcp, udp, any
+	Protocol string `json:"protocol,omitempty"`
+	// Specifies the port number of the resource, which can be a compute instance,
+	// load balancer (v2 or v3), or virtual IP address.
+	// Value range: 0-65535, Default: 0
+	InternalServicePort string `json:"internal_service_port,omitempty"`
+	// Specifies the port number of the transit IP address.
+	// Value range: 0-65535, Default: 0
+	TransitServicePort string `json:"transit_service_port,omitempty"`
+}
+
+// This function is used to update a DNAT rule.
+func Update(client *golangsdk.ServiceClient, ruleId string, opts UpdatePrivateDnatOpts) (*DnatCommonResponse, error) {
+	b, err := build.RequestBody(opts, "dnat_rule")
+	if err != nil {
+		return nil, err
+	}
+
+	// PUT /v3/{project_id}/private-nat/dnat-rules/{dnat_rule_id}
+	raw, err := client.Put(client.ServiceURL("private-nat", "dnat-rules", ruleId), b, nil, &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res DnatCommonResponse
+	return &res, extract.Into(raw.Body, &res)
+}


### PR DESCRIPTION
### What this PR does / why we need it

Add new service [Private NAT DNAT rules](https://docs.otc.t-systems.com/nat-gateway/api-ref/apis_for_private_nat_gateways_v3.0/dnat_rules/index.html).

### Which issue this PR fixes

OTC Provider Issue https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3066

### Test
```
=== RUN   TestPrivateNatDnatRulesLifecycle
    natgateway_test.go:34: Attempting to create Private Nat Gateway
    natgateway_test.go:57: Created Nat Gateway: 703ab671-093b-410e-9d3b-d62221fcc04b
    dnatrules_test.go:34: Created DNAT rule: 1376ebae-0f87-4bb1-9a1e-953da11eebe3
    dnatrules_test.go:36: Deleting DNAT rule: 1376ebae-0f87-4bb1-9a1e-953da11eebe3
    dnatrules_test.go:38: Deleting DNAT rule: 1376ebae-0f87-4bb1-9a1e-953da11eebe3
    natgateway_test.go:63: Attempting to delete Private Nat Gateway: 703ab671-093b-410e-9d3b-d62221fcc04b
    natgateway_test.go:67: Private Nat Gateway is deleted: 703ab671-093b-410e-9d3b-d62221fcc04b
--- PASS: TestPrivateNatDnatRulesLifecycle (11.67s)
PASS
```
