### PR TITLE
[Feat.] New methods for attaching and detaching volumes for ecs v1

### DIFF
--- a/acceptance/openstack/ecs/v1/cloudservers_test.go
+++ b/acceptance/openstack/ecs/v1/cloudservers_test.go
@@ -3,11 +3,14 @@ package v1
 import (
 	"testing"
 
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/blockstorage/v2/volumes"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/tags"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ecs/v1/cloudservers"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ecs/v1/disk"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ims/v2/images"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
@@ -181,4 +184,86 @@ func TestCloudServersIPV6(t *testing.T) {
 		}
 	}
 	th.AssertEquals(t, true, ipv6enabled)
+}
+
+func TestCloudServerVolumeLifecycle(t *testing.T) {
+	client, err := clients.NewComputeV1Client()
+	th.AssertNoErr(t, err)
+
+	clientEvs, err := clients.NewBlockStorageV2Client()
+	th.AssertNoErr(t, err)
+
+	az := clients.EnvOS.GetEnv("AVAILABILITY_ZONE")
+	if az == "" {
+		t.Skip("OS_AVAILABILITY_ZONE env vars is missing but ECSv1 test requires")
+	}
+	createVolumeOpts := volumes.CreateOpts{
+		Size:             40,
+		Name:             tools.RandomString("tf-evs-disk-", 4),
+		VolumeType:       "SSD",
+		AvailabilityZone: az,
+	}
+
+	vol, err := volumes.Create(clientEvs, createVolumeOpts).Extract()
+	th.AssertNoErr(t, err)
+
+	err = waitForEvsAvailable(clientEvs, 100, vol.ID)
+	th.AssertNoErr(t, err)
+
+	t.Cleanup(func() {
+		err = volumes.Delete(clientEvs, vol.ID, volumes.DeleteOpts{}).ExtractErr()
+		th.AssertNoErr(t, err)
+	})
+
+	// Get ECSv1 createOpts
+	createOpts := openstack.GetCloudServerCreateOpts(t)
+
+	// Check ECSv1 createOpts
+	openstack.DryRunCloudServerConfig(t, client, createOpts)
+	t.Logf("CreateOpts are ok for creating a cloudServer")
+
+	// Create ECSv1 instance
+	ecs := openstack.CreateCloudServer(t, client, createOpts)
+
+	t.Cleanup(func() {
+		openstack.DeleteCloudServer(t, client, ecs.ID)
+	})
+
+	t.Logf("Attaching volume to cloudserver: %s", vol.ID)
+	attach, err := disk.Attach(client, disk.CreateOpts{
+		ServerID: ecs.ID,
+		VolumeAttachment: &disk.VolumeAttachment{
+			VolumeID: vol.ID,
+		},
+	})
+	th.AssertNoErr(t, err)
+
+	err = cloudservers.WaitForJobSuccess(client, 120, attach.JobID)
+	th.AssertNoErr(t, err)
+
+	t.Logf("Get all attached volumes to cloudserver: %s", ecs.ID)
+	attachments, err := disk.GetAttachments(client, ecs.ID)
+
+	tools.PrintResource(t, attachments)
+
+	t.Logf("Force Detaching volume from cloudserver: %s", vol.ID)
+	detach, err := disk.Detach(client, ecs.ID, vol.ID, 1)
+	th.AssertNoErr(t, err)
+
+	err = cloudservers.WaitForJobSuccess(client, 120, detach.JobID)
+	th.AssertNoErr(t, err)
+}
+
+func waitForEvsAvailable(client *golangsdk.ServiceClient, secs int, volId string) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		vol, err := volumes.Get(client, volId).Extract()
+		if err != nil {
+			return false, err
+		}
+
+		if vol.Status == "available" {
+			return true, nil
+		}
+		return false, nil
+	})
 }

--- a/openstack/ecs/v1/disk/Attach.go
+++ b/openstack/ecs/v1/disk/Attach.go
@@ -1,0 +1,58 @@
+package disk
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateOpts struct {
+	// ID of the ECS to which the disk will be attached.
+	ServerID string `json:"-"`
+	// Specifies the ECS attachment information.
+	VolumeAttachment *VolumeAttachment `json:"volumeAttachment" required:"true"`
+	// Specifies whether to check the request without actually attaching the disk.
+	// If set to true, only a pre-check is performed and no disk is attached.
+	// If set to false or omitted, the disk is attached after the check passes.
+	DryRun *bool `json:"dry_run,omitempty"`
+}
+
+type VolumeAttachment struct {
+	// ID of the disk to be attached. The value is in UUID format.
+	VolumeID string `json:"volumeId" required:"true"`
+	// Disk device name, such as /dev/sda or /dev/vdb.
+	Device string `json:"device,omitempty"`
+	// Disk type, for example SSD.
+	VolumeType string `json:"volume_type,omitempty"`
+	// Number of disks to attach.
+	Count int `json:"count,omitempty"`
+	// Indicates whether to attach the disk in passthrough (SCSI) mode.
+	// If set to "true", the disk device type is SCSI.
+	// If set to "false", the disk device type is VBD.
+	HwPassthrough string `json:"hw:passthrough,omitempty"`
+}
+
+func Attach(client *golangsdk.ServiceClient, opts CreateOpts) (*JobResponse, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST /v1/{project_id}/cloudservers/{server_id}/attachvolume
+	raw, err := client.Post(client.ServiceURL("cloudservers", opts.ServerID, "attachvolume"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res JobResponse
+
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type JobResponse struct {
+	// ID of the task.
+	JobID string `json:"job_id"`
+}

--- a/openstack/ecs/v1/disk/Detach.go
+++ b/openstack/ecs/v1/disk/Detach.go
@@ -1,0 +1,24 @@
+package disk
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Detach(client *golangsdk.ServiceClient, serverID, volumeID string, deleteFlag int) (*JobResponse, error) {
+	url := client.ServiceURL("cloudservers", serverID, "detachvolume", volumeID)
+	if deleteFlag != 0 {
+		url += "?delete_flag=1"
+	}
+
+	raw, err := client.Delete(url, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res JobResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/ecs/v1/disk/GetAttachments.go
+++ b/openstack/ecs/v1/disk/GetAttachments.go
@@ -1,0 +1,59 @@
+package disk
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func GetAttachments(client *golangsdk.ServiceClient, serverID string) (*Attachments, error) {
+	// GET /v1/{project_id}/cloudservers/{server_id}/block_device
+	raw, err := client.Get(client.ServiceURL("cloudservers", serverID, "block_device"),
+		nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res Attachments
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type Attachments struct {
+	// Specifies the disks attached to an ECS.
+	VolumeAttachments []Volume `json:"volumeAttachments"`
+	// Specifies the number of disks that can be attached to an ECS.
+	AttachableQuantity *AttachableQuantity `json:"attachableQuantity"`
+}
+
+type Volume struct {
+	// Specifies the ECS ID in UUID format.
+	ServerID string `json:"serverId"`
+	// Specifies the EVS disk ID in UUID format.
+	VolumeID string `json:"volumeId"`
+	// Specifies the mount ID, which is the same as the EVS disk ID.
+	// The value is in UUID format.
+	ID string `json:"id"`
+	// Specifies the EVS disk size in GB.
+	Size int `json:"size"`
+	// Specifies the drive letter of the EVS disk, displayed as the
+	// device name on the console, for example /dev/vda or /dev/vdb.
+	Device string `json:"device"`
+	// Specifies the PCI address.
+	PCIAddress string `json:"pciAddress"`
+	// Specifies the EVS disk boot sequence.
+	// 0 indicates the system disk; a non-zero value indicates a data disk.
+	BootIndex int `json:"bootIndex"`
+	// Specifies the disk bus type.
+	// Options: virtio and scsi.
+	Bus string `json:"bus"`
+}
+
+// AttachableQuantity describes how many additional disks can be attached.
+type AttachableQuantity struct {
+	// Specifies the number of SCSI disks that can be attached to an ECS.
+	FreeSCSI int `json:"free_scsi"`
+	// Specifies the number of virtio_blk disks that can be attached to an ECS.
+	FreeBLK int `json:"free_blk"`
+	// Specifies the total number of disks that can be attached to an ECS.
+	FreeDisk int `json:"free_disk"`
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Another methods to attachd and force detach voloumes to/from ECS instance

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
```
=== RUN   TestCloudServerVolumeLifecycle
    common.go:190: Attempting to check ECSv1 createOpts
    cloudservers_test.go:223: CreateOpts are ok for creating a cloudServer
    cloudservers_test.go:226: Attempting to create ECSv1
    cloudservers_test.go:226: Created ECSv1 instance: 5a76f1df-4f2c-4519-8f8f-5450dc0b15e6
    tools.go:75: {
          "volumeAttachments": [
            {
              "serverId": "5a76f1df-4f2c-4519-8f8f-5450dc0b15e6",
              "volumeId": "1b14ff65-ff5f-4cea-abe5-070732f22787",
              "id": "1b14ff65-ff5f-4cea-abe5-070732f22787",
              "size": 4,
              "device": "/dev/vda",
              "pciAddress": "0000:02:01.0",
              "bootIndex": 0,
              "bus": "virtio"
            },
            {
              "serverId": "5a76f1df-4f2c-4519-8f8f-5450dc0b15e6",
              "volumeId": "c0eb3548-f332-41c9-8b9c-c3967ea914cc",
              "id": "c0eb3548-f332-41c9-8b9c-c3967ea914cc",
              "size": 40,
              "device": "/dev/vdb",
              "pciAddress": "0000:02:02.0",
              "bootIndex": 0,
              "bus": "virtio"
            },
            {
              "serverId": "5a76f1df-4f2c-4519-8f8f-5450dc0b15e6",
              "volumeId": "85ed3bdc-8b38-4657-97f4-3e5f07ca1d58",
              "id": "85ed3bdc-8b38-4657-97f4-3e5f07ca1d58",
              "size": 40,
              "device": "/dev/vdc",
              "pciAddress": "0000:02:03.0",
              "bootIndex": 0,
              "bus": "virtio"
            }
          ],
          "attachableQuantity": {
            "free_scsi": 57,
            "free_blk": 21,
            "free_disk": 57
          }
        }
    common.go:216: Attempting to delete ECSv1: 5a76f1df-4f2c-4519-8f8f-5450dc0b15e6
    common.go:233: ECSv1 instance deleted: 5a76f1df-4f2c-4519-8f8f-5450dc0b15e6
--- PASS: TestCloudServerVolumeLifecycle (98.75s)
PASS

Process finished with the exit code 0
```