### PR TITLE
[RDS]: minor version upgarde

### DIFF
--- a/acceptance/openstack/rds/v3/helpers.go
+++ b/acceptance/openstack/rds/v3/helpers.go
@@ -83,7 +83,7 @@ func CreateMySqlRDS(t *testing.T, client *golangsdk.ServiceClient, region string
 		Name:             rdsName,
 		Port:             "8635",
 		Password:         "acc-test-password1!",
-		FlavorRef:        "rds.mysql.c2.medium",
+		FlavorRef:        "rds.mysql.n1.large.4",
 		Region:           region,
 		AvailabilityZone: az,
 		VpcId:            vpcID,
@@ -92,7 +92,7 @@ func CreateMySqlRDS(t *testing.T, client *golangsdk.ServiceClient, region string
 		TimeZone:         "UTC+01:00",
 
 		Volume: &instances.Volume{
-			Type: "COMMON",
+			Type: "CLOUDSSD",
 			Size: 100,
 		},
 		Datastore: &instances.Datastore{

--- a/acceptance/openstack/rds/v3/rds_test.go
+++ b/acceptance/openstack/rds/v3/rds_test.go
@@ -554,3 +554,31 @@ func TestRdsTimeZone(t *testing.T) {
 	th.AssertEquals(t, len(instanceList.Instances), 1)
 	th.AssertEquals(t, instanceList.Instances[0].TimeZone, "UTC+01:00")
 }
+
+func TestRdsUpgradeVersion(t *testing.T) {
+	if os.Getenv("RUN_RDS_LIFECYCLE") == "" {
+		t.Skip("new RDS have latest minor versions")
+	}
+
+	client, err := clients.NewRdsV3()
+	th.AssertNoErr(t, err)
+
+	cc, err := clients.CloudAndClient()
+	th.AssertNoErr(t, err)
+
+	t.Log("Creating instance")
+
+	// Create MySql RDSv3 instance
+	rds := CreateMySqlRDS(t, client, cc.RegionName)
+	t.Cleanup(func() { DeleteRDS(t, client, rds.Id) })
+
+	upgradeOpts := instances.UpgradeDbVersionOpts{
+		InstanceId: rds.Id,
+		Delay:      false,
+	}
+
+	upgradeResp, err := instances.UpgradeDbVersion(client, upgradeOpts)
+	th.AssertNoErr(t, err)
+
+	_ = instances.WaitForJobCompleted(client, 600, *upgradeResp)
+}

--- a/openstack/rds/v3/instances/UpgradeDbVersion.go
+++ b/openstack/rds/v3/instances/UpgradeDbVersion.go
@@ -1,0 +1,30 @@
+package instances
+
+import (
+	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type UpgradeDbVersionOpts struct {
+	InstanceId string `json:"-"`
+	Delay      bool   `json:"delay,omitempty"`
+}
+
+func UpgradeDbVersion(client *golangsdk.ServiceClient, opts UpgradeDbVersionOpts) (*string, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Post(client.ServiceURL("instances", opts.InstanceId, "action", "db-upgrade"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res JobId
+	err = extract.Into(raw.Body, &res)
+	return &res.JobId, err
+}


### PR DESCRIPTION
### Acceptance tests
Newly created RDS have latest minor versions and can't be upgraded
```
    helpers.go:105: Failure in helpers.go, line 105: unexpected error "Bad request with: [POST https://rds.eu-de.otc.t-systems.com/v3/a720688fb87f4575a4c000d818061eae/instances], error message: {\"error_msg\":\"Datastore not found.\",\"error_code\":\"DBS.280269\"}"

```
