### PR TITLE
[DDS]: maintenance window

### DIFF
--- a/acceptance/openstack/dds/v3/instances_test.go
+++ b/acceptance/openstack/dds/v3/instances_test.go
@@ -318,6 +318,14 @@ func updateDdsInstance(t *testing.T, client *golangsdk.ServiceClient, instance i
 	th.AssertNoErr(t, err)
 	err = waitForJobCompleted(client, 600, *job)
 	th.AssertNoErr(t, err)
+
+	t.Log("Modify instance maintenance window")
+	err = instances.ModifyMaintenanceWindow(client, instances.ModifyMaintenanceWindowOpt{
+		InstanceId: instance.Id,
+		StartTime:  "14:00",
+		EndTime:    "15:00",
+	})
+	th.AssertNoErr(t, err)
 }
 
 func createDdsSingleInstance(t *testing.T, client *golangsdk.ServiceClient) *instances.Instance {

--- a/openstack/dds/v3/instances/ModifyMaintenanceWindow.go
+++ b/openstack/dds/v3/instances/ModifyMaintenanceWindow.go
@@ -1,0 +1,24 @@
+package instances
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type ModifyMaintenanceWindowOpt struct {
+	StartTime  string `json:"start_time" required:"true"`
+	EndTime    string `json:"end_time" required:"true"`
+	InstanceId string `json:"-"`
+}
+
+func ModifyMaintenanceWindow(client *golangsdk.ServiceClient, opts ModifyMaintenanceWindowOpt) error {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Put(client.ServiceURL("instances", opts.InstanceId, "maintenance-window"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 204},
+	})
+	return err
+}


### PR DESCRIPTION
### Acceptance tests
```
=== RUN   TestDdsSingleLifeCycle
    instances_test.go:126: Attempting to create DDSv3 single instance
    instances_test.go:378: DDSv3 replica set instance successfully created
    instances_test.go:136: {06419b8564af433183571b1b00984aa8in02 dds-acc-JSQloOlT  normal 8635 Single eu-de {DDS-Community 4.0 } wiredTiger 2025-09-30T07:28:57 2025-09-30T07:28:56 rwuser 0 cf9e960a-59c4-430e-8cd4-ea246bfd50a4 7e40fd6b-9b74-4e93-9af9-06359814c069 738517ba-a383-4653-a5c9-4d225ee5736e {09:00-10:00 0xc00042f4a0 } 18:00-21:00 [{single    {20 0.2938232421875} [{564f560a8e804499aaa74e21b8b9bf49no02 dds-acc-JSQloOlT_single_node_1 normal Primary 192.168.0.25  dds.mongodb.s2.medium.4.single eu-de-01}]}]   [] 0 []}
    instances_test.go:217: Update name
    helpers.go:59: Attempting to create eip/bandwidth
    helpers.go:75: Waiting for eip 4df90ea7-b3b6-4346-b9d9-607708afced7 to be active
    helpers.go:82: Created eip/bandwidth: 4df90ea7-b3b6-4346-b9d9-607708afced7
    instances_test.go:237: AttachEip
    instances_test.go:249: UnbindEip
    instances_test.go:259: Enable the SSL
    instances_test.go:266: Modify instance internal IP
    instances_test.go:276: Modify instance port
    instances_test.go:285: Modify instance SG
    instances_test.go:294: Modify instance specs
    instances_test.go:312: Modify instance volume size
    instances_test.go:322: Modify instance maintenance window
    instances_test.go:515: Attempting to delete DDSv3 instance: 06419b8564af433183571b1b00984aa8in02
    instances_test.go:525: DDSv3 instance deleted successfully: 06419b8564af433183571b1b00984aa8in02
    helpers.go:88: Attempting to delete eip/bandwidth: 4df90ea7-b3b6-4346-b9d9-607708afced7
    helpers.go:94: Waitting for eip 4df90ea7-b3b6-4346-b9d9-607708afced7 to be deleted
    helpers.go:99: Deleted eip/bandwidth: 4df90ea7-b3b6-4346-b9d9-607708afced7
--- PASS: TestDdsSingleLifeCycle (1002.12s)
PASS

Process finished with the exit code 0
```