### PR TITLE
[Feat.] New attributes for SMN subscriptions

### DIFF
--- a/acceptance/openstack/smn/v2/subscriptions_test.go
+++ b/acceptance/openstack/smn/v2/subscriptions_test.go
@@ -19,6 +19,9 @@ func TestTopicSubscriptionWorkflow(t *testing.T) {
 	createOpts := subscriptions.CreateOpts{
 		Endpoint: "example@email.com",
 		Protocol: "email",
+		Extension: &subscriptions.SubscriptionExtension{
+			Header: map[string]string{"Content-Type": "application/json"},
+		},
 	}
 
 	subscription, err := subscriptions.Create(client, createOpts, topic)

--- a/openstack/smn/v2/subscriptions/Create.go
+++ b/openstack/smn/v2/subscriptions/Create.go
@@ -10,9 +10,40 @@ type CreateOpts struct {
 	// Message endpoint
 	Endpoint string `json:"endpoint" required:"true"`
 	// Protocol of the message endpoint
+	// The following protocols are supported:
+	// email: The endpoints are email address.
+	// sms: The endpoints are phone numbers.
+	// http and https: The endpoints are URLs.
 	Protocol string `json:"protocol" required:"true"`
 	// Description of the subscription
 	Remark string `json:"remark,omitempty"`
+	// Extended information
+	Extension *SubscriptionExtension `json:"extension,omitempty"`
+	// This parameter is mandatory when subscriptions need to be created in batches.
+	// SMN allows you to create a maximum of 50 subscriptions at a time.
+	Subscriptions []AddSubscriptions `json:"subscriptions,omitempty"`
+}
+
+type AddSubscriptions struct {
+	// Message endpoint
+	Endpoint string `json:"endpoint" required:"true"`
+	// Protocol of the message endpoint
+	// The following protocols are supported:
+	// email: The endpoints are email address.
+	// sms: The endpoints are phone numbers.
+	// http and https: The endpoints are URLs.
+	Protocol string `json:"protocol" required:"true"`
+	// Description of the subscription
+	Remark string `json:"remark,omitempty"`
+	// Extended information
+	Extension *SubscriptionExtension `json:"extension,omitempty"`
+}
+
+type SubscriptionExtension struct {
+	// This is an HTTP header field, which can be customized within the field range.
+	// The field content exists in the form of key/value pairs.
+	// When a topic is used to send messages, confirmed subscription messages carry the user-defined HTTP header.
+	Header map[string]string `json:"header,omitempty"`
 }
 
 func Create(client *golangsdk.ServiceClient, opts CreateOpts, topicUrn string) (*CreateResponse, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
New attributes in create:
`Extension`
`Subscriptions`

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
```
=== RUN   TestTopicSubscriptionWorkflow
    helpers.go:13: Attempting to create SMN topic
    helpers.go:20: Created SMN topic: urn:smn:eu-de:45c274f200d2498683982c8741fb76ac:topic-zhk
    subscriptions_test.go:18: Attempting to create SMN subscription
    subscriptions_test.go:29: Created SMN subscription: urn:smn:eu-de:45c274f200d2498683982c8741fb76ac:topic-zhk:f926c1527cab4043891071438d5a8f78
    subscriptions_test.go:31: Attempting to delete SMN subscription: urn:smn:eu-de:45c274f200d2498683982c8741fb76ac:topic-zhk:f926c1527cab4043891071438d5a8f78
    subscriptions_test.go:34: Deleted SMN subscription: urn:smn:eu-de:45c274f200d2498683982c8741fb76ac:topic-zhk:f926c1527cab4043891071438d5a8f78
    helpers.go:26: Attempting to delete SMN topic: urn:smn:eu-de:45c274f200d2498683982c8741fb76ac:topic-zhk
    helpers.go:29: Deleted SMN topic: urn:smn:eu-de:45c274f200d2498683982c8741fb76ac:topic-zhk
--- PASS: TestTopicSubscriptionWorkflow (27.42s)
PASS

Process finished with the exit code 0
```