### PR TITLE
TaurusDB: other apis

### DIFF
--- a/acceptance/openstack/taurus/v3/instance_test.go
+++ b/acceptance/openstack/taurus/v3/instance_test.go
@@ -171,3 +171,29 @@ func TestTaurusReadReplicaLifecycle(t *testing.T) {
 		th.AssertNoErr(t, job.WaitForJobSuccess(client, 600, *deleteNodeJob))
 	})
 }
+
+func TestTaurusListDatastores(t *testing.T) {
+	client, err := clients.NewTaurusDBV3Client()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to list taurus db data stores")
+	listResp, err := instance.ListDatastores(client, "gaussdb-mysql")
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, listResp)
+}
+
+func TestTaurusListFlavors(t *testing.T) {
+	client, err := clients.NewTaurusDBV3Client()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to list taurus db flavors")
+	flavorOpts := instance.ListFlavorsOpts{
+		AvailabilityZoneMode: "multi",
+		DatabaseName:         "gaussdb-mysql",
+	}
+	listResp, err := instance.ListFlavors(client, flavorOpts)
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, listResp[0])
+}

--- a/acceptance/openstack/taurus/v3/logs_test.go
+++ b/acceptance/openstack/taurus/v3/logs_test.go
@@ -1,0 +1,78 @@
+package v3
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/taurus/v3/instance"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/taurus/v3/job"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/taurus/v3/logs"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestTaurusInstanceLogs(t *testing.T) {
+	t.Skip("too long to run in ci")
+	vpcID := os.Getenv("OS_VPC_ID")
+	subnetID := os.Getenv("OS_NETWORK_ID")
+	secGroupID := os.Getenv("OS_SECURITY_GROUP_ID")
+
+	client, err := clients.NewTaurusDBV3Client()
+	th.AssertNoErr(t, err)
+
+	createResp := createTaurusInstance(t, client, vpcID, subnetID, secGroupID)
+
+	t.Cleanup(func() {
+		t.Logf("Attempting to delete taurus db")
+		_, err = instance.Delete(client, createResp.Instance.Id)
+		th.AssertNoErr(t, err)
+	})
+
+	t.Logf("Attempting to create taurus db read replica")
+
+	createReplicaJobs, err := instance.CreateReplica(client, createResp.Instance.Id,
+		instance.CreateReplicaOpts{
+			Priorities: []int{1, 2},
+		},
+	)
+	th.AssertNoErr(t, err)
+
+	replicaJobs := strings.Split(*createReplicaJobs, ",")
+
+	th.AssertNoErr(t, job.WaitForJobSuccess(client, 600, replicaJobs[0]))
+	th.AssertNoErr(t, job.WaitForJobSuccess(client, 600, replicaJobs[1]))
+
+	getResp, err := instance.Get(client, createResp.Instance.Id)
+	th.AssertNoErr(t, err)
+
+	nodeId := getResp.Nodes[0].Id
+
+	endDate := time.Now().Format("2006-01-02T15:04:05-0700")
+	startDate := time.Now().Add(-1 * time.Hour).Format("2006-01-02T15:04:05-0700")
+
+	t.Logf("Attempting to list taurus db error logs")
+	errLogs, err := logs.GetErrorLogs(client, logs.GetErrorLogsOpts{
+		InstanceId: createResp.Instance.Id,
+		NodeId:     nodeId,
+		StartDate:  startDate,
+		EndDate:    endDate,
+	},
+	)
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, errLogs)
+
+	t.Logf("Attempting to list taurus db slow logs")
+	slowLogs, err := logs.GetSlowLogs(client, logs.GetSlowLogsOpts{
+		InstanceId: createResp.Instance.Id,
+		NodeId:     nodeId,
+		StartDate:  startDate,
+		EndDate:    endDate,
+	})
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, slowLogs)
+}

--- a/acceptance/openstack/taurus/v3/template_test.go
+++ b/acceptance/openstack/taurus/v3/template_test.go
@@ -1,0 +1,51 @@
+package v3
+
+import (
+	"os"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/taurus/v3/instance"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/taurus/v3/template"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestTaurusTemplatesList(t *testing.T) {
+	client, err := clients.NewTaurusDBV3Client()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to list taurus db configurations")
+	getTemplate, err := template.ListConfigurations(client, template.ListConfigurationsOpts{})
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, len(getTemplate) >= 1, true)
+	tools.PrintResource(t, getTemplate)
+}
+
+func TestTaurusInstanceTemplatesList(t *testing.T) {
+	t.Skip("too long to run in ci")
+	vpcID := os.Getenv("OS_VPC_ID")
+	subnetID := os.Getenv("OS_NETWORK_ID")
+	secGroupID := os.Getenv("OS_SECURITY_GROUP_ID")
+
+	client, err := clients.NewTaurusDBV3Client()
+	th.AssertNoErr(t, err)
+
+	createResp := createTaurusInstance(t, client, vpcID, subnetID, secGroupID)
+
+	t.Cleanup(func() {
+		t.Logf("Attempting to delete taurus db")
+		_, err = instance.Delete(client, createResp.Instance.Id)
+		th.AssertNoErr(t, err)
+	})
+
+	t.Logf("Attempting to list taurus db configurations")
+	getTemplate, err := template.GetInstanceConfigurations(client, template.GetInstanceConfOpts{
+		InstanceId: createResp.Instance.Id,
+	})
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, len(getTemplate) >= 1, true)
+	tools.PrintResource(t, getTemplate)
+}

--- a/doc.go
+++ b/doc.go
@@ -3,7 +3,7 @@ Package golangsdk provides a multi-vendor interface to OpenStack-compatible
 clouds. The library has a three-level hierarchy: providers, services, and
 resources.
 
-Authenticating with Providers
+# Authenticating with Providers
 
 Provider structs represent the cloud providers that offer and manage a
 collection of services. You will generally want to create one Provider
@@ -15,14 +15,14 @@ information provided by the cloud operator. Additionally, the cloud may refer to
 TenantID or TenantName as project_id and project_name. Credentials are
 specified like so:
 
-  opts := golangsdk.AuthOptions{
-    IdentityEndpoint: "https://openstack.example.com:5000/v2.0",
-    Username: "{username}",
-    Password: "{password}",
-    TenantID: "{tenant_id}",
-  }
+	opts := golangsdk.AuthOptions{
+	  IdentityEndpoint: "https://openstack.example.com:5000/v2.0",
+	  Username: "{username}",
+	  Password: "{password}",
+	  TenantID: "{tenant_id}",
+	}
 
-  provider, err := openstack.AuthenticatedClient(opts)
+	provider, err := openstack.AuthenticatedClient(opts)
 
 You may also use the openstack.AuthOptionsFromEnv() helper function. This
 function reads in standard environment variables frequently found in an
@@ -32,23 +32,23 @@ instead of "project".
 	opts, err := openstack.AuthOptionsFromEnv()
 	provider, err := openstack.AuthenticatedClient(opts)
 
-Service Clients
+# Service Clients
 
 Service structs are specific to a provider and handle all of the logic and
 operations for a particular OpenStack service. Examples of services include:
 Compute, Object Storage, Block Storage. In order to define one, you need to
 pass in the parent provider, like so:
 
-  opts := golangsdk.EndpointOpts{Region: "RegionOne"}
+	opts := golangsdk.EndpointOpts{Region: "RegionOne"}
 
-  client := openstack.NewComputeV2(provider, opts)
+	client := openstack.NewComputeV2(provider, opts)
 
-Resources
+# Resources
 
 Resource structs are the domain models that services make use of in order
 to work with and represent the state of API resources:
 
-  server, err := servers.Get(client, "{serverId}").Extract()
+	server, err := servers.Get(client, "{serverId}").Extract()
 
 Intermediate Result structs are returned for API operations, which allow
 generic access to the HTTP headers, response body, and any errors associated
@@ -56,11 +56,11 @@ with the network transaction. To turn a result into a usable resource struct,
 you must call the Extract method which is chained to the response, or an
 Extract function from an applicable extension:
 
-  result := servers.Get(client, "{serverId}")
+	result := servers.Get(client, "{serverId}")
 
-  // Attempt to extract the disk configuration from the OS-DCF disk config
-  // extension:
-  config, err := diskconfig.ExtractGet(result)
+	// Attempt to extract the disk configuration from the OS-DCF disk config
+	// extension:
+	config, err := diskconfig.ExtractGet(result)
 
 All requests that enumerate a collection return a Pager struct that is used to
 iterate through the results one page at a time. Use the EachPage method on that
@@ -68,17 +68,17 @@ Pager to handle each successive Page in a closure, then use the appropriate
 extraction method from that request's package to interpret that Page as a slice
 of results:
 
-  err := servers.List(client, nil).EachPage(func (page pagination.Page) (bool, error) {
-    s, err := servers.ExtractServers(page)
-    if err != nil {
-      return false, err
-    }
+	err := servers.List(client, nil).EachPage(func (page pagination.Page) (bool, error) {
+	  s, err := servers.ExtractServers(page)
+	  if err != nil {
+	    return false, err
+	  }
 
-    // Handle the []servers.Server slice.
+	  // Handle the []servers.Server slice.
 
-    // Return "false" or an error to prematurely stop fetching new pages.
-    return true, nil
-  })
+	  // Return "false" or an error to prematurely stop fetching new pages.
+	  return true, nil
+	})
 
 If you want to obtain the entire collection of pages without doing any
 intermediary processing on each page, you can use the AllPages method:

--- a/openstack/taurus/v3/instance/ListDatastores.go
+++ b/openstack/taurus/v3/instance/ListDatastores.go
@@ -1,0 +1,26 @@
+package instance
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func ListDatastores(client *golangsdk.ServiceClient, databaseName string) (*DatastoresResponse, error) {
+	raw, err := client.Get(client.ServiceURL("datastores", databaseName), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res DatastoresResponse
+	err = extract.IntoStructPtr(raw.Body, &res, "")
+	return &res, err
+}
+
+type DatastoresResponse struct {
+	Datastores []MysqlEngineVersionInfo `json:"datastores"`
+}
+
+type MysqlEngineVersionInfo struct {
+	Id   string `json:"id"`
+	Name string `json:"name"`
+}

--- a/openstack/taurus/v3/instance/ListFlavors.go
+++ b/openstack/taurus/v3/instance/ListFlavors.go
@@ -1,0 +1,44 @@
+package instance
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListFlavorsOpts struct {
+	DatabaseName         string `json:"-"`
+	VersionName          string `q:"version_name"`
+	AvailabilityZoneMode string `q:"availability_zone_mode" required:"true"`
+	SpecCode             string `q:"spec_code"`
+}
+
+func ListFlavors(client *golangsdk.ServiceClient, opts ListFlavorsOpts) ([]MysqlFlavorInfo, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("flavors", opts.DatabaseName).
+		WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		Flavors []MysqlFlavorInfo `json:"flavors"`
+	}
+	err = extract.IntoStructPtr(raw.Body, &res, "")
+	return res.Flavors, err
+}
+
+type MysqlFlavorInfo struct {
+	Id           string            `json:"id"`
+	SpecCode     string            `json:"spec_code"`
+	Vcpus        string            `json:"vcpus"`
+	Ram          string            `json:"ram"`
+	Type         string            `json:"type"`
+	VersionName  string            `json:"version_name"`
+	InstanceMode string            `json:"instance_mode"`
+	AzStatus     map[string]string `json:"az_status"`
+}

--- a/openstack/taurus/v3/logs/GetErrorLogs.go
+++ b/openstack/taurus/v3/logs/GetErrorLogs.go
@@ -1,0 +1,60 @@
+package logs
+
+import (
+	"bytes"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+)
+
+type GetErrorLogsOpts struct {
+	InstanceId string `json:"-"`
+	StartDate  string `q:"start_date" required:"true"`
+	EndDate    string `q:"end_date" required:"true"`
+	NodeId     string `q:"node_id" required:"true"`
+	Offset     int    `q:"offset"`
+	Limit      int    `q:"limit"`
+	Level      string `q:"level"`
+}
+
+func GetErrorLogs(client *golangsdk.ServiceClient, opts GetErrorLogsOpts) ([]MysqlErrorLogList, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("instances", opts.InstanceId, "errorlog").
+		WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	pages, err := pagination.Pager{
+		Client:     client,
+		InitialURL: client.ServiceURL(url.String()),
+		CreatePage: func(r pagination.NewPageResult) pagination.NewPage {
+			return ErrorLogPage{NewSinglePageBase: pagination.NewSinglePageBase{NewPageResult: r}}
+		},
+	}.NewAllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return ExtractErrorLogs(pages)
+}
+
+func ExtractErrorLogs(r pagination.NewPage) ([]MysqlErrorLogList, error) {
+	var s struct {
+		ErrorLogList []MysqlErrorLogList `json:"error_log_list"`
+	}
+	err := extract.Into(bytes.NewReader((r.(ErrorLogPage)).Body), &s)
+	return s.ErrorLogList, err
+}
+
+type ErrorLogPage struct {
+	pagination.NewSinglePageBase
+}
+
+type MysqlErrorLogList struct {
+	NodeId  string `json:"node_id"`
+	Time    string `json:"time"`
+	Level   string `json:"level"`
+	Content string `json:"content"`
+}

--- a/openstack/taurus/v3/logs/GetSlowLogs.go
+++ b/openstack/taurus/v3/logs/GetSlowLogs.go
@@ -1,0 +1,68 @@
+package logs
+
+import (
+	"bytes"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+)
+
+type GetSlowLogsOpts struct {
+	InstanceId string `q:"-"`
+	StartDate  string `q:"start_date" required:"true"`
+	EndDate    string `q:"end_date" required:"true"`
+	NodeId     string `q:"node_id" required:"true"`
+	Offset     int    `q:"offset"`
+	Limit      int    `q:"limit"`
+	Type       string `q:"type"`
+}
+
+func GetSlowLogs(client *golangsdk.ServiceClient, opts GetSlowLogsOpts) ([]MysqlSlowLogList, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("instances", opts.InstanceId, "slowlog").
+		WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	pages, err := pagination.Pager{
+		Client:     client,
+		InitialURL: client.ServiceURL(url.String()),
+		CreatePage: func(r pagination.NewPageResult) pagination.NewPage {
+			return SlowLogPage{NewSinglePageBase: pagination.NewSinglePageBase{NewPageResult: r}}
+		},
+	}.NewAllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return ExtractSlowLogs(pages)
+}
+
+func ExtractSlowLogs(r pagination.NewPage) ([]MysqlSlowLogList, error) {
+	var s struct {
+		SlowLogList []MysqlSlowLogList `json:"slow_log_list"`
+	}
+	err := extract.Into(bytes.NewReader((r.(SlowLogPage)).Body), &s)
+	return s.SlowLogList, err
+}
+
+type SlowLogPage struct {
+	pagination.NewSinglePageBase
+}
+
+type MysqlSlowLogList struct {
+	NodeId       string `json:"node_id"`
+	Count        string `json:"count"`
+	Time         string `json:"time"`
+	LockTime     string `json:"lock_time"`
+	RowsSent     string `json:"rows_sent"`
+	RowsExamined string `json:"rows_examined"`
+	Database     string `json:"database"`
+	Users        string `json:"users"`
+	QuerySample  string `json:"query_sample"`
+	Type         string `json:"type"`
+	StartTime    string `json:"start_time"`
+	ClientIp     string `json:"client_ip"`
+}

--- a/openstack/taurus/v3/template/GetInstanceConfigurations.go
+++ b/openstack/taurus/v3/template/GetInstanceConfigurations.go
@@ -1,0 +1,66 @@
+package template
+
+import (
+	"bytes"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+)
+
+type GetInstanceConfOpts struct {
+	InstanceId string `json:"-"`
+	Offset     int    `q:"offset"`
+	Limit      int    `q:"limit"`
+}
+
+func GetInstanceConfigurations(client *golangsdk.ServiceClient, opts GetInstanceConfOpts) ([]ParameterValuesInfo, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("instances", opts.InstanceId, "configurations").
+		WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	pages, err := pagination.Pager{
+		Client:     client,
+		InitialURL: client.ServiceURL(url.String()),
+		CreatePage: func(r pagination.NewPageResult) pagination.NewPage {
+			return InstanceConfigurationPage{NewSinglePageBase: pagination.NewSinglePageBase{NewPageResult: r}}
+		},
+	}.NewAllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return ExtractInstanceConfigurations(pages)
+}
+
+func ExtractInstanceConfigurations(r pagination.NewPage) ([]ParameterValuesInfo, error) {
+	var s struct {
+		ParameterValues []ParameterValuesInfo `json:"parameter_values"`
+	}
+	err := extract.Into(bytes.NewReader((r.(InstanceConfigurationPage)).Body), &s)
+	return s.ParameterValues, err
+}
+
+type InstanceConfigurationPage struct {
+	pagination.NewSinglePageBase
+}
+
+type ParameterValuesInfo struct {
+	Name            string `json:"name"`
+	Value           string `json:"value"`
+	RestartRequired bool   `json:"restart_required"`
+	Readonly        bool   `json:"readonly"`
+	ValueRange      string `json:"value_range"`
+	Type            string `json:"type"`
+	Description     string `json:"description"`
+}
+
+type ParameterConfigurationInfo struct {
+	DatastoreVersionName string `json:"datastore_version_name"`
+	DatastoreName        string `json:"datastore_name"`
+	Created              string `json:"created"`
+	Updated              string `json:"updated"`
+}

--- a/openstack/taurus/v3/template/ListConfigurations.go
+++ b/openstack/taurus/v3/template/ListConfigurations.go
@@ -1,0 +1,59 @@
+package template
+
+import (
+	"bytes"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+)
+
+type ListConfigurationsOpts struct {
+	Offset int `q:"offset"`
+	Limit  int `q:"limit"`
+}
+
+func ListConfigurations(client *golangsdk.ServiceClient, opts ListConfigurationsOpts) ([]ConfigurationSummary, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("configurations").
+		WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	pages, err := pagination.Pager{
+		Client:     client,
+		InitialURL: client.ServiceURL(url.String()),
+		CreatePage: func(r pagination.NewPageResult) pagination.NewPage {
+			return ConfigurationPage{NewSinglePageBase: pagination.NewSinglePageBase{NewPageResult: r}}
+		},
+	}.NewAllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return ExtractConfigurations(pages)
+}
+
+func ExtractConfigurations(r pagination.NewPage) ([]ConfigurationSummary, error) {
+	var s struct {
+		Configurations []ConfigurationSummary `json:"configurations"`
+	}
+	err := extract.Into(bytes.NewReader((r.(ConfigurationPage)).Body), &s)
+	return s.Configurations, err
+}
+
+type ConfigurationPage struct {
+	pagination.NewSinglePageBase
+}
+
+type ConfigurationSummary struct {
+	Id                   string `json:"id"`
+	Name                 string `json:"name"`
+	Description          string `json:"description"`
+	DatastoreVersionName string `json:"datastore_version_name"`
+	DatastoreName        string `json:"datastore_name"`
+	Created              string `json:"created"`
+	Updated              string `json:"updated"`
+	UserDefined          bool   `json:"user_defined"`
+}


### PR DESCRIPTION
### Acceptance tests
```
=== RUN   TestTaurusListDatastores
    instance_test.go:179: Attempting to list taurus db data stores
    tools.go:75: {
          "datastores": [
            {
              "id": "887ce2b1-29a8-337f-b3d1-9b75394447b9",
              "name": "8.0"
            }
          ]
        }
--- PASS: TestTaurusListDatastores (1.51s)
PASS

Process finished with the exit code 0

=== RUN   TestTaurusListFlavors
    instance_test.go:190: Attempting to list taurus db flavors
    tools.go:75: {
          "id": "76a13bbd-766d-3821-8699-7ec37e8761b8",
          "spec_code": "gaussdb.mysql.large.x86.4",
          "vcpus": "2",
          "ram": "8",
          "type": "x86",
          "version_name": "8.0",
          "instance_mode": "Cluster",
          "az_status": {
            "eu-de-01": "normal",
            "eu-de-02": "unsupported",
            "eu-de-03": "normal"
          }
        }
--- PASS: TestTaurusListFlavors (0.86s)
PASS

Process finished with the exit code 0

=== RUN   TestTaurusTemplatesList
    template_test.go:16: Attempting to list taurus db configurations
    tools.go:75: [
          {
            "id": "43570e0de32e40c5a15f831aa5ce4176pr07",
            "name": "Default-TaurusDB V2.0",
            "description": "Default parameter template for TaurusDB V2.0",
            "datastore_version_name": "8.0",
            "datastore_name": "GaussDB(for MySQL)",
            "created": "2020-02-14T09:53:09+0000",
            "updated": "2020-02-14T09:53:09+0000",
            "user_defined": false
          }
        ]
--- PASS: TestTaurusTemplatesList (0.95s)

=== RUN   TestTaurusInstanceTemplatesList
    instance_test.go:17: Attempting to create taurus db
    template_test.go:43: Attempting to list taurus db configurations
    tools.go:75: [
          {
            "name": "audit_log_buffer_size",
            "value": "1048576",
            "restart_required": true,
            "readonly": false,
            "value_range": "4096-67108864",
            "type": "integer",
            "description": "Specifies the size of the audit log buffer. This parameter is only valid when audit_log_handler is set to FILE and audit_log_strategy is set to ASYNCHRONOUS or PERFORMANCE. Its value must be a multiple of 4,096."
          }
		  ]
    template_test.go:38: Attempting to delete taurus db
--- PASS: TestTaurusInstanceTemplatesList (436.25s)
PASS

Process finished with the exit code 0

=== RUN   TestTaurusInstanceLogs
    instance_test.go:17: Attempting to create taurus db
    logs_test.go:34: Attempting to create taurus db read replica
    logs_test.go:56: Attempting to list taurus db error logs
    tools.go:75: [
          {
            "node_id": "090abc3b75a1483cb2b8453cd9ae19a9no07",
            "time": "2025-10-08T17:18:07",
            "level": "WARNING",
            "content": "[MY-010005] [Server] Skip re-populating collations and character sets tables in read-only mode."
          },
          {
            "node_id": "090abc3b75a1483cb2b8453cd9ae19a9no07",
            "time": "2025-10-08T17:18:03",
            "level": "WARNING",
            "content": "[MY-010161] [Server] You need to use --log-bin to make --binlog-expire-logs-seconds work."
          }
        ]
    logs_test.go:68: Attempting to list taurus db slow logs
    tools.go:75: []
    logs_test.go:29: Attempting to delete taurus db
--- PASS: TestTaurusInstanceLogs (876.92s)
PASS

Process finished with the exit code 0
```