### PR TITLE
[GeminiDB]: versions & backups

### DIFF
--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -1053,6 +1053,15 @@ func NewGeminiDBClient() (client *golangsdk.ServiceClient, err error) {
 	return openstack.NewGeminiDBV3(cc.ProviderClient, golangsdk.EndpointOpts{})
 }
 
+func NewGeminiDBSpecClient() (client *golangsdk.ServiceClient, err error) {
+	cc, err := CloudAndClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return openstack.NewGeminiDBV3Spec(cc.ProviderClient, golangsdk.EndpointOpts{})
+}
+
 // NewAPIGWClient returns authenticated APIGW v2 client
 func NewAPIGWClient() (client *golangsdk.ServiceClient, err error) {
 	cc, err := CloudAndClient()

--- a/acceptance/openstack/gemini/v3/backup_test.go
+++ b/acceptance/openstack/gemini/v3/backup_test.go
@@ -1,0 +1,71 @@
+package v3
+
+import (
+	"os"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/gemini/v3/backup"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestGeminiBackupsLifecycle(t *testing.T) {
+	instanceId := os.Getenv("OS_INSTANCE_ID")
+	if instanceId == "" {
+		t.Skip("OS_INSTANCE_ID is required for backup test")
+	}
+
+	client, err := clients.NewGeminiDBClient()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to get backup policy for instance: %s", instanceId)
+	getResp, err := backup.GetBackupPolicy(client, backup.GetBackupPolicyOpts{
+		Type:       "Instance",
+		InstanceId: instanceId,
+	})
+	th.AssertNoErr(t, err)
+	tools.PrintResource(t, getResp)
+
+	originalPolicy := getResp.BackupPolicy
+
+	t.Logf("Attempting to set backup policy")
+
+	th.AssertNoErr(t, waitForInstanceAvailable(client, 1200, instanceId))
+
+	setOpts := backup.SetBackupPolicyOpts{
+		InstanceId: instanceId,
+		BackupPolicy: backup.BackupPolicy{
+			KeepDays:  7,
+			StartTime: "01:00-02:00",
+			Period:    "1,2,3,4,5,6",
+		},
+	}
+	err = backup.SetBackupPolicy(client, setOpts)
+	th.AssertNoErr(t, err)
+	t.Logf("Backup policy set successfully")
+
+	t.Logf("Verifying updated backup policy")
+	updatedResp, err := backup.GetBackupPolicy(client, backup.GetBackupPolicyOpts{
+		InstanceId: instanceId,
+		Type:       "Instance",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 7, updatedResp.BackupPolicy.KeepDays)
+	th.AssertEquals(t, "01:00-02:00", updatedResp.BackupPolicy.StartTime)
+	tools.PrintResource(t, updatedResp)
+
+	if originalPolicy != nil {
+		t.Logf("Restoring original backup policy")
+		restoreOpts := backup.SetBackupPolicyOpts{
+			InstanceId: instanceId,
+			BackupPolicy: backup.BackupPolicy{
+				KeepDays:  originalPolicy.KeepDays,
+				StartTime: originalPolicy.StartTime,
+				Period:    originalPolicy.Period,
+			},
+		}
+		err = backup.SetBackupPolicy(client, restoreOpts)
+		th.AssertNoErr(t, err)
+	}
+}

--- a/acceptance/openstack/gemini/v3/spec_test.go
+++ b/acceptance/openstack/gemini/v3/spec_test.go
@@ -1,0 +1,31 @@
+package v3
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/gemini/v3/spec"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestGeminiListFlavors(t *testing.T) {
+	client, err := clients.NewGeminiDBSpecClient()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to list Gemini db flavors")
+	listResp, err := spec.ListFlavors(client, spec.ListFlavorsOpts{})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, len(listResp.Flavors) > 1, true)
+}
+
+func TestGeminiGetVersions(t *testing.T) {
+	client, err := clients.NewGeminiDBClient()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Attempting to list Gemini db flavors")
+	listResp, err := spec.GetVersions(client, "cassandra")
+	th.AssertNoErr(t, err)
+
+	tools.PrintResource(t, listResp)
+}

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -1050,6 +1050,16 @@ func NewGeminiDBV3(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) 
 	return initClientOpts(client, eo, "geminidb")
 }
 
+func NewGeminiDBV3Spec(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "geminidb")
+	if err != nil {
+		return nil, err
+	}
+	sc.Endpoint = strings.Replace(sc.Endpoint, "v3", "v3.1", 1)
+	sc.ResourceBase = sc.Endpoint
+	return sc, err
+}
+
 func NewDataArtsV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
 	return initCommonServiceClient(client, eo, "dayu-dlf", "v1")
 }

--- a/openstack/gemini/v3/backup/GetBackupPolicy.go
+++ b/openstack/gemini/v3/backup/GetBackupPolicy.go
@@ -1,0 +1,46 @@
+package backup
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type GetBackupPolicyOpts struct {
+	InstanceId string `json:"-"`
+	Type       string `q:"type"`
+}
+
+func GetBackupPolicy(client *golangsdk.ServiceClient, opts GetBackupPolicyOpts) (*GetBackupPolicyResponse, error) {
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL("instances", opts.InstanceId, "backups", "policy")+query.String(), nil, &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res GetBackupPolicyResponse
+	return &res, extract.Into(raw.Body, &res)
+}
+
+type GetBackupPolicyResponse struct {
+	BackupPolicy   *ShowBackupPolicyResult  `json:"backup_policy"`
+	DatabaseTables []QueryDatabaseTableInfo `json:"database_tables,omitempty"`
+}
+
+type ShowBackupPolicyResult struct {
+	KeepDays           int    `json:"keep_days"`
+	DifferentialPeriod string `json:"differential_period"`
+	IncrementalPeriod  string `json:"incremental_period"`
+	StartTime          string `json:"start_time"`
+	Period             string `json:"period"`
+}
+
+type QueryDatabaseTableInfo struct {
+	DatabaseName string   `json:"database_name"`
+	TableNames   []string `json:"table_names"`
+}

--- a/openstack/gemini/v3/backup/SetBackupPolicy.go
+++ b/openstack/gemini/v3/backup/SetBackupPolicy.go
@@ -1,0 +1,27 @@
+package backup
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+type SetBackupPolicyOpts struct {
+	InstanceId     string                   `json:"-"`
+	BackupPolicy   BackupPolicy             `json:"backup_policy"`
+	DatabaseTables []PutDatabaseTablePolicy `json:"database_tables,omitempty"`
+}
+
+func SetBackupPolicy(client *golangsdk.ServiceClient, opts SetBackupPolicyOpts) error {
+	_, err := client.Put(client.ServiceURL("instances", opts.InstanceId, "backups", "policy"), opts, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return err
+}
+
+type BackupPolicy struct {
+	KeepDays  int    `json:"keep_days"`
+	StartTime string `json:"start_time,omitempty"`
+	Period    string `json:"period,omitempty"`
+}
+
+type PutDatabaseTablePolicy struct {
+	DatabaseName string   `json:"database_name"`
+	TableNames   []string `json:"table_names,omitempty"`
+}

--- a/openstack/gemini/v3/spec/GetVersions.go
+++ b/openstack/gemini/v3/spec/GetVersions.go
@@ -1,0 +1,22 @@
+package spec
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func GetVersions(client *golangsdk.ServiceClient, datastoreName string) (*GetVersionsResponse, error) {
+	raw, err := client.Get(client.ServiceURL("datastores", datastoreName, "versions"), nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res GetVersionsResponse
+	return &res, extract.Into(raw.Body, &res)
+}
+
+type GetVersionsResponse struct {
+	Versions []string `json:"versions"`
+}

--- a/openstack/gemini/v3/spec/ListFlavors.go
+++ b/openstack/gemini/v3/spec/ListFlavors.go
@@ -1,0 +1,44 @@
+package spec
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func ListFlavors(client *golangsdk.ServiceClient, opts ListFlavorsOpts) (*ListFlavorsResponse, error) {
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL("flavors")+query.String(), nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListFlavorsResponse
+	return &res, extract.Into(raw.Body, &res)
+}
+
+type ListFlavorsOpts struct {
+	EngineName string `q:"engine_name"`
+	Offset     *int   `q:"offset"`
+	Limit      *int   `q:"limit"`
+}
+
+type ListFlavorsResponse struct {
+	TotalCount int       `json:"total_count"`
+	Flavors    []Flavors `json:"flavors"`
+}
+
+type Flavors struct {
+	EngineName       string            `json:"engine_name"`
+	EngineVersion    string            `json:"engine_version"`
+	Vcpus            string            `json:"vcpus"`
+	Ram              string            `json:"ram"`
+	SpecCode         string            `json:"spec_code"`
+	AvailabilityZone []string          `json:"availability_zone"`
+	AzStatus         map[string]string `json:"az_status"`
+}


### PR DESCRIPTION
### Acceptance tests
```
=== RUN   TestGeminiBackupsLifecycle
    backup_test.go:22: Attempting to get backup policy for instance: 5da95eb3870b449b90781263a3677b24in06
    tools.go:75: {
          "backup_policy": {
            "keep_days": 7,
            "differential_period": "0",
            "incremental_period": "5",
            "start_time": "01:00-02:00",
            "period": "1,2,3,4,5,6,7"
          }
        }
    backup_test.go:32: Attempting to set backup policy
    backup_test.go:46: Backup policy set successfully
    backup_test.go:48: Verifying updated backup policy
    tools.go:75: {
          "backup_policy": {
            "keep_days": 7,
            "differential_period": "0",
            "incremental_period": "5",
            "start_time": "01:00-02:00",
            "period": "1,2,3,4,5,6"
          }
        }
    backup_test.go:59: Restoring original backup policy
--- PASS: TestGeminiBackupsLifecycle (4.55s)
PASS

Process finished with the exit code 0

=== RUN   TestGeminiListFlavors
    spec_test.go:16: Attempting to list Gemini db flavors
--- PASS: TestGeminiListFlavors (1.66s)
PASS

Process finished with the exit code 0

=== RUN   TestGeminiGetVersions
    spec_test.go:26: Attempting to list Gemini db flavors
    tools.go:75: {
          "versions": [
            "3.11"
          ]
        }
--- PASS: TestGeminiGetVersions (0.62s)
PASS

Process finished with the exit code 0
```