### PR TITLE
[Feat.] Network: Add Private NAT transit IP service APIs

### DIFF
--- a/acceptance/openstack/networking/v3/privatenat/transitip_test.go
+++ b/acceptance/openstack/networking/v3/privatenat/transitip_test.go
@@ -1,0 +1,41 @@
+package privatenat
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v3/privatenat/transitip"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestPrivateNatTransitIpLifecycle(t *testing.T) {
+	client, err := clients.NewNatV3Client()
+	th.AssertNoErr(t, err)
+	networkId := clients.EnvOS.GetEnv("NETWORK_ID")
+	if networkId == "" {
+		t.Skip("OS_NETWORK_ID is missing but test requires using existing network")
+	}
+
+	createOpts := transitip.CreateTransitIpOpts{
+		VirSubnetID: networkId,
+	}
+	createResp, err := transitip.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+	transitIpId := createResp.TransitIp.Id
+	t.Logf("Created Transit IP: %s", transitIpId)
+	t.Cleanup(func() {
+		t.Logf("Deleting Transit IP: %s", transitIpId)
+		th.AssertNoErr(t, transitip.Delete(client, transitIpId))
+		t.Logf("Deleting Transit IP: %s", transitIpId)
+	})
+
+	getResponse, err := transitip.Get(client, transitIpId)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, networkId, getResponse.TransitIp.VirSubnetID)
+
+	listResonse, err := transitip.List(client, transitip.ListTransitIpsQueryParams{
+		Id: []string{transitIpId},
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(listResonse.TransitIps))
+}

--- a/openstack/networking/v3/privatenat/transitip/Common.go
+++ b/openstack/networking/v3/privatenat/transitip/Common.go
@@ -1,0 +1,46 @@
+package transitip
+
+// ########## COMMON RESPONSE STRUCTS ###########
+
+type TransitIPCommonResponse struct {
+	// Specifies the response body of the transit IP address.
+	TransitIp TransitIP `json:"transit_ip"`
+	// Request ID
+	RequestID string `json:"request_id"`
+}
+
+type TransitIP struct {
+	// Specifies the ID of the transit IP address.
+	Id string `json:"id"`
+	// Project ID
+	ProjectId string `json:"project_id"`
+	// Specifies the network interface ID of the transit IP address.
+	NetworkInterfaceId string `json:"network_interface_id"`
+	// Specifies the transit IP address.
+	IpAddress string `json:"ip_address"`
+	// Specifies the time when the transit IP address was assigned. It is a UTC time in yyyy-mm-ddThh:mm:ssZ format.
+	CreatedAt string `json:"created_at"`
+	// Specifies the time when the transit IP address was updated. It is a UTC time in yyyy-mm-ddThh:mm:ssZ format.
+	UpdatedAt string `json:"updated_at"`
+	// Specifies the subnet ID of the current tenant.
+	VirSubnetID string `json:"virsubnet_id"`
+	// Specifies the tag list.
+	Tags []Tag `json:"tags"`
+	// Specifies the ID of the private NAT gateway associated with the transit IP address.
+	GatewayId string `json:"gateway_id"`
+	// Specifies the ID of the enterprise project that is associated with the transit IP address when the transit IP address is being assigned.
+	EnterpriseProjectID string `json:"enterprise_project_id"`
+	// Specifies the transit IP address status.
+	// The value can be:
+	// ACTIVE: The transit IP address is running properly.
+	// FROZEN: The transit IP address is frozen.
+	Status string `json:"status"`
+}
+
+type Tag struct {
+	// Specifies the tag key. A key can contain up to 128 Unicode characters.
+	// Key cannot be left blank.
+	Key string `json:"key"`
+	// Specifies the tag value. Each value can contain up to 255 Unicode characters.
+	Value string `json:"value"`
+}

--- a/openstack/networking/v3/privatenat/transitip/Create.go
+++ b/openstack/networking/v3/privatenat/transitip/Create.go
@@ -1,0 +1,47 @@
+package transitip
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateTransitIpOpts struct {
+	// Specifies the subnet ID of the current project.
+	VirSubnetID string `json:"virsubnet_id" required:"true"`
+	// Specifies the transit IP address.
+	IpAddress string `json:"ip_address,omitempty"`
+	// Specifies the ID of the enterprise project that is associated with the transit IP address when the transit IP address is being assigned.
+	// Default value: 0.
+	EnterpriseProjectID string `json:"enterprise_project_id,omitempty"`
+	// Specifies the tag list.
+	Tags []TagOptions `json:"tags,omitempty"`
+}
+
+type TagOptions struct {
+	// Specifies the tag key. A key can contain up to 128 Unicode characters.
+	// Key cannot be left blank.
+	Key string `json:"key" required:"true"`
+	// Specifies the tag value. Each value can contain up to 255 Unicode characters.
+	Value string `json:"value" required:"true"`
+}
+
+// This function is used to assign a transit IP address.
+func Create(client *golangsdk.ServiceClient, opts CreateTransitIpOpts) (*TransitIPCommonResponse, error) {
+	b, err := build.RequestBody(opts, "transit_ip")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST /v3/{project_id}/private-nat/transit-ips
+	raw, err := client.Post(client.ServiceURL("private-nat", "transit-ips"), b, nil, &golangsdk.RequestOpts{
+		OkCodes:     []int{200, 201},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res TransitIPCommonResponse
+	return &res, extract.Into(raw.Body, &res)
+}

--- a/openstack/networking/v3/privatenat/transitip/Delete.go
+++ b/openstack/networking/v3/privatenat/transitip/Delete.go
@@ -1,0 +1,12 @@
+package transitip
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+// This function is used to release a transit IP address.
+func Delete(client *golangsdk.ServiceClient, transitIpId string) error {
+	// DELETE /v3/{project_id}/private-nat/transit-ips/{transit_ip_id}
+	_, err := client.Delete(client.ServiceURL("private-nat", "transit-ips", transitIpId), &golangsdk.RequestOpts{
+		OkCodes: []int{200, 204},
+	})
+	return err
+}

--- a/openstack/networking/v3/privatenat/transitip/Get.go
+++ b/openstack/networking/v3/privatenat/transitip/Get.go
@@ -1,0 +1,19 @@
+package transitip
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// This function is used to query details about a specified transit IP address.
+func Get(client *golangsdk.ServiceClient, transitIpId string) (*TransitIPCommonResponse, error) {
+	// GET /v3/{project_id}/private-nat/transit-ips/{transit_ip_id}
+	raw, err := client.Get(client.ServiceURL("private-nat", "transit-ips", transitIpId), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res TransitIPCommonResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/networking/v3/privatenat/transitip/List.go
+++ b/openstack/networking/v3/privatenat/transitip/List.go
@@ -1,0 +1,75 @@
+package transitip
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListTransitIpsQueryParams struct {
+	// Specifies the number of records displayed on each page.
+	// The value ranges from 1 to 2000. Default value: 2000
+	Limit int `q:"limit"`
+	// Specifies the start resource ID of pagination query. If the parameter is left blank, only resources on the first page are queried.
+	// The value is obtained from next_marker or previous_marker in PageInfo queried last time.
+	Marker string `q:"marker"`
+	// Specifies whether to query resources on the previous page.
+	PageReverse bool `q:"page_reverse"`
+	// Specifies the ID of the transit IP address.
+	Id []string `q:"id"`
+	// Project ID
+	ProjectId []string `q:"project_id"`
+	// Specifies the network interface ID of the transit IP address.
+	NetworkInterfaceId []string `q:"network_interface_id"`
+	// Specifies the transit IP address.
+	IpAddress []string `q:"ip_address"`
+	// Specifies the ID of the private NAT gateway associated with the transit IP address.
+	GatewayId []string `q:"gateway_id"`
+	// Specifies the ID of the enterprise project that is associated with the transit IP address when the transit IP address is assigned.
+	EnterpriseProjectId []string `q:"enterprise_project_id"`
+	// Specifies the subnet ID of the current tenant.
+	VirSubnetID []string `q:"virsubnet_id"`
+	// Specifies the transit subnet ID.
+	TransitSubnetId []string `q:"transit_subnet_id"`
+	// Provides supplementary information about the transit IP address.
+	// The description can contain up to 255 characters and cannot contain angle brackets (<>).
+	Description []string `q:"description"`
+}
+
+// This function is used to query transit IP addresses.
+func List(client *golangsdk.ServiceClient, opts ListResponse) (*ListResponse, error) {
+	// GET /v3/{project_id}/private-nat/transit-ips
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("private-nat", "transit-ips").
+		WithQueryParams(opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListResponse struct {
+	// Specifies the response body for querying transit IP addresses.
+	TransitIps []TransitIP `json:"transit_ips"`
+	// Request ID
+	RequestID string `json:"request_id"`
+	// Specifies the pagination information.
+	PageInfo PageInfo `json:"page_info"`
+}
+
+type PageInfo struct {
+	// Specifies the ID of the last record in this query, which can be used in the next query.
+	NextMarker string `json:"next_marker"`
+	// Specifies the ID of the first record in the pagination query result.
+	// When page_reverse is set to true, this parameter is used together to query resources on the previous page.
+	PreviousMarker string `json:"previous_marker"`
+	// Specifies the ID of the last record in the pagination query result. It is usually used to query resources on the next page. Value range: 1-200
+	CurrentCount int `json:"current_count"`
+}

--- a/openstack/networking/v3/privatenat/transitip/List.go
+++ b/openstack/networking/v3/privatenat/transitip/List.go
@@ -36,7 +36,7 @@ type ListTransitIpsQueryParams struct {
 }
 
 // This function is used to query transit IP addresses.
-func List(client *golangsdk.ServiceClient, opts ListResponse) (*ListResponse, error) {
+func List(client *golangsdk.ServiceClient, opts ListTransitIpsQueryParams) (*ListResponse, error) {
 	// GET /v3/{project_id}/private-nat/transit-ips
 	url, err := golangsdk.NewURLBuilder().
 		WithEndpoints("private-nat", "transit-ips").


### PR DESCRIPTION
### What this PR does / why we need it

Add new service [Private NAT Transit IP Addresses](https://docs.otc.t-systems.com/nat-gateway/api-ref/apis_for_private_nat_gateways_v3.0/transit_ip_addresses/index.html).

### Which issue this PR fixes

OTC Provider Issue [#3066](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3066)

### Tests

```
=== RUN   TestPrivateNatTransitIpLifecycle
    transitip_test.go:25: Created Transit IP: 045dc9a1-325f-42f8-a1af-40cfeccd6ab2
    transitip_test.go:27: Deleting Transit IP: 045dc9a1-325f-42f8-a1af-40cfeccd6ab2
    transitip_test.go:29: Deleting Transit IP: 045dc9a1-325f-42f8-a1af-40cfeccd6ab2
--- PASS: TestPrivateNatTransitIpLifecycle (11.44s)
PASS
```
