### PR TITLE
[Feat.] Taurusdb: sql filter methods

### DIFF
--- a/acceptance/openstack/cbr/v3/backups_test.go
+++ b/acceptance/openstack/cbr/v3/backups_test.go
@@ -51,6 +51,9 @@ func TestBackupLifecycle(t *testing.T) {
 }
 
 func TestBackupListing(t *testing.T) {
+	if os.Getenv("RUN_CBR") == "" {
+		t.Skip("too long to run in ci")
+	}
 	client, err := clients.NewCbrV3Client()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/taurus/v3/sqlfilter_test.go
+++ b/acceptance/openstack/taurus/v3/sqlfilter_test.go
@@ -1,0 +1,190 @@
+package v3
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/taurus/v3/instance"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/taurus/v3/job"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/taurus/v3/sqlfilter"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestTaurusSqlFilterLifecycle(t *testing.T) {
+	// t.Skip("too long to run in ci")
+	vpcID := os.Getenv("OS_VPC_ID")
+	subnetID := os.Getenv("OS_NETWORK_ID")
+	secGroupID := os.Getenv("OS_SECURITY_GROUP_ID")
+
+	client, err := clients.NewTaurusDBV3Client()
+	th.AssertNoErr(t, err)
+
+	createResp := createTaurusInstance(t, client, vpcID, subnetID, secGroupID)
+	instanceID := createResp.Instance.Id
+
+	t.Cleanup(func() {
+		t.Logf("Attempting to delete taurus db")
+		_, err = instance.Delete(client, instanceID)
+		th.AssertNoErr(t, err)
+	})
+
+	t.Logf("Waiting for instance to become available")
+	err = waitForInstanceAvailable(client, 1200, instanceID)
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to create taurus db read replica")
+
+	createReplicaJobs, err := instance.CreateReplica(client, createResp.Instance.Id,
+		instance.CreateReplicaOpts{
+			Priorities: []int{1, 2},
+		},
+	)
+	th.AssertNoErr(t, err)
+
+	replicaJobs := strings.Split(*createReplicaJobs, ",")
+
+	th.AssertNoErr(t, job.WaitForJobSuccess(client, 600, replicaJobs[0]))
+	th.AssertNoErr(t, job.WaitForJobSuccess(client, 600, replicaJobs[1]))
+
+	getResp, err := instance.Get(client, createResp.Instance.Id)
+	th.AssertNoErr(t, err)
+
+	nodeId := getResp.Nodes[0].Id
+
+	t.Logf("Testing GetSqlFilterSwitch - should be OFF by default")
+	switchResponse, err := sqlfilter.GetSqlFilterSwitch(client, instanceID)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, switchResponse.SwitchStatus, "OFF")
+
+	t.Logf("Testing SwitchSqlFilter - enabling")
+	enableSqlFilterOpts := sqlfilter.SqlFilterSwitchOpts{
+		SwitchStatus: "ON",
+		InstanceId:   instanceID,
+	}
+	jobID, err := sqlfilter.SwitchSqlFilter(client, enableSqlFilterOpts)
+	th.AssertNoErr(t, err)
+
+	t.Logf("Waiting for enable sql filter job to complete")
+	th.AssertNoErr(t, job.WaitForJobSuccess(client, 300, *jobID))
+
+	t.Cleanup(func() {
+		t.Logf("Attempting to disable sql filter")
+		disableOpts := sqlfilter.SqlFilterSwitchOpts{
+			SwitchStatus: "OFF",
+			InstanceId:   instanceID,
+		}
+		jobID, err = sqlfilter.SwitchSqlFilter(client, disableOpts)
+		th.AssertNoErr(t, err)
+
+		t.Logf("Waiting for disable sql filter job to complete")
+		th.AssertNoErr(t, job.WaitForJobSuccess(client, 300, *jobID))
+	})
+
+	t.Logf("Testing GetSqlFilterSwitch - should be ON now")
+	switchResponse, err = sqlfilter.GetSqlFilterSwitch(client, instanceID)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, switchResponse.SwitchStatus, "ON")
+
+	t.Logf("Testing UpdateSqlFilterRules")
+	updateRulesOpts := sqlfilter.UpdateSqlFilterRulesOpts{
+		SqlFilterRules: []sqlfilter.NodeSqlFilterRuleInfo{
+			{
+				NodeId: nodeId,
+				Rules: []sqlfilter.NodeSqlFilterRule{
+					{
+						SqlType: "SELECT",
+						Patterns: []sqlfilter.NodeSqlFilterRulePattern{
+							{
+								Pattern:        "select~from~test_table",
+								MaxConcurrency: 10,
+							},
+							{
+								Pattern:        "select~from~users~where~id",
+								MaxConcurrency: 5,
+							},
+						},
+					},
+					{
+						SqlType: "UPDATE",
+						Patterns: []sqlfilter.NodeSqlFilterRulePattern{
+							{
+								Pattern:        "update~test_table~set",
+								MaxConcurrency: 3,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	jobID, err = sqlfilter.UpdateSqlFilterRules(client, instanceID, updateRulesOpts)
+	th.AssertNoErr(t, err)
+
+	t.Logf("Waiting for update sql filter rules job to complete")
+	th.AssertNoErr(t, job.WaitForJobSuccess(client, 300, *jobID))
+
+	t.Logf("Testing GetSqlFilterRules - all rules")
+	getRulesOpts := sqlfilter.GetSqlFilterRulesOpts{
+		NodeId: nodeId,
+	}
+	rulesResponse, err := sqlfilter.GetSqlFilterRules(client, instanceID, getRulesOpts)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, rulesResponse.NodeId, nodeId)
+	th.AssertEquals(t, len(rulesResponse.SqlFilterRules) > 0, true)
+
+	t.Logf("Testing GetSqlFilterRules - SELECT only")
+	getRulesOptsSelect := sqlfilter.GetSqlFilterRulesOpts{
+		NodeId: nodeId,
+		Type:   "SELECT",
+	}
+	selectRulesResponse, err := sqlfilter.GetSqlFilterRules(client, instanceID, getRulesOptsSelect)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, selectRulesResponse.NodeId, nodeId)
+
+	hasSelectRule := false
+	for _, rule := range selectRulesResponse.SqlFilterRules {
+		if rule.SqlType == "SELECT" {
+			hasSelectRule = true
+			th.AssertEquals(t, len(rule.Patterns) > 0, true)
+			break
+		}
+	}
+	th.AssertEquals(t, hasSelectRule, true)
+
+	t.Logf("Testing DeleteSqlFilterRules")
+	deleteRulesOpts := sqlfilter.DeleteSqlFilterRulesOpts{
+		SqlFilterRules: []sqlfilter.DeleteNodeSqlFilterRuleInfo{
+			{
+				NodeId: nodeId,
+				Rules: []sqlfilter.DeleteNodeSqlFilterRule{
+					{
+						SqlType:  "SELECT",
+						Patterns: []string{"select~from~test_table"},
+					},
+					{
+						SqlType:  "UPDATE",
+						Patterns: []string{"update~test_table~set"},
+					},
+				},
+			},
+		},
+	}
+	jobID, err = sqlfilter.DeleteSqlFilterRules(client, instanceID, deleteRulesOpts)
+	th.AssertNoErr(t, err)
+
+	t.Logf("Waiting for delete sql filter rules job to complete")
+	th.AssertNoErr(t, job.WaitForJobSuccess(client, 300, *jobID))
+
+	t.Logf("Verifying rules were deleted")
+	finalRulesResponse, err := sqlfilter.GetSqlFilterRules(client, instanceID, getRulesOpts)
+	th.AssertNoErr(t, err)
+
+	for _, rule := range finalRulesResponse.SqlFilterRules {
+		for _, pattern := range rule.Patterns {
+			th.AssertEquals(t, pattern.Pattern != "select~from~test_table", true)
+			th.AssertEquals(t, pattern.Pattern != "update~test_table~set", true)
+		}
+	}
+}

--- a/acceptance/openstack/taurus/v3/sqlfilter_test.go
+++ b/acceptance/openstack/taurus/v3/sqlfilter_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestTaurusSqlFilterLifecycle(t *testing.T) {
-	// t.Skip("too long to run in ci")
+	t.Skip("too long to run in ci")
 	vpcID := os.Getenv("OS_VPC_ID")
 	subnetID := os.Getenv("OS_NETWORK_ID")
 	secGroupID := os.Getenv("OS_SECURITY_GROUP_ID")

--- a/openstack/taurus/v3/sqlfilter/DeleteSqlFIlterRules.go
+++ b/openstack/taurus/v3/sqlfilter/DeleteSqlFIlterRules.go
@@ -1,0 +1,36 @@
+package sqlfilter
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type DeleteSqlFilterRulesOpts struct {
+	SqlFilterRules []DeleteNodeSqlFilterRuleInfo `json:"sql_filter_rules" required:"true"`
+}
+
+type DeleteNodeSqlFilterRuleInfo struct {
+	NodeId string                    `json:"node_id" required:"true"`
+	Rules  []DeleteNodeSqlFilterRule `json:"rules" required:"true"`
+}
+
+type DeleteNodeSqlFilterRule struct {
+	SqlType  string   `json:"sql_type" required:"true"`
+	Patterns []string `json:"patterns" required:"true"`
+}
+
+func DeleteSqlFilterRules(client *golangsdk.ServiceClient, instanceId string, opts DeleteSqlFilterRulesOpts) (*string, error) {
+	raw, err := client.Delete(client.ServiceURL("instances", instanceId, "sql-filter", "rules"), &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: opts,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res jobResponse
+	return &res.JobId, extract.Into(raw.Body, &res)
+}

--- a/openstack/taurus/v3/sqlfilter/GetSqlFilterRules.go
+++ b/openstack/taurus/v3/sqlfilter/GetSqlFilterRules.go
@@ -1,0 +1,45 @@
+package sqlfilter
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type GetSqlFilterRulesOpts struct {
+	NodeId string `q:"node_id" required:"true"`
+	Type   string `q:"type,omitempty"`
+}
+
+func GetSqlFilterRules(client *golangsdk.ServiceClient, instanceId string, opts GetSqlFilterRulesOpts) (*SqlFilterRulesResponse, error) {
+	url := client.ServiceURL("instances", instanceId, "sql-filter", "rules")
+
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	raw, err := client.Get(url, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res SqlFilterRulesResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type SqlFilterRulesResponse struct {
+	NodeId         string          `json:"node_id"`
+	SqlFilterRules []SqlFilterRule `json:"sql_filter_rules"`
+}
+
+type SqlFilterRule struct {
+	SqlType  string                 `json:"sql_type"`
+	Patterns []SqlFilterRulePattern `json:"patterns"`
+}
+
+type SqlFilterRulePattern struct {
+	Pattern        string `json:"pattern"`
+	MaxConcurrency int    `json:"max_concurrency"`
+}

--- a/openstack/taurus/v3/sqlfilter/GetSqlFilterSwitch.go
+++ b/openstack/taurus/v3/sqlfilter/GetSqlFilterSwitch.go
@@ -1,0 +1,21 @@
+package sqlfilter
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func GetSqlFilterSwitch(client *golangsdk.ServiceClient, instanceId string) (*SqlFilterSwitchResponse, error) {
+	raw, err := client.Get(client.ServiceURL("instances", instanceId, "sql-filter", "switch"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res SqlFilterSwitchResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type SqlFilterSwitchResponse struct {
+	SwitchStatus string `json:"switch_status"`
+}

--- a/openstack/taurus/v3/sqlfilter/SwitchSqlFilter.go
+++ b/openstack/taurus/v3/sqlfilter/SwitchSqlFilter.go
@@ -1,0 +1,33 @@
+package sqlfilter
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type SqlFilterSwitchOpts struct {
+	InstanceId   string `json:"-"`
+	SwitchStatus string `json:"switch_status" required:"true"`
+}
+
+func SwitchSqlFilter(client *golangsdk.ServiceClient, opts SqlFilterSwitchOpts) (*string, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Post(client.ServiceURL("instances", opts.InstanceId, "sql-filter", "switch"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res jobResponse
+	return &res.JobId, extract.Into(raw.Body, &res)
+}
+
+type jobResponse struct {
+	JobId string `json:"job_id"`
+}

--- a/openstack/taurus/v3/sqlfilter/UpdateSqlFilterRules.go
+++ b/openstack/taurus/v3/sqlfilter/UpdateSqlFilterRules.go
@@ -1,0 +1,43 @@
+package sqlfilter
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type UpdateSqlFilterRulesOpts struct {
+	SqlFilterRules []NodeSqlFilterRuleInfo `json:"sql_filter_rules" required:"true"`
+}
+
+type NodeSqlFilterRuleInfo struct {
+	NodeId string              `json:"node_id" required:"true"`
+	Rules  []NodeSqlFilterRule `json:"rules" required:"true"`
+}
+
+type NodeSqlFilterRule struct {
+	SqlType  string                     `json:"sql_type" required:"true"`
+	Patterns []NodeSqlFilterRulePattern `json:"patterns" required:"true"`
+}
+
+type NodeSqlFilterRulePattern struct {
+	Pattern        string `json:"pattern" required:"true"`
+	MaxConcurrency int    `json:"max_concurrency" required:"true"`
+}
+
+func UpdateSqlFilterRules(client *golangsdk.ServiceClient, instanceId string, opts UpdateSqlFilterRulesOpts) (*string, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Put(client.ServiceURL("instances", instanceId, "sql-filter", "rules"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res jobResponse
+	return &res.JobId, extract.Into(raw.Body, &res)
+}


### PR DESCRIPTION
### Acceptance tests
```
=== RUN   TestTaurusSqlFilterLifecycle
    instance_test.go:17: Attempting to create taurus db
    sqlfilter_test.go:33: Waiting for instance to become available
    sqlfilter_test.go:37: Attempting to create taurus db read replica
    sqlfilter_test.go:56: Testing GetSqlFilterSwitch - should be OFF by default
    sqlfilter_test.go:61: Testing SwitchSqlFilter - enabling
    sqlfilter_test.go:69: Waiting for enable sql filter job to complete
    sqlfilter_test.go:85: Testing GetSqlFilterSwitch - should be ON now
    sqlfilter_test.go:90: Testing UpdateSqlFilterRules
    sqlfilter_test.go:125: Waiting for update sql filter rules job to complete
    sqlfilter_test.go:128: Testing GetSqlFilterRules - all rules
    sqlfilter_test.go:137: Testing GetSqlFilterRules - SELECT only
    sqlfilter_test.go:156: Testing DeleteSqlFilterRules
    sqlfilter_test.go:177: Waiting for delete sql filter rules job to complete
    sqlfilter_test.go:180: Verifying rules were deleted
    sqlfilter_test.go:73: Attempting to disable sql filter
    sqlfilter_test.go:81: Waiting for disable sql filter job to complete
    sqlfilter_test.go:28: Attempting to delete taurus db
--- PASS: TestTaurusSqlFilterLifecycle (1403.37s)
PASS

Process finished with the exit code 0
```