### PR TITLE
[Feat.] add er_attachment_id to evpn gateway response

### DIFF
--- a/acceptance/openstack/er/associations_test.go
+++ b/acceptance/openstack/er/associations_test.go
@@ -39,14 +39,14 @@ func TestERAssociationsLifeCycle(t *testing.T) {
 	createResp, err := instance.Create(client, createOpts)
 	th.AssertNoErr(t, err)
 
-	err = waitForInstanceAvailable(client, 100, createResp.Instance.ID)
+	err = WaitForInstanceAvailable(client, 100, createResp.Instance.ID)
 	th.AssertNoErr(t, err)
 
 	t.Cleanup(func() {
 		t.Logf("Attempting to delete enterprise router")
 		err = instance.Delete(client, createResp.Instance.ID)
 		th.AssertNoErr(t, err)
-		err = waitForInstanceDeleted(client, 500, createResp.Instance.ID)
+		err = WaitForInstanceDeleted(client, 500, createResp.Instance.ID)
 	})
 
 	createRouteTableOpts := route_table.CreateOpts{

--- a/acceptance/openstack/er/helpers.go
+++ b/acceptance/openstack/er/helpers.go
@@ -5,7 +5,7 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/instance"
 )
 
-func waitForInstanceAvailable(client *golangsdk.ServiceClient, secs int, instanceID string) error {
+func WaitForInstanceAvailable(client *golangsdk.ServiceClient, secs int, instanceID string) error {
 	return golangsdk.WaitFor(secs, func() (bool, error) {
 		erInstance, err := instance.Get(client, instanceID)
 		if err != nil {
@@ -18,7 +18,7 @@ func waitForInstanceAvailable(client *golangsdk.ServiceClient, secs int, instanc
 	})
 }
 
-func waitForInstanceDeleted(client *golangsdk.ServiceClient, secs int, instanceID string) error {
+func WaitForInstanceDeleted(client *golangsdk.ServiceClient, secs int, instanceID string) error {
 	return golangsdk.WaitFor(secs, func() (bool, error) {
 		_, err := instance.Get(client, instanceID)
 		if err != nil {

--- a/acceptance/openstack/er/propagations_test.go
+++ b/acceptance/openstack/er/propagations_test.go
@@ -39,14 +39,14 @@ func TestERPropagationsLifeCycle(t *testing.T) {
 	createResp, err := instance.Create(client, createOpts)
 	th.AssertNoErr(t, err)
 
-	err = waitForInstanceAvailable(client, 100, createResp.Instance.ID)
+	err = WaitForInstanceAvailable(client, 100, createResp.Instance.ID)
 	th.AssertNoErr(t, err)
 
 	t.Cleanup(func() {
 		t.Logf("Attempting to delete enterprise router")
 		err = instance.Delete(client, createResp.Instance.ID)
 		th.AssertNoErr(t, err)
-		err = waitForInstanceDeleted(client, 500, createResp.Instance.ID)
+		err = WaitForInstanceDeleted(client, 500, createResp.Instance.ID)
 	})
 
 	createRouteTableOpts := route_table.CreateOpts{

--- a/acceptance/openstack/er/route_tables_test.go
+++ b/acceptance/openstack/er/route_tables_test.go
@@ -41,14 +41,14 @@ func TestRouteTableLifeCycle(t *testing.T) {
 	createResp, err := instance.Create(client, createOpts)
 	th.AssertNoErr(t, err)
 
-	err = waitForInstanceAvailable(client, 100, createResp.Instance.ID)
+	err = WaitForInstanceAvailable(client, 100, createResp.Instance.ID)
 	th.AssertNoErr(t, err)
 
 	t.Cleanup(func() {
 		t.Logf("Attempting to delete enterprise router")
 		err = instance.Delete(client, createResp.Instance.ID)
 		th.AssertNoErr(t, err)
-		err = waitForInstanceDeleted(client, 500, createResp.Instance.ID)
+		err = WaitForInstanceDeleted(client, 500, createResp.Instance.ID)
 	})
 
 	createRouteTableOpts := route_table.CreateOpts{

--- a/acceptance/openstack/er/router_test.go
+++ b/acceptance/openstack/er/router_test.go
@@ -40,7 +40,7 @@ func TestEnterpriseRouterLifeCycle(t *testing.T) {
 	createResp, err := instance.Create(client, createOpts)
 	th.AssertNoErr(t, err)
 
-	err = waitForInstanceAvailable(client, 100, createResp.Instance.ID)
+	err = WaitForInstanceAvailable(client, 100, createResp.Instance.ID)
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, createOpts.Name, createResp.Instance.Name)
@@ -53,7 +53,7 @@ func TestEnterpriseRouterLifeCycle(t *testing.T) {
 		t.Logf("Attempting to delete enterprise router")
 		err = instance.Delete(client, createResp.Instance.ID)
 		th.AssertNoErr(t, err)
-		err = waitForInstanceDeleted(client, 500, createResp.Instance.ID)
+		err = WaitForInstanceDeleted(client, 500, createResp.Instance.ID)
 	})
 
 	tOpts := tags.TagOpts{

--- a/acceptance/openstack/er/routes_test.go
+++ b/acceptance/openstack/er/routes_test.go
@@ -43,14 +43,14 @@ func TestRoutesLifeCycle(t *testing.T) {
 	createResp, err := instance.Create(client, createOpts)
 	th.AssertNoErr(t, err)
 
-	err = waitForInstanceAvailable(client, 100, createResp.Instance.ID)
+	err = WaitForInstanceAvailable(client, 100, createResp.Instance.ID)
 	th.AssertNoErr(t, err)
 
 	t.Cleanup(func() {
 		t.Logf("Attempting to delete enterprise router")
 		err = instance.Delete(client, createResp.Instance.ID)
 		th.AssertNoErr(t, err)
-		err = waitForInstanceDeleted(client, 500, createResp.Instance.ID)
+		err = WaitForInstanceDeleted(client, 500, createResp.Instance.ID)
 	})
 
 	createRouteTableOpts := route_table.CreateOpts{

--- a/acceptance/openstack/er/vpc_attachments_test.go
+++ b/acceptance/openstack/er/vpc_attachments_test.go
@@ -43,14 +43,14 @@ func TestVPCAttachmentsLifeCycle(t *testing.T) {
 	createResp, err := instance.Create(client, createOpts)
 	th.AssertNoErr(t, err)
 
-	err = waitForInstanceAvailable(client, 100, createResp.Instance.ID)
+	err = WaitForInstanceAvailable(client, 100, createResp.Instance.ID)
 	th.AssertNoErr(t, err)
 
 	t.Cleanup(func() {
 		t.Logf("Attempting to delete enterprise router")
 		err = instance.Delete(client, createResp.Instance.ID)
 		th.AssertNoErr(t, err)
-		err = waitForInstanceDeleted(client, 500, createResp.Instance.ID)
+		err = WaitForInstanceDeleted(client, 500, createResp.Instance.ID)
 	})
 
 	createVpcOpts := vpc.CreateOpts{

--- a/acceptance/openstack/evpn/gateway_test.go
+++ b/acceptance/openstack/evpn/gateway_test.go
@@ -8,7 +8,10 @@ import (
 
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack/er"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/instance"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/evpn/v5/gateway"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/eips"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/subnets"
@@ -33,7 +36,7 @@ func TestGatewaysAZsList(t *testing.T) {
 	tools.PrintResource(t, azs)
 }
 
-func TestGatewayVPCLifecycle(t *testing.T) {
+func TestGatewayLifecycle(t *testing.T) {
 	t.Skip("unstable creation of gateway")
 	subnetId := os.Getenv("OS_SUBNET_ID")
 	vpcId := os.Getenv("OS_VPC_ID")
@@ -159,4 +162,90 @@ func WaitForGatewayDeleted(c *golangsdk.ServiceClient, id string, secs int) erro
 		}
 		return false, nil
 	})
+}
+
+func TestGatewayWithERLifecycle(t *testing.T) {
+	// t.Skip("unstable creation of gateway")
+	subnetId := os.Getenv("OS_SUBNET_ID")
+	vpcId := os.Getenv("OS_VPC_ID")
+
+	if subnetId == "" && vpcId == "" {
+		t.Skip("`OS_SUBNET_ID` and `OS_VPC_ID` and needs to be defined for test")
+	}
+
+	clientER, err := clients.NewERClient()
+	th.AssertNoErr(t, err)
+	routerName := tools.RandomString("acctest_er_router-", 4)
+
+	erRouter, err := erRouterCreate(t, routerName, clientER)
+	th.AssertNoErr(t, err)
+
+	clientEVPN, err := clients.NewEVPNClient()
+	th.AssertNoErr(t, err)
+
+	clientNetV2, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	subnet, err := subnets.Get(clientNetV2, subnetId).Extract()
+	th.AssertNoErr(t, err)
+
+	name := tools.RandomString("acc_evpn_gateway_", 5)
+	cOpts := gateway.CreateOpts{
+		Name:                name,
+		AttachmentType:      "er",
+		ErId:                erRouter.Instance.ID,
+		NetworkType:         "private",
+		AccessVpcId:         vpcId,
+		AccessSubnetId:      subnet.NetworkID,
+		AccessPrivateIp1:    "10.0.0.10",
+		AccessPrivateIp2:    "10.0.0.11",
+		AvailabilityZoneIds: []string{"eu-de-01", "eu-de-02"},
+	}
+	t.Logf("Attempting to CREATE Enterprise VPN Gateway: %s", name)
+	gw, err := gateway.Create(clientEVPN, cOpts)
+	th.AssertNoErr(t, err)
+	th.AssertNoErr(t, WaitForGatewayActive(clientEVPN, gw.ID, 800))
+	th.AssertEquals(t, name, gw.Name)
+	t.Cleanup(func() {
+		t.Logf("Attempting to DELETE Enterprise VPN Gateway: %s", gw.ID)
+		th.AssertNoErr(t, gateway.Delete(clientEVPN, gw.ID))
+		th.AssertNoErr(t, WaitForGatewayDeleted(clientEVPN, gw.ID, 800))
+	})
+	t.Logf("Attempting to GET Enterprise VPN Gateway: %s", gw.ID)
+	gwGet, err := gateway.Get(clientEVPN, gw.ID)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, len(gwGet.ErAttachmentId) > 0)
+}
+
+func erRouterCreate(t *testing.T, routerName string, c *golangsdk.ServiceClient) (*instance.RouterInstanceResp, error) {
+	createOpts := instance.CreateOpts{
+		Name:                        routerName,
+		Description:                 "terraform created enterprise router",
+		Asn:                         64512,
+		EnableDefaultAssociation:    pointerto.Bool(true),
+		EnableDefaultPropagation:    pointerto.Bool(true),
+		AutoAcceptSharedAttachments: pointerto.Bool(true),
+		AvailabilityZoneIDs: []string{
+			"eu-de-01",
+			"eu-de-02",
+		},
+	}
+
+	t.Logf("Attempting to create enterprise router")
+
+	createResp, err := instance.Create(c, createOpts)
+	th.AssertNoErr(t, err)
+
+	err = er.WaitForInstanceAvailable(c, 100, createResp.Instance.ID)
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, createOpts.Name, createResp.Instance.Name)
+
+	t.Cleanup(func() {
+		t.Logf("Attempting to delete enterprise router")
+		err = instance.Delete(c, createResp.Instance.ID)
+		th.AssertNoErr(t, err)
+		err = er.WaitForInstanceDeleted(c, 500, createResp.Instance.ID)
+	})
+	return createResp, err
 }

--- a/acceptance/openstack/evpn/gateway_test.go
+++ b/acceptance/openstack/evpn/gateway_test.go
@@ -165,7 +165,7 @@ func WaitForGatewayDeleted(c *golangsdk.ServiceClient, id string, secs int) erro
 }
 
 func TestGatewayWithERLifecycle(t *testing.T) {
-	// t.Skip("unstable creation of gateway")
+	t.Skip("unstable creation of gateway")
 	subnetId := os.Getenv("OS_SUBNET_ID")
 	vpcId := os.Getenv("OS_VPC_ID")
 

--- a/openstack/evpn/v5/gateway/Create.go
+++ b/openstack/evpn/v5/gateway/Create.go
@@ -195,6 +195,8 @@ type Gateway struct {
 	// Specifies a private IP address used by the VPN gateway to connect to
 	// a customer gateway when the network type is private network.
 	AccessPrivateIp2 string `json:"access_private_ip_2"`
+	// ID of the enterprise router attachment associated with the VPN gateway.
+	ErAttachmentId string `json:"er_attachment_id"`
 }
 
 type PolicyTemplate struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Add missing paramete `er_attachment_id`
### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
```
=== RUN   TestGatewayWithERLifecycle
    gateway_test.go:234: Attempting to create enterprise router
    gateway_test.go:204: Attempting to CREATE Enterprise VPN Gateway: acc_evpn_gateway_bwc6d
    gateway_test.go:214: Attempting to GET Enterprise VPN Gateway: 36d3d930-50d6-4f45-a2ba-30e96d18cb90
    gateway_test.go:210: Attempting to DELETE Enterprise VPN Gateway: 36d3d930-50d6-4f45-a2ba-30e96d18cb90
    gateway_test.go:245: Attempting to delete enterprise router
--- PASS: TestGatewayWithERLifecycle (299.30s)
PASS
```