### PR TITLE
[Fix] SFSTurbo: Add hpc_bw to SFS Turbo share output

### DIFF
--- a/openstack/sfs_turbo/v1/shares/Common.go
+++ b/openstack/sfs_turbo/v1/shares/Common.go
@@ -1,7 +1,7 @@
 package shares
 
 import (
-	"github.com/opentelekomcloud/gophertelekomcloud"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
 
@@ -50,6 +50,8 @@ type Turbo struct {
 	AvailCapacity string `json:"avail_capacity"`
 	// bandwidth is returned for an enhanced file system
 	ExpandType string `json:"expand_type"`
+	// File system bandwidth.
+	HpcBW string `json:"hpc_bw"`
 	// The ID of the encryption key
 	CryptKeyID string `json:"crypt_key_id"`
 	// The billing mode, 0 indicates pay-per-use, 1 indicates yearly/monthly subscription

--- a/openstack/sfs_turbo/v1/shares/Delete.go
+++ b/openstack/sfs_turbo/v1/shares/Delete.go
@@ -6,7 +6,7 @@ import (
 
 // Delete will delete an existing SFS Turbo file system with the given UUID.
 func Delete(client *golangsdk.ServiceClient, shareId string) error {
-	// DELETE /v1/{project_id}/meshes/{mesh_id}
+	// DELETE /v1/{project_id}/sfs-turbo/shares/{share_id}
 	_, err := client.Delete(client.ServiceURL("sfs-turbo", "shares", shareId), &golangsdk.RequestOpts{
 		OkCodes: []int{200, 202},
 	})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it

Add `hpc_bw `to output field to SFS Turbo share

### Which issue this PR fixes
Refer to OTC provider issue [#3122](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3122
)
### Tests

```
=== RUN   TestSFSTurboList
--- PASS: TestSFSTurboList (0.98s)
=== RUN   TestSFSTurboLifecycle
    common.go:74: Security group 3add917a-7c40-4a17-b14f-003762b3cb55 was created
    helpers.go:15: Attempting to create SFSTurboV1
    helpers.go:39: Waiting for SFS Turbo 1306793c-4e39-4d19-b183-1484f29e404f to be active
    helpers.go:46: Created SFS turbo: 1306793c-4e39-4d19-b183-1484f29e404f
    helpers.go:64: Attempting to expand SFS Turbo: 1306793c-4e39-4d19-b183-1484f29e404f
    helpers.go:81: Expanded SFS turbo: 1306793c-4e39-4d19-b183-1484f29e404f
    helpers.go:87: Attempting to change SG SFS Turbo: 1306793c-4e39-4d19-b183-1484f29e404f
    helpers.go:104: Change SG SFS turbo: 1306793c-4e39-4d19-b183-1484f29e404f
    helpers.go:52: Attempting to delete SFS Turbo: 1306793c-4e39-4d19-b183-1484f29e404f
    helpers.go:60: Deleted SFS Turbo: 1306793c-4e39-4d19-b183-1484f29e404f
    common.go:85: Security group 3add917a-7c40-4a17-b14f-003762b3cb55 was deleted
--- PASS: TestSFSTurboLifecycle (451.47s)
PASS
```
