### PR TITLE
[Feat.] New endpoint for changing values of configuration parameters …

### DIFF
--- a/acceptance/openstack/cce/v3/clusters_test.go
+++ b/acceptance/openstack/cce/v3/clusters_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack/cce"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/clusters"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/nodepools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/floatingips"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/subnets"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
@@ -79,7 +80,7 @@ func TestCluster(t *testing.T) {
 }
 
 func TestTurboClusterWithCillium(t *testing.T) {
-	t.Skip("Only available in whitelisted tenants")
+	// t.Skip("Only available in whitelisted tenants")
 	vpcID := clients.EnvOS.GetEnv("VPC_ID")
 	if vpcID == "" {
 		t.Skip("OS_VPC_ID is required for this test")
@@ -171,6 +172,29 @@ func TestTurboClusterWithCillium(t *testing.T) {
 	th.AssertEquals(t, cluster.Metadata.Name, clusterGet.Metadata.Name)
 	th.AssertEquals(t, cluster.Metadata.Timezone, clusterGet.Metadata.Timezone)
 	th.AssertEquals(t, cluster.Spec.PublicAccess.Cidrs[0], "192.168.45.0/24")
+
+	updatedConf, err := nodepools.UpdateConfiguration(client, clusterID, "master", nodepools.UpdateConfigurationOpts{
+		Kind:       "Configuration",
+		APIVersion: "v3",
+		Metadata: nodepools.ConfigurationMetadata{
+			Name: "configuration",
+		},
+		Spec: nodepools.ClusterConfigurationsSpec{
+			Packages: []clusters.PackageConfiguration{
+				{
+					Name: "kube-apiserver",
+					Configurations: []clusters.Configuration{
+						{
+							Name:  "support-overload",
+							Value: false,
+						},
+					},
+				},
+			},
+		},
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, updatedConf.Metadata.Name, "configuration")
 
 	if clusterID != "" {
 		cce.DeleteCluster(t, clusterID)

--- a/openstack/cce/v3/nodepools/UpdateConfiguration.go
+++ b/openstack/cce/v3/nodepools/UpdateConfiguration.go
@@ -1,0 +1,60 @@
+package nodepools
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/clusters"
+)
+
+type UpdateConfigurationOpts struct {
+	// API type. Must be "Configuration".
+	Kind string `json:"kind" required:"true"`
+	// API version. Must be "v3".
+	APIVersion string `json:"apiVersion" required:"true"`
+	// Configuration metadata.
+	Metadata ConfigurationMetadata `json:"metadata" required:"true"`
+	// Configuration specifications.
+	Spec ClusterConfigurationsSpec `json:"spec" required:"true"`
+}
+
+type ConfigurationMetadata struct {
+	// Configuration name (e.g., "configuration")
+	Name string `json:"name" required:"true"`
+	// Optional labels map.
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+type ClusterConfigurationsSpec struct {
+	// Component configuration item details.
+	Packages []clusters.PackageConfiguration `json:"packages" required:"true"`
+}
+
+// UpdateConfiguration changes the values of configuration parameters of a node pool.
+func UpdateConfiguration(client *golangsdk.ServiceClient, clusterId, nodepoolId string, opts UpdateConfigurationOpts) (*Configuration, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	// PUT /api/v3/projects/{project_id}/clusters/{cluster_id}/nodepools/{nodepool_id}/configuration
+	raw, err := client.Put(
+		client.ServiceURL("clusters", clusterId, "nodepools", nodepoolId, "configuration"),
+		b, nil,
+		&golangsdk.RequestOpts{OkCodes: []int{200}},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var res Configuration
+	return &res, extract.Into(raw.Body, &res)
+}
+
+// Configuration represents the response body returned after updating configuration.
+type Configuration struct {
+	Kind       string                    `json:"kind"`
+	APIVersion string                    `json:"apiVersion"`
+	Metadata   ConfigurationMetadata     `json:"metadata"`
+	Spec       ClusterConfigurationsSpec `json:"spec"`
+	Status     map[string]interface{}    `json:"status,omitempty"`
+}


### PR DESCRIPTION
…of nodepool

<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Implements: https://docs.otc.t-systems.com/cloud-container-engine/api-ref/apis/configuration_management/changing_the_values_of_configuration_parameters_of_a_node_pool.html#updatenodepoolconfiguration

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
=== RUN   TestTurboClusterWithCillium
--- PASS: TestTurboClusterWithCillium (484.49s)
PASS

Process finished with the exit code 0