### PR TITLE
[Fix] Autoscaling: Fix param name in as_configuration_v1 create opts

### DIFF
--- a/openstack/autoscaling/v1/configurations/create.go
+++ b/openstack/autoscaling/v1/configurations/create.go
@@ -3,7 +3,7 @@ package configurations
 import (
 	"encoding/base64"
 
-	"github.com/opentelekomcloud/gophertelekomcloud"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 )
 
@@ -36,7 +36,7 @@ type InstanceConfigOpts struct {
 	// Specifies the EIP of the ECS. The EIP can be configured in two ways.
 	// Do not use an EIP. In this case, this parameter is unavailable.
 	// Automatically assign an EIP. You need to specify the information about the new EIP.
-	PubicIp *PublicIp `json:"public_ip,omitempty"`
+	PublicIp *PublicIp `json:"public_ip,omitempty"`
 	// Specifies the user data to be injected during the ECS creation process. Text, text files, and gzip files can be injected.
 	// Constraints:
 	// The content to be injected must be encoded with base64. The maximum size of the content to be injected (before encoding) is 32 KB.


### PR DESCRIPTION
### What this PR does / why we need it
Fix typo for `PublicIP` in InstanceConfigOpts in `as_configuration_v1` create.

### Which issue this PR fixes
Issue #848 

### Tests
```
=== RUN   TestConfigurationsLifecycle
    helpers.go:73: Attempting to create AutoScaling Configuration
    helpers.go:98: Created AutoScaling Configuration: 15175310-3070-4687-a30c-05debbf90f29
    helpers.go:103: Attempting to delete AutoScaling Configuration
    helpers.go:106: Deleted AutoScaling Configuration: 15175310-3070-4687-a30c-05debbf90f29
--- PASS: TestConfigurationsLifecycle (5.77s)
PASS
```
