### PR TITLE
[Feat/Test] Network: Add Private NAT SNAT rules service APIs and additional tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
           OS_REGION: "eu-de"
 
   eco_check:
-    name: eco/check
+    name: check
     if: >
       always()
     needs: [lint, vet, unit_tests, acc_tests]

--- a/acceptance/openstack/networking/v3/privatenat/dnatrules_test.go
+++ b/acceptance/openstack/networking/v3/privatenat/dnatrules_test.go
@@ -35,12 +35,18 @@ func TestPrivateNatDnatRulesLifecycle(t *testing.T) {
 	t.Cleanup(func() {
 		t.Logf("Deleting DNAT rule: %s", ruleId)
 		th.AssertNoErr(t, dnatrules.Delete(client, ruleId))
-		t.Logf("Deleting DNAT rule: %s", ruleId)
+		t.Logf("Deleted DNAT rule: %s", ruleId)
 	})
 
 	getResponse, err := dnatrules.Get(client, ruleId)
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, "created", getResponse.DnatRule.Description)
+
+	listResponse, err := dnatrules.List(client, dnatrules.ListDnatRulesQueryParams{
+		Id: []string{ruleId},
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(listResponse.DnatRules))
 
 	updateResponse, err := dnatrules.Update(client, ruleId, dnatrules.UpdatePrivateDnatOpts{
 		Description: "updated",

--- a/acceptance/openstack/networking/v3/privatenat/natgateway_test.go
+++ b/acceptance/openstack/networking/v3/privatenat/natgateway_test.go
@@ -23,6 +23,12 @@ func TestPrivateNatGatewayLifecycle(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, natGateway.Name, getResponse.Gateway.Name)
 
+	listResponse, err := natgateway.List(client, natgateway.ListGatewaysQueryParams{
+		Id: []string{natGateway.Id},
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(listResponse.Gateways))
+
 	updateResponse, err := natgateway.Update(client, natGateway.Id, natgateway.UpdateGatewayOpts{
 		Description: "updated",
 	})

--- a/acceptance/openstack/networking/v3/privatenat/snatrules_test.go
+++ b/acceptance/openstack/networking/v3/privatenat/snatrules_test.go
@@ -1,0 +1,56 @@
+package privatenat
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v3/privatenat/snatrules"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestPrivateNatSnatRulesLifecycle(t *testing.T) {
+	client, err := clients.NewNatV3Client()
+	th.AssertNoErr(t, err)
+	transitIpId := clients.EnvOS.GetEnv("TRANSIT_IP_ID")
+	networkId := clients.EnvOS.GetEnv("NETWORK_ID")
+	if transitIpId == "" || networkId == "" {
+		t.Skip("OS_TRANSIT_IP_ID or OS_NETWORK_ID is missing but test requires using existing network")
+	}
+
+	natGateway := createPrivateNatGateway(t, client)
+	t.Cleanup(func() {
+		deletePrivateNatGateway(t, client, natGateway.Id)
+	})
+
+	createOpts := snatrules.CreatePrivateSnatOpts{
+		GatewayId:    natGateway.Id,
+		VirSubnetId:  networkId,
+		Description:  "created",
+		TransitIpIds: []string{transitIpId},
+	}
+	snatCreateResp, err := snatrules.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+	ruleId := snatCreateResp.SnatRule.Id
+	t.Logf("Created SNAT rule: %s", ruleId)
+	t.Cleanup(func() {
+		t.Logf("Deleting SNAT rule: %s", ruleId)
+		th.AssertNoErr(t, snatrules.Delete(client, ruleId))
+		t.Logf("Deleted SNAT rule: %s", ruleId)
+	})
+
+	getResponse, err := snatrules.Get(client, ruleId)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "created", getResponse.SnatRule.Description)
+
+	listResponse, err := snatrules.List(client, snatrules.ListSnatRulesQueryParams{
+		Id: []string{ruleId},
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(listResponse.SnatRules))
+
+	updateResponse, err := snatrules.Update(client, ruleId, snatrules.UpdatePrivateSnatOpts{
+		Description: "updated",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "updated", updateResponse.SnatRule.Description)
+}

--- a/acceptance/openstack/networking/v3/privatenat/transitip_test.go
+++ b/acceptance/openstack/networking/v3/privatenat/transitip_test.go
@@ -26,7 +26,7 @@ func TestPrivateNatTransitIpLifecycle(t *testing.T) {
 	t.Cleanup(func() {
 		t.Logf("Deleting Transit IP: %s", transitIpId)
 		th.AssertNoErr(t, transitip.Delete(client, transitIpId))
-		t.Logf("Deleting Transit IP: %s", transitIpId)
+		t.Logf("Deleted Transit IP: %s", transitIpId)
 	})
 
 	getResponse, err := transitip.Get(client, transitIpId)

--- a/openstack/networking/v3/privatenat/snatrules/Common.go
+++ b/openstack/networking/v3/privatenat/snatrules/Common.go
@@ -1,0 +1,46 @@
+package snatrules
+
+// ############# COMMON RESPONSE STRUCTS #############
+
+type SnatCommonResponse struct {
+	// Specifies the response body of the SNAT rule
+	SnatRule PrivateSnat `json:"snat_rule"`
+	// Specifies the request ID
+	RequestId string `json:"request_id"`
+}
+
+type PrivateSnat struct {
+	// Specifies the SNAT rule ID
+	Id string `json:"id"`
+	// Specifies the project ID
+	ProjectId string `json:"project_id"`
+	// Specifies the private NAT gateway ID
+	GatewayId string `json:"gateway_id"`
+	// Specifies the CIDR block that matches the SNAT rule.
+	// Constraint: Either this parameter or virsubnet_id must be specified.
+	Cidr string `json:"cidr"`
+	// Specifies the ID of the subnet that matches the SNAT rule.
+	// Constraint: Either this parameter or cidr must be specified.
+	VirSubnetId string `json:"virsubnet_id"`
+	// Provides supplementary information about the SNAT rule.
+	// The description can contain up to 255 characters and cannot contain angle brackets (<>).
+	Description string `json:"description"`
+	// Specifies the list of details of associated transit IP addresses.
+	TransitIpAssociations []TransitIPAssociation `json:"transit_ip_associations"`
+	// Specifies the time when the SNAT rule was created (UTC, yyyy-mm-ddThh:mm:ssZ)
+	CreatedAt string `json:"created_at"`
+	// Specifies the time when the SNAT rule was updated (UTC, yyyy-mm-ddThh:mm:ssZ)
+	UpdatedAt string `json:"updated_at"`
+	// Specifies the ID of the enterprise project that is associated with the SNAT rule when created
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// Specifies the SNAT rule status of a private NAT gateway.
+	// Enumeration values: ACTIVE, FROZEN
+	Status string `json:"status"`
+}
+
+type TransitIPAssociation struct {
+	// Specifies the ID of the transit IP address
+	TransitIpId string `json:"transit_ip_id"`
+	// Specifies the transit IP address
+	TransitIpAddress string `json:"transit_ip_address"`
+}

--- a/openstack/networking/v3/privatenat/snatrules/Create.go
+++ b/openstack/networking/v3/privatenat/snatrules/Create.go
@@ -1,0 +1,44 @@
+package snatrules
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreatePrivateSnatOpts struct {
+	// Specifies the private NAT gateway ID.
+	GatewayId string `json:"gateway_id" required:"true"`
+	// Specifies the CIDR block that matches the SNAT rule.
+	// Constraint: Either this parameter or virsubnet_id must be specified.
+	Cidr string `json:"cidr,omitempty"`
+	// Specifies the ID of the subnet that matches the SNAT rule.
+	// Constraint: Either this parameter or cidr must be specified.
+	VirSubnetId string `json:"virsubnet_id,omitempty"`
+	// Provides supplementary information about the SNAT rule.
+	// The description can contain up to 255 characters and cannot contain angle brackets (<>).
+	Description string `json:"description,omitempty"`
+	// Specifies the IDs of the transit IP addresses.
+	// Constraints: A maximum number of 20 IDs is allowed.
+	TransitIpIds []string `json:"transit_ip_ids" required:"true"`
+}
+
+// This function is used to create an SNAT rule.
+func Create(client *golangsdk.ServiceClient, opts CreatePrivateSnatOpts) (*SnatCommonResponse, error) {
+	b, err := build.RequestBody(opts, "snat_rule")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST /v3/{project_id}/private-nat/snat-rules
+	raw, err := client.Post(client.ServiceURL("private-nat", "snat-rules"), b, nil, &golangsdk.RequestOpts{
+		OkCodes:     []int{200, 201},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res SnatCommonResponse
+	return &res, extract.Into(raw.Body, &res)
+}

--- a/openstack/networking/v3/privatenat/snatrules/Delete.go
+++ b/openstack/networking/v3/privatenat/snatrules/Delete.go
@@ -1,0 +1,12 @@
+package snatrules
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+// This function is used to delete a specified SNAT rule.
+func Delete(client *golangsdk.ServiceClient, ruleId string) error {
+	// DELETE /v3/{project_id}/private-nat/snat-rules/{snat_rule_id}
+	_, err := client.Delete(client.ServiceURL("private-nat", "snat-rules", ruleId), &golangsdk.RequestOpts{
+		OkCodes: []int{200, 204},
+	})
+	return err
+}

--- a/openstack/networking/v3/privatenat/snatrules/Get.go
+++ b/openstack/networking/v3/privatenat/snatrules/Get.go
@@ -1,0 +1,19 @@
+package snatrules
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// This function is used to query details about a specified SNAT rule.
+func Get(client *golangsdk.ServiceClient, ruleId string) (*SnatCommonResponse, error) {
+	// GET /v3/{project_id}/private-nat/snat-rules/{snat_rule_id}
+	raw, err := client.Get(client.ServiceURL("private-nat", "snat-rules", ruleId), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res SnatCommonResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/networking/v3/privatenat/snatrules/List.go
+++ b/openstack/networking/v3/privatenat/snatrules/List.go
@@ -1,0 +1,75 @@
+package snatrules
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListSnatRulesQueryParams struct {
+	// Specifies the number of records displayed on each page.
+	// The value ranges from 1 to 2000. Default value: 2000
+	Limit int `q:"limit"`
+	// Specifies the start resource ID of pagination query. If the parameter is left blank, only resources on the first page are queried.
+	// The value is obtained from next_marker or previous_marker in PageInfo queried last time.
+	Marker string `q:"marker"`
+	// Specifies whether to query resources on the previous page.
+	PageReverse bool `q:"page_reverse"`
+	// Specifies the SNAT rule ID.
+	Id []string `q:"id"`
+	// Project ID
+	ProjectId []string `q:"project_id"`
+	// Provides supplementary information about the private NAT gateway.
+	// The description can contain up to 255 characters and cannot contain angle brackets (<>).
+	Description []string `q:"description"`
+	// Specifies the private NAT gateway ID.
+	GatewayId []string `q:"gateway_id"`
+	// Specifies the CIDR block that matches the SNAT rule.
+	Cidr []string `q:"cidr"`
+	// Specifies the ID of the subnet that matches the SNAT rule.
+	VirSubnetId []string `q:"virsubnet_id"`
+	// Specifies the ID of the transit IP address.
+	TransitIpId []string `q:"transit_ip_id"`
+	// Specifies the transit IP address.
+	TransitIpAddress []string `q:"transit_ip_address"`
+	// Specifies the ID of the enterprise project that is associated with the SNAT rule when the SNAT rule is created.
+	EnterpriseProjectId []string `q:"enterprise_project_id"`
+}
+
+// This function is used to query SNAT rules.
+func List(client *golangsdk.ServiceClient, opts ListSnatRulesQueryParams) (*ListResponse, error) {
+	// GET /v3/{project_id}/private-nat/snat-rules
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("private-nat", "snat-rules").
+		WithQueryParams(opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListResponse struct {
+	// Specifies the response body for querying SNAT rules.
+	SnatRules []PrivateSnat `json:"snat_rules"`
+	// Request ID
+	RequestID string `json:"request_id"`
+	// Specifies the pagination information.
+	PageInfo PageInfo `json:"page_info"`
+}
+
+type PageInfo struct {
+	// Specifies the ID of the last record in this query, which can be used in the next query.
+	NextMarker string `json:"next_marker"`
+	// Specifies the ID of the first record in the pagination query result.
+	// When page_reverse is set to true, this parameter is used together to query resources on the previous page.
+	PreviousMarker string `json:"previous_marker"`
+	// Specifies the ID of the last record in the pagination query result. It is usually used to query resources on the next page. Value range: 1-200
+	CurrentCount int `json:"current_count"`
+}

--- a/openstack/networking/v3/privatenat/snatrules/Update.go
+++ b/openstack/networking/v3/privatenat/snatrules/Update.go
@@ -1,0 +1,36 @@
+package snatrules
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type UpdatePrivateSnatOpts struct {
+	// Provides supplementary information about the SNAT rule.
+	// The description can contain up to 255 characters and cannot contain angle brackets (<>).
+	Description string `json:"description,omitempty"`
+	// Specifies the IDs of the transit IP addresses.
+	// Constraints: A maximum number of 20 IDs is allowed.
+	TransitIpIds []string `json:"transit_ip_ids,omitempty"`
+}
+
+// This function is used to update an SNAT rule.
+func Update(client *golangsdk.ServiceClient, ruleId string, opts UpdatePrivateSnatOpts) (*SnatCommonResponse, error) {
+	b, err := build.RequestBody(opts, "snat_rule")
+	if err != nil {
+		return nil, err
+	}
+
+	// PUT /v3/{project_id}/private-nat/snat-rules/{snat_rule_id}
+	raw, err := client.Put(client.ServiceURL("private-nat", "snat-rules", ruleId), b, nil, &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res SnatCommonResponse
+	return &res, extract.Into(raw.Body, &res)
+}


### PR DESCRIPTION
### What this PR does / why we need it

Add new service [Private NAT SNAT rules](https://docs.otc.t-systems.com/nat-gateway/api-ref/apis_for_private_nat_gateways_v3.0/snat_rules/index.html).
Test List functions for Private NAT gateway and DNAT rules

### Which issue this PR fixes

OTC Provider Issue [#3066](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3066)

### Tests

```
=== RUN   TestPrivateNatSnatRulesLifecycle
    natgateway_test.go:34: Attempting to create Private Nat Gateway
    natgateway_test.go:57: Created Nat Gateway: 129cbd1f-6289-4102-91c5-b10d13e4519c
    snatrules_test.go:34: Created SNAT rule: bbcdb0c1-1bcd-47f8-9d6a-c6ddf260dcde
    snatrules_test.go:36: Deleting SNAT rule: bbcdb0c1-1bcd-47f8-9d6a-c6ddf260dcde
    snatrules_test.go:38: Deleted SNAT rule: bbcdb0c1-1bcd-47f8-9d6a-c6ddf260dcde
    natgateway_test.go:63: Attempting to delete Private Nat Gateway: 129cbd1f-6289-4102-91c5-b10d13e4519c
    natgateway_test.go:67: Private Nat Gateway is deleted: 129cbd1f-6289-4102-91c5-b10d13e4519c
--- PASS: TestPrivateNatSnatRulesLifecycle (4.05s)
PASS
=== RUN   TestPrivateNatGatewayLifecycle
    natgateway_test.go:40: Attempting to create Private Nat Gateway
    natgateway_test.go:63: Created Nat Gateway: fdf6cf4f-4376-4fb8-8f34-115bd2f9950f
    natgateway_test.go:69: Attempting to delete Private Nat Gateway: fdf6cf4f-4376-4fb8-8f34-115bd2f9950f
    natgateway_test.go:73: Private Nat Gateway is deleted: fdf6cf4f-4376-4fb8-8f34-115bd2f9950f
--- PASS: TestPrivateNatGatewayLifecycle (7.17s)
PASS
=== RUN   TestPrivateNatDnatRulesLifecycle
    natgateway_test.go:40: Attempting to create Private Nat Gateway
    natgateway_test.go:63: Created Nat Gateway: 077d83b0-5b0d-4655-8cc6-2c9e4c957909
    dnatrules_test.go:34: Created DNAT rule: 7d3cf6f9-2214-467a-b2af-e9bf6da95e0e
    dnatrules_test.go:36: Deleting DNAT rule: 7d3cf6f9-2214-467a-b2af-e9bf6da95e0e
    dnatrules_test.go:38: Deleted DNAT rule: 7d3cf6f9-2214-467a-b2af-e9bf6da95e0e
    natgateway_test.go:69: Attempting to delete Private Nat Gateway: 077d83b0-5b0d-4655-8cc6-2c9e4c957909
    natgateway_test.go:73: Private Nat Gateway is deleted: 077d83b0-5b0d-4655-8cc6-2c9e4c957909
--- PASS: TestPrivateNatDnatRulesLifecycle (12.56s)
PASS
```
