### PR TITLE
[CES]: v2 api implementatiuon

### DIFF
--- a/acceptance/openstack/ces/v2/records_test.go
+++ b/acceptance/openstack/ces/v2/records_test.go
@@ -1,0 +1,43 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ces/v2/records"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestAlarmRecordsList(t *testing.T) {
+	client, err := clients.NewCesV2Client()
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to list alarm records")
+	listResp, err := records.List(client, records.ListOpts{
+		Limit: 10,
+	})
+	th.AssertNoErr(t, err)
+
+	t.Logf("Found %d alarm records", listResp.Count)
+	for _, record := range listResp.AlarmHistories {
+		t.Logf("Record ID: %s, Name: %s, Status: %s, Level: %d",
+			record.RecordId, record.Name, record.Status, record.Level)
+	}
+}
+
+func TestAlarmRecordsListWithFilters(t *testing.T) {
+	client, err := clients.NewCesV2Client()
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to list alarm records with status filter")
+	listResp, err := records.List(client, records.ListOpts{
+		Status: "alarm",
+		Limit:  10,
+	})
+	th.AssertNoErr(t, err)
+
+	t.Logf("Found %d alarm records with status 'alarm'", listResp.Count)
+	for _, record := range listResp.AlarmHistories {
+		th.AssertEquals(t, record.Status, "alarm")
+	}
+}

--- a/acceptance/openstack/ces/v2/resourcegroups_test.go
+++ b/acceptance/openstack/ces/v2/resourcegroups_test.go
@@ -1,0 +1,130 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ces/v2/resourcegroups"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestResourceGroupsCRUD(t *testing.T) {
+	client, err := clients.NewCesV2Client()
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to create resource group")
+	createOpts := resourcegroups.CreateOpts{
+		GroupName: "test-rg-acc",
+		Type:      "Manual",
+	}
+
+	groupId, err := resourcegroups.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+	t.Logf("Created resource group: %s", groupId)
+
+	t.Cleanup(func() {
+		t.Log("Attempting to delete resource group")
+		_, err := resourcegroups.Delete(client, resourcegroups.DeleteOpts{
+			GroupIds: []string{groupId},
+		})
+		th.AssertNoErr(t, err)
+	})
+
+	t.Log("Attempting to get resource group details")
+	group, err := resourcegroups.Get(client, groupId)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, group.GroupName, "test-rg-acc")
+	th.AssertEquals(t, group.Type, "Manual")
+
+	t.Log("Attempting to list resource groups")
+	listResp, err := resourcegroups.List(client, resourcegroups.ListOpts{
+		GroupName: "test-rg-acc",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, listResp.Count >= 1, true)
+
+	t.Log("Attempting to update resource group")
+	err = resourcegroups.Update(client, groupId, resourcegroups.UpdateOpts{
+		GroupName: "test-rg-acc-updated",
+	})
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to verify resource group was updated")
+	group, err = resourcegroups.Get(client, groupId)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, group.GroupName, "test-rg-acc-updated")
+}
+
+func TestResourceGroupsWithTags(t *testing.T) {
+	client, err := clients.NewCesV2Client()
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to create resource group with tags")
+	createOpts := resourcegroups.CreateOpts{
+		GroupName: "test-rg-tag-acc",
+		Type:      "TAG",
+		Tags: []resourcegroups.ResourceGroupTag{
+			{
+				Key:   "Environment",
+				Value: "Test",
+			},
+			{
+				Key:   "Project",
+				Value: "Acceptance",
+			},
+		},
+	}
+
+	groupId, err := resourcegroups.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+	t.Logf("Created resource group with tags: %s", groupId)
+
+	t.Cleanup(func() {
+		t.Log("Attempting to delete resource group")
+		_, err := resourcegroups.Delete(client, resourcegroups.DeleteOpts{
+			GroupIds: []string{groupId},
+		})
+		th.AssertNoErr(t, err)
+	})
+
+	t.Log("Attempting to get resource group details")
+	group, err := resourcegroups.Get(client, groupId)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, group.GroupName, "test-rg-tag-acc")
+	th.AssertEquals(t, group.Type, "TAG")
+	th.AssertEquals(t, len(group.Tags), 2)
+
+	t.Log("Attempting to update resource group tags")
+	err = resourcegroups.Update(client, groupId, resourcegroups.UpdateOpts{
+		GroupName: "test-rg-tag-acc-updated",
+		Tags: []resourcegroups.ResourceGroupTag{
+			{
+				Key:   "Environment",
+				Value: "Production",
+			},
+		},
+	})
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to verify resource group was updated")
+	group, err = resourcegroups.Get(client, groupId)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, group.GroupName, "test-rg-tag-acc-updated")
+}
+
+func TestResourceGroupsList(t *testing.T) {
+	client, err := clients.NewCesV2Client()
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to list all resource groups")
+	listResp, err := resourcegroups.List(client, resourcegroups.ListOpts{
+		Limit: 10,
+	})
+	th.AssertNoErr(t, err)
+
+	t.Logf("Found %d resource groups", listResp.Count)
+	for _, rg := range listResp.ResourceGroups {
+		t.Logf("Resource Group ID: %s, Name: %s, Type: %s",
+			rg.GroupId, rg.GroupName, rg.Type)
+	}
+}

--- a/acceptance/openstack/ces/v2/templates_test.go
+++ b/acceptance/openstack/ces/v2/templates_test.go
@@ -1,0 +1,162 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ces/v2/templates"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestAlarmTemplatesCRUD(t *testing.T) {
+	client, err := clients.NewCesV2Client()
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to create alarm template")
+	createOpts := templates.CreateOpts{
+		TemplateName:        "test-template-acc",
+		TemplateDescription: "Test alarm template for acceptance tests",
+		Policies: []templates.Policy{
+			{
+				Namespace:          "SYS.ECS",
+				DimensionName:      "instance_id",
+				MetricName:         "cpu_util",
+				Period:             300,
+				Filter:             "average",
+				ComparisonOperator: ">",
+				Value:              80,
+				Unit:               "%",
+				Count:              3,
+				AlarmLevel:         2,
+				SuppressDuration:   300,
+			},
+		},
+	}
+
+	templateId, err := templates.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+	t.Logf("Created alarm template: %s", templateId)
+
+	t.Cleanup(func() {
+		t.Log("Attempting to delete alarm template")
+		_, err := templates.Delete(client, templates.DeleteOpts{
+			TemplateIds:          []string{templateId},
+			DeleteAssociateAlarm: false,
+		})
+		th.AssertNoErr(t, err)
+	})
+
+	t.Log("Attempting to get alarm template details")
+	template, err := templates.Get(client, templateId)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, template.TemplateName, "test-template-acc")
+	th.AssertEquals(t, template.TemplateDescription, "Test alarm template for acceptance tests")
+	th.AssertEquals(t, len(template.Policies), 1)
+	th.AssertEquals(t, template.Policies[0].MetricName, "cpu_util")
+
+	t.Log("Attempting to list alarm templates")
+	listResp, err := templates.List(client, templates.ListOpts{
+		TemplateName: "test-template-acc",
+		TemplateType: "custom",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, listResp.Count >= 1, true)
+
+	t.Log("Attempting to update alarm template")
+	err = templates.Update(client, templateId, templates.UpdateOpts{
+		TemplateName:        "test-template-acc-updated",
+		TemplateDescription: "Updated description",
+		Policies: []templates.Policy{
+			{
+				Namespace:          "SYS.ECS",
+				DimensionName:      "instance_id",
+				MetricName:         "cpu_util",
+				Period:             300,
+				Filter:             "average",
+				ComparisonOperator: ">=",
+				Value:              90,
+				Unit:               "%",
+				Count:              5,
+				AlarmLevel:         1,
+				SuppressDuration:   600,
+			},
+		},
+	})
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to verify template was updated")
+	template, err = templates.Get(client, templateId)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, template.TemplateName, "test-template-acc-updated")
+	th.AssertEquals(t, template.TemplateDescription, "Updated description")
+	th.AssertEquals(t, template.Policies[0].ComparisonOperator, ">=")
+	th.AssertEquals(t, template.Policies[0].Value, float64(90))
+	th.AssertEquals(t, template.Policies[0].AlarmLevel, 1)
+}
+
+func TestAlarmTemplatesList(t *testing.T) {
+	client, err := clients.NewCesV2Client()
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to list system alarm templates")
+	listResp, err := templates.List(client, templates.ListOpts{
+		TemplateType: "system",
+		Limit:        10,
+	})
+	th.AssertNoErr(t, err)
+
+	t.Logf("Found %d system alarm templates", listResp.Count)
+	for _, tmpl := range listResp.AlarmTemplates {
+		t.Logf("Template ID: %s, Name: %s, Type: %s",
+			tmpl.TemplateId, tmpl.TemplateName, tmpl.TemplateType)
+	}
+}
+
+func TestAlarmTemplateAssociationAlarms(t *testing.T) {
+	client, err := clients.NewCesV2Client()
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to create alarm template")
+	createOpts := templates.CreateOpts{
+		TemplateName:        "test-template-assoc-acc",
+		TemplateDescription: "Test template for association alarms",
+		Policies: []templates.Policy{
+			{
+				Namespace:          "SYS.ECS",
+				DimensionName:      "instance_id",
+				MetricName:         "cpu_util",
+				Period:             300,
+				Filter:             "average",
+				ComparisonOperator: ">",
+				Value:              80,
+				Unit:               "%",
+				Count:              3,
+				AlarmLevel:         2,
+				SuppressDuration:   300,
+			},
+		},
+	}
+
+	templateId, err := templates.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+
+	t.Cleanup(func() {
+		t.Log("Attempting to delete alarm template")
+		_, err := templates.Delete(client, templates.DeleteOpts{
+			TemplateIds:          []string{templateId},
+			DeleteAssociateAlarm: true,
+		})
+		th.AssertNoErr(t, err)
+	})
+
+	t.Log("Attempting to list association alarms")
+	listResp, err := templates.ListAssociationAlarms(client, templateId, templates.ListAssociationAlarmsOpts{
+		Limit: 10,
+	})
+	th.AssertNoErr(t, err)
+
+	t.Logf("Found %d associated alarm rules", listResp.Count)
+	for _, alarm := range listResp.Alarms {
+		t.Logf("Alarm ID: %s, Name: %s", alarm.AlarmId, alarm.Name)
+	}
+}

--- a/openstack/ces/v2/records/List.go
+++ b/openstack/ces/v2/records/List.go
@@ -1,0 +1,172 @@
+package records
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// ListOpts contains the options for querying alarm records.
+type ListOpts struct {
+	// Specifies the alarm rule ID.
+	AlarmId string `q:"alarm_id"`
+	// Specifies the alarm rule name. Enter 1 to 128 characters.
+	Name string `q:"name"`
+	// Specifies the alarm record status.
+	// Possible values: ok, alarm, invalid
+	Status string `q:"status"`
+	// Specifies the alarm severity.
+	// 1: critical, 2: major, 3: minor, 4: informational
+	Level int `q:"level,omitempty"`
+	// Specifies the namespace of a service.
+	// The value must be in the service.item format and can contain 3 to 32 characters.
+	Namespace string `q:"namespace"`
+	// Specifies the resource ID.
+	// For multiple dimensions, the format is dim1=value1,dim2=value2.
+	ResourceId string `q:"resource_id"`
+	// Specifies the start time of the query.
+	// The value is in UTC format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
+	From string `q:"from"`
+	// Specifies the end time of the query.
+	// The value is in UTC format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
+	To string `q:"to"`
+	// Specifies the pagination offset. Default: 0, Max: 999
+	Offset int `q:"offset,omitempty"`
+	// Specifies the number of records on each page. Default: 100, Range: 1-100
+	Limit int `q:"limit,omitempty"`
+}
+
+// ListResponse contains the response from the List request.
+type ListResponse struct {
+	// Specifies the list of alarm records.
+	AlarmHistories []AlarmHistoryItem `json:"alarm_histories"`
+	// Specifies the total number of alarm records.
+	Count int `json:"count"`
+}
+
+// AlarmHistoryItem represents an alarm record.
+type AlarmHistoryItem struct {
+	// Specifies the alarm record ID.
+	RecordId string `json:"record_id"`
+	// Specifies the alarm rule ID.
+	AlarmId string `json:"alarm_id"`
+	// Specifies the alarm rule name.
+	Name string `json:"name"`
+	// Specifies the alarm record status.
+	// Possible values: ok, alarm, invalid
+	Status string `json:"status"`
+	// Specifies the alarm severity.
+	// 1: critical, 2: major, 3: minor, 4: informational
+	Level int `json:"level"`
+	// Specifies the alarm rule type.
+	// Possible values: ALL_INSTANCE, RESOURCE_GROUP, MULTI_INSTANCE, EVENT.SYS, EVENT.CUSTOM
+	Type string `json:"type"`
+	// Specifies whether to send notifications.
+	ActionEnabled bool `json:"action_enabled"`
+	// Specifies the time when the alarm record was generated (UTC).
+	BeginTime string `json:"begin_time"`
+	// Specifies the time when the alarm record ended (UTC).
+	EndTime string `json:"end_time"`
+	// Specifies the time when the first alarm was generated (UTC).
+	FirstAlarmTime string `json:"first_alarm_time"`
+	// Specifies the time when the last alarm was generated (UTC).
+	LastAlarmTime string `json:"last_alarm_time"`
+	// Specifies the time when the alarm was cleared (UTC).
+	AlarmRecoveryTime string `json:"alarm_recovery_time"`
+	// Specifies the metric information.
+	Metric Metric `json:"metric"`
+	// Specifies the alarm triggering condition.
+	Condition AlarmCondition `json:"condition"`
+	// Specifies additional information about the alarm.
+	AdditionalInfo AdditionalInfo `json:"additional_info"`
+	// Specifies the action triggered by an alarm.
+	AlarmActions []Notification `json:"alarm_actions"`
+	// Specifies the action triggered after an alarm is cleared.
+	OkActions []Notification `json:"ok_actions"`
+	// Specifies the metric monitoring data.
+	DataPoints []DataPointInfo `json:"data_points"`
+}
+
+// Metric represents metric information.
+type Metric struct {
+	// Specifies the namespace of a service.
+	Namespace string `json:"namespace"`
+	// Specifies the metric name.
+	MetricName string `json:"metric_name"`
+	// Specifies the list of metric dimensions.
+	Dimensions []Dimension `json:"dimensions"`
+}
+
+// Dimension represents a metric dimension.
+type Dimension struct {
+	// Specifies the dimension name.
+	Name string `json:"name"`
+	// Specifies the dimension value.
+	Value string `json:"value"`
+}
+
+// AlarmCondition represents the alarm triggering condition.
+type AlarmCondition struct {
+	// Specifies the rollup period in seconds.
+	Period int `json:"period"`
+	// Specifies the data rollup method.
+	// Possible values: average, max, min, sum, variance
+	Filter string `json:"filter"`
+	// Specifies the comparison operator.
+	// Possible values: >, <, >=, <=, =, !=
+	ComparisonOperator string `json:"comparison_operator"`
+	// Specifies the alarm threshold.
+	Value float64 `json:"value"`
+	// Specifies the data unit.
+	Unit string `json:"unit"`
+	// Specifies the number of consecutive times that the alarm condition is met.
+	Count int `json:"count"`
+	// Specifies the interval for triggering an alarm if the alarm persists in seconds.
+	SuppressDuration int `json:"suppress_duration"`
+}
+
+// AdditionalInfo represents additional information about the alarm.
+type AdditionalInfo struct {
+	// Specifies the resource ID.
+	ResourceId string `json:"resource_id"`
+	// Specifies the resource name.
+	ResourceName string `json:"resource_name"`
+	// Specifies the event ID.
+	EventId string `json:"event_id"`
+}
+
+// Notification represents an alarm notification.
+type Notification struct {
+	// Specifies the notification type.
+	// Possible values: notification, autoscaling, groupwatch, ecsRecovery, contact, contactGroup, iecAction
+	Type string `json:"type"`
+	// Specifies the list of objects to be notified.
+	NotificationList []string `json:"notification_list"`
+}
+
+// DataPointInfo represents a monitoring data point.
+type DataPointInfo struct {
+	// Specifies the time when the monitoring data was collected (UTC).
+	Time string `json:"time"`
+	// Specifies the monitoring value.
+	Value float64 `json:"value"`
+}
+
+// List returns a list of alarm records.
+func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListResponse, error) {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints("alarm-histories").WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	// GET /v2/{project_id}/alarm-histories
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/ces/v2/resourcegroups/Create.go
+++ b/openstack/ces/v2/resourcegroups/Create.go
@@ -1,0 +1,64 @@
+package resourcegroups
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// CreateOpts contains the options for creating a resource group.
+type CreateOpts struct {
+	// Specifies the resource group name.
+	// It can contain 1 to 128 characters and must start with a letter.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	GroupName string `json:"group_name" required:"true"`
+	// Specifies the enterprise project ID.
+	// The value can be a UUID or "0".
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
+	// Specifies how resources are added to the resource group.
+	// Possible values: EPS, TAG, Manual
+	// Default: Manual
+	Type string `json:"type,omitempty"`
+	// Specifies the tags for dynamic resource matching.
+	// This parameter is mandatory when type is set to TAG.
+	// A maximum of 10 tags can be specified.
+	Tags []ResourceGroupTag `json:"tags,omitempty"`
+	// Specifies the enterprise project IDs for the EPS type.
+	// This parameter is mandatory when type is set to EPS.
+	// A maximum of 10 enterprise project IDs can be specified.
+	AssociationEpIds []string `json:"association_ep_ids,omitempty"`
+}
+
+// ResourceGroupTag represents a tag for dynamic resource matching.
+type ResourceGroupTag struct {
+	// Specifies the tag key.
+	// It can contain 1 to 36 characters.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	Key string `json:"key" required:"true"`
+	// Specifies the tag value.
+	// It can contain 0 to 43 characters.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	Value string `json:"value,omitempty"`
+}
+
+// Create creates a new resource group.
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (string, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return "", err
+	}
+
+	// POST /v2/{project_id}/resource-groups
+	raw, err := client.Post(client.ServiceURL("resource-groups"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var res struct {
+		GroupId string `json:"group_id"`
+	}
+	err = extract.Into(raw.Body, &res)
+	return res.GroupId, err
+}

--- a/openstack/ces/v2/resourcegroups/Delete.go
+++ b/openstack/ces/v2/resourcegroups/Delete.go
@@ -1,0 +1,40 @@
+package resourcegroups
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// DeleteOpts contains the options for batch deleting resource groups.
+type DeleteOpts struct {
+	// Specifies the list of resource group IDs to delete.
+	// A maximum of 100 resource groups can be deleted at a time.
+	GroupIds []string `json:"group_ids" required:"true"`
+}
+
+// DeleteResponse contains the response from the batch delete request.
+type DeleteResponse struct {
+	// Specifies the list of deleted resource group IDs.
+	GroupIds []string `json:"group_ids"`
+}
+
+// Delete batch deletes resource groups.
+func Delete(client *golangsdk.ServiceClient, opts DeleteOpts) (*DeleteResponse, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST /v2/{project_id}/resource-groups/batch-delete
+	raw, err := client.Post(client.ServiceURL("resource-groups", "batch-delete"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res DeleteResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/ces/v2/resourcegroups/Get.go
+++ b/openstack/ces/v2/resourcegroups/Get.go
@@ -1,0 +1,41 @@
+package resourcegroups
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// ResourceGroupDetail represents the detailed information of a resource group.
+type ResourceGroupDetail struct {
+	// Specifies the resource group name.
+	GroupName string `json:"group_name"`
+	// Specifies the resource group ID.
+	GroupId string `json:"group_id"`
+	// Specifies the time when the resource group was created.
+	// The value is in UTC format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
+	CreateTime string `json:"create_time"`
+	// Specifies the enterprise project ID.
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// Specifies how resources are added to the resource group.
+	// Possible values: EPS, TAG, Manual
+	Type string `json:"type"`
+	// Specifies the enterprise project IDs for the EPS type.
+	AssociationEpIds []string `json:"association_ep_ids"`
+	// Specifies the tags for dynamic resource matching.
+	Tags []ResourceGroupTag `json:"tags"`
+}
+
+// Get retrieves details of a resource group.
+func Get(client *golangsdk.ServiceClient, groupId string) (*ResourceGroupDetail, error) {
+	// GET /v2/{project_id}/resource-groups/{group_id}
+	raw, err := client.Get(client.ServiceURL("resource-groups", groupId), nil, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res ResourceGroupDetail
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/ces/v2/resourcegroups/List.go
+++ b/openstack/ces/v2/resourcegroups/List.go
@@ -1,0 +1,72 @@
+package resourcegroups
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// ListOpts contains the options for querying resource groups.
+type ListOpts struct {
+	// Specifies the enterprise project ID.
+	// The value can be a UUID or "0".
+	EnterpriseProjectId string `q:"enterprise_project_id"`
+	// Specifies the resource group name. Fuzzy matching is supported.
+	// It can contain 1 to 128 characters.
+	GroupName string `q:"group_name"`
+	// Specifies the resource group ID.
+	// It contains 24 characters and starts with "rg".
+	GroupId string `q:"group_id"`
+	// Specifies the pagination offset.
+	// Default: 0, Range: 0-10000
+	Offset int `q:"offset,omitempty"`
+	// Specifies the number of records on each page.
+	// Default: 100, Range: 1-100
+	Limit int `q:"limit,omitempty"`
+	// Specifies how resources are added to the resource group.
+	// Possible values: EPS, TAG, Manual
+	Type string `q:"type"`
+}
+
+// ListResponse contains the response from the List request.
+type ListResponse struct {
+	// Specifies the total number of resource groups.
+	Count int `json:"count"`
+	// Specifies the list of resource groups.
+	ResourceGroups []ResourceGroup `json:"resource_groups"`
+}
+
+// ResourceGroup represents a resource group in the list response.
+type ResourceGroup struct {
+	// Specifies the resource group name.
+	GroupName string `json:"group_name"`
+	// Specifies the resource group ID.
+	GroupId string `json:"group_id"`
+	// Specifies the time when the resource group was created.
+	// The value is in UTC format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
+	CreateTime string `json:"create_time"`
+	// Specifies the enterprise project ID.
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// Specifies how resources are added to the resource group.
+	// Possible values: EPS, TAG, Manual
+	Type string `json:"type"`
+}
+
+// List returns a list of resource groups.
+func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListResponse, error) {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints("resource-groups").WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	// GET /v2/{project_id}/resource-groups
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/ces/v2/resourcegroups/Update.go
+++ b/openstack/ces/v2/resourcegroups/Update.go
@@ -1,0 +1,32 @@
+package resourcegroups
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+// UpdateOpts contains the options for modifying a resource group.
+type UpdateOpts struct {
+	// Specifies the resource group name.
+	// It can contain 1 to 128 characters.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	GroupName string `json:"group_name" required:"true"`
+	// Specifies the tags for dynamic resource matching.
+	// This parameter is used when the resource group type is TAG.
+	// A maximum of 10 tags can be specified.
+	Tags []ResourceGroupTag `json:"tags,omitempty"`
+}
+
+// Update modifies a resource group.
+func Update(client *golangsdk.ServiceClient, groupId string, opts UpdateOpts) error {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	// PUT /v2/{project_id}/resource-groups/{group_id}
+	_, err = client.Put(client.ServiceURL("resource-groups", groupId), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return err
+}

--- a/openstack/ces/v2/templates/Create.go
+++ b/openstack/ces/v2/templates/Create.go
@@ -1,0 +1,86 @@
+package templates
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// CreateOpts contains the options for creating a custom alarm template.
+type CreateOpts struct {
+	// Specifies the alarm template name.
+	// It must start with a letter and can contain letters, digits, underscores (_),
+	// hyphens (-), parentheses, and periods (.).
+	// Enter 1 to 128 characters.
+	TemplateName string `json:"template_name" required:"true"`
+	// Specifies the alarm template type.
+	// 0: metric alarm template
+	// 2: event alarm template
+	TemplateType int `json:"template_type,omitempty"`
+	// Provides supplementary information about the alarm template.
+	// Enter 0 to 256 characters.
+	TemplateDescription string `json:"template_description,omitempty"`
+	// Specifies the alarm policies. A maximum of 50 policies are supported.
+	Policies []Policy `json:"policies" required:"true"`
+}
+
+// Policy represents an alarm policy in the template.
+type Policy struct {
+	// Specifies the namespace of a service.
+	// The value must be in the service.item format and can contain 3 to 32 characters.
+	Namespace string `json:"namespace" required:"true"`
+	// Specifies the resource dimension.
+	// The value can contain a maximum of 32 characters.
+	// Leave this parameter blank for an event alarm template.
+	DimensionName string `json:"dimension_name,omitempty"`
+	// Specifies the metric name of a resource.
+	// It must start with a letter and can contain 1 to 96 characters.
+	MetricName string `json:"metric_name" required:"true"`
+	// Specifies the aggregation period in seconds.
+	// Possible values: 0, 1, 300, 1200, 3600, 14400, 86400
+	Period int `json:"period" required:"true"`
+	// Specifies the data aggregation method.
+	// Possible values: average, max, min, sum, variance
+	Filter string `json:"filter" required:"true"`
+	// Specifies the comparison operator.
+	// Possible values: >, <, >=, <=, =, !=
+	ComparisonOperator string `json:"comparison_operator" required:"true"`
+	// Specifies the alarm threshold.
+	Value float64 `json:"value,omitempty"`
+	// Specifies the data unit.
+	// Enter 0 to 32 characters.
+	Unit string `json:"unit,omitempty"`
+	// Specifies the number of consecutive times that the alarm condition is met.
+	// For event alarms: 1-180
+	// For metric alarms: 1, 2, 3, 4, 5, 10, 15, 30, 60, 90, 120, or 180
+	Count int `json:"count" required:"true"`
+	// Specifies the alarm severity.
+	// 1: critical, 2: major, 3: minor, 4: informational
+	// Default value: 2
+	AlarmLevel int `json:"alarm_level,omitempty"`
+	// Specifies the interval for triggering an alarm if the alarm persists in seconds.
+	// Possible values: 0, 300, 600, 900, 1800, 3600, 10800, 21600, 43200, 86400
+	SuppressDuration int `json:"suppress_duration" required:"true"`
+}
+
+// Create creates a new custom alarm template.
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (string, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return "", err
+	}
+
+	// POST /v2/{project_id}/alarm-templates
+	raw, err := client.Post(client.ServiceURL("alarm-templates"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{201},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var res struct {
+		TemplateId string `json:"template_id"`
+	}
+	err = extract.Into(raw.Body, &res)
+	return res.TemplateId, err
+}

--- a/openstack/ces/v2/templates/Delete.go
+++ b/openstack/ces/v2/templates/Delete.go
@@ -1,0 +1,44 @@
+package templates
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// DeleteOpts contains the options for batch deleting custom alarm templates.
+type DeleteOpts struct {
+	// Specifies the list of alarm template IDs to delete.
+	// A maximum of 100 templates can be deleted at a time.
+	TemplateIds []string `json:"template_ids" required:"true"`
+	// Specifies whether to delete the alarm rules associated with the alarm template.
+	// true: The alarm rules are also deleted.
+	// false: The alarm rules are not deleted.
+	DeleteAssociateAlarm bool `json:"delete_associate_alarm"`
+}
+
+// DeleteResponse contains the response from the batch delete request.
+type DeleteResponse struct {
+	// Specifies the list of deleted alarm template IDs.
+	TemplateIds []string `json:"template_ids"`
+}
+
+// Delete batch deletes custom alarm templates.
+func Delete(client *golangsdk.ServiceClient, opts DeleteOpts) (*DeleteResponse, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST /v2/{project_id}/alarm-templates/batch-delete
+	raw, err := client.Post(client.ServiceURL("alarm-templates", "batch-delete"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res DeleteResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/ces/v2/templates/Get.go
+++ b/openstack/ces/v2/templates/Get.go
@@ -1,0 +1,66 @@
+package templates
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// TemplateDetail represents the detailed information of an alarm template.
+type TemplateDetail struct {
+	// Specifies the alarm template ID.
+	TemplateId string `json:"template_id"`
+	// Specifies the alarm template name.
+	TemplateName string `json:"template_name"`
+	// Specifies the alarm template type.
+	// Possible values: system, custom
+	TemplateType string `json:"template_type"`
+	// Specifies the time when the alarm template was created.
+	// The value is in UTC format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
+	CreateTime string `json:"create_time"`
+	// Provides supplementary information about the alarm template.
+	TemplateDescription string `json:"template_description"`
+	// Specifies the alarm policies.
+	Policies []PolicyResp `json:"policies"`
+}
+
+// PolicyResp represents an alarm policy in the response.
+type PolicyResp struct {
+	// Specifies the namespace of a service.
+	Namespace string `json:"namespace"`
+	// Specifies the resource dimension.
+	DimensionName string `json:"dimension_name"`
+	// Specifies the metric name of a resource.
+	MetricName string `json:"metric_name"`
+	// Specifies the aggregation period in seconds.
+	Period int `json:"period"`
+	// Specifies the data aggregation method.
+	Filter string `json:"filter"`
+	// Specifies the comparison operator.
+	ComparisonOperator string `json:"comparison_operator"`
+	// Specifies the alarm threshold.
+	Value float64 `json:"value"`
+	// Specifies the data unit.
+	Unit string `json:"unit"`
+	// Specifies the number of consecutive times that the alarm condition is met.
+	Count int `json:"count"`
+	// Specifies the alarm severity.
+	// 1: critical, 2: major, 3: minor, 4: informational
+	AlarmLevel int `json:"alarm_level"`
+	// Specifies the interval for triggering an alarm if the alarm persists in seconds.
+	SuppressDuration int `json:"suppress_duration"`
+}
+
+// Get retrieves details of an alarm template.
+func Get(client *golangsdk.ServiceClient, templateId string) (*TemplateDetail, error) {
+	// GET /v2/{project_id}/alarm-templates/{template_id}
+	raw, err := client.Get(client.ServiceURL("alarm-templates", templateId), nil, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res TemplateDetail
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/ces/v2/templates/List.go
+++ b/openstack/ces/v2/templates/List.go
@@ -1,0 +1,70 @@
+package templates
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// ListOpts contains the options for querying alarm templates.
+type ListOpts struct {
+	// Specifies the pagination offset. Default: 0, Range: 0-10000
+	Offset int `q:"offset,omitempty"`
+	// Specifies the number of records on each page. Default: 100, Range: 1-100
+	Limit int `q:"limit,omitempty"`
+	// Specifies the namespace of a service.
+	// The value must be in the service.item format and can contain 3 to 32 characters.
+	Namespace string `q:"namespace"`
+	// Specifies the resource dimension.
+	// Multiple values can be separated by commas.
+	DimName string `q:"dim_name"`
+	// Specifies the alarm template type.
+	// Possible values: system, custom, system_event, custom_event, system_custom_event
+	TemplateType string `q:"template_type"`
+	// Specifies the alarm template name. Fuzzy matching is supported.
+	// Enter 1 to 128 characters.
+	TemplateName string `q:"template_name"`
+}
+
+// ListResponse contains the response from the List request.
+type ListResponse struct {
+	// Specifies the list of alarm templates.
+	AlarmTemplates []Template `json:"alarm_templates"`
+	// Specifies the total number of alarm templates.
+	Count int `json:"count"`
+}
+
+// Template represents an alarm template in the list response.
+type Template struct {
+	// Specifies the alarm template ID.
+	TemplateId string `json:"template_id"`
+	// Specifies the alarm template name.
+	TemplateName string `json:"template_name"`
+	// Specifies the alarm template type.
+	// Possible values: system, custom
+	TemplateType string `json:"template_type"`
+	// Specifies the time when the alarm template was created.
+	// The value is in UTC format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
+	CreateTime string `json:"create_time"`
+	// Provides supplementary information about the alarm template.
+	TemplateDescription string `json:"template_description"`
+}
+
+// List returns a list of alarm templates.
+func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListResponse, error) {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints("alarm-templates").WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	// GET /v2/{project_id}/alarm-templates
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/ces/v2/templates/ListAssociationAlarms.go
+++ b/openstack/ces/v2/templates/ListAssociationAlarms.go
@@ -1,0 +1,55 @@
+package templates
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// ListAssociationAlarmsOpts contains the options for querying alarm rules associated with an alarm template.
+type ListAssociationAlarmsOpts struct {
+	// Specifies the pagination offset. Default: 0, Range: 0-10000
+	Offset int `q:"offset,omitempty"`
+	// Specifies the number of records on each page. Default: 100, Range: 1-100
+	Limit int `q:"limit,omitempty"`
+}
+
+// ListAssociationAlarmsResponse contains the response from the ListAssociationAlarms request.
+type ListAssociationAlarmsResponse struct {
+	// Specifies the list of alarm rules associated with the alarm template.
+	Alarms []AssociationAlarm `json:"alarms"`
+	// Specifies the total number of alarm rules.
+	Count int `json:"count"`
+}
+
+// AssociationAlarm represents an alarm rule associated with an alarm template.
+type AssociationAlarm struct {
+	// Specifies the alarm rule ID.
+	AlarmId string `json:"alarm_id"`
+	// Specifies the alarm rule name.
+	Name string `json:"name"`
+	// Specifies the alarm rule description.
+	Description string `json:"description"`
+}
+
+// ListAssociationAlarms returns a list of alarm rules associated with an alarm template.
+func ListAssociationAlarms(client *golangsdk.ServiceClient, templateId string, opts ListAssociationAlarmsOpts) (*ListAssociationAlarmsResponse, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("alarm-templates", templateId, "association-alarms").
+		WithQueryParams(&opts).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	// GET /v2/{project_id}/alarm-templates/{template_id}/association-alarms
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListAssociationAlarmsResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/ces/v2/templates/Update.go
+++ b/openstack/ces/v2/templates/Update.go
@@ -1,0 +1,38 @@
+package templates
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+// UpdateOpts contains the options for modifying a custom alarm template.
+type UpdateOpts struct {
+	// Specifies the alarm template name.
+	// It must start with a letter and can contain letters, digits, underscores (_),
+	// hyphens (-), parentheses, and periods (.).
+	// Enter 1 to 128 characters.
+	TemplateName string `json:"template_name" required:"true"`
+	// Specifies the alarm template type.
+	// 0: metric alarm template
+	// 2: event alarm template
+	TemplateType int `json:"template_type,omitempty"`
+	// Provides supplementary information about the alarm template.
+	// Enter 0 to 256 characters.
+	TemplateDescription string `json:"template_description,omitempty"`
+	// Specifies the alarm policies. A maximum of 50 policies are supported.
+	Policies []Policy `json:"policies" required:"true"`
+}
+
+// Update modifies a custom alarm template.
+func Update(client *golangsdk.ServiceClient, templateId string, opts UpdateOpts) error {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	// PUT /v2/{project_id}/alarm-templates/{template_id}
+	_, err = client.Put(client.ServiceURL("alarm-templates", templateId), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return err
+}


### PR DESCRIPTION
### Acceptance tests
```
=== RUN   TestAlarmRecordsList
    records_test.go:15: Attempting to list alarm records
    records_test.go:21: Found 0 alarm records
--- PASS: TestAlarmRecordsList (2.08s)
=== RUN   TestAlarmRecordsListWithFilters
    records_test.go:32: Attempting to list alarm records with status filter
    records_test.go:39: Found 0 alarm records with status 'alarm'
--- PASS: TestAlarmRecordsListWithFilters (0.58s)
PASS

Process finished with the exit code 0

=== RUN   TestAlarmTemplatesCRUD
    templates_test.go:15: Attempting to create alarm template
    templates_test.go:38: Created alarm template: at17685595119859WXQGoWoR
    templates_test.go:49: Attempting to get alarm template details
    templates_test.go:57: Attempting to list alarm templates
    templates_test.go:65: Attempting to update alarm template
    templates_test.go:87: Attempting to verify template was updated
    templates_test.go:41: Attempting to delete alarm template
--- PASS: TestAlarmTemplatesCRUD (2.32s)
=== RUN   TestAlarmTemplatesList
    templates_test.go:101: Attempting to list system alarm templates
    templates_test.go:108: Found 94 system alarm templates
    templates_test.go:110: Template ID: at0000000000gpu001, Name: GPU Alarm Template, Type: system
    templates_test.go:110: Template ID: at000000000000moderation001, Name: Content Moderation Alarm Template, Type: system
    templates_test.go:110: Template ID: at000000000000cloudtable001, Name: CloudTable Service Alarm Template, Type: system
    templates_test.go:110: Template ID: at0000000000000modelarts002, Name: ModelArts Alarm Template(service), Type: system
    templates_test.go:110: Template ID: at0000000000000modelarts001, Name: ModelArts Alarm Template, Type: system
    templates_test.go:110: Template ID: at0000000000000gaussdbv5003, Name: GaussDB Alarm Template(Component), Type: system
    templates_test.go:110: Template ID: at0000000000000gaussdbv5002, Name: GaussDB Alarm Template(Instance), Type: system
    templates_test.go:110: Template ID: at0000000000000gaussdbv5001, Name: GaussDB Alarm Template(Node), Type: system
    templates_test.go:110: Template ID: at000000000000000gaussdb001, Name: TaurusDB Alarm Template(Nodes), Type: system
    templates_test.go:110: Template ID: at0000000000000000vpc002, Name: Bandwidth Alarm Template, Type: system
--- PASS: TestAlarmTemplatesList (0.61s)
=== RUN   TestAlarmTemplateAssociationAlarms
    templates_test.go:119: Attempting to create alarm template
    templates_test.go:152: Attempting to list association alarms
    templates_test.go:158: Found 0 associated alarm rules
    templates_test.go:144: Attempting to delete alarm template
--- PASS: TestAlarmTemplateAssociationAlarms (1.11s)
PASS

Process finished with the exit code 0

=== RUN   TestResourceGroupsCRUD
    resourcegroups_test.go:15: Attempting to create resource group
    resourcegroups_test.go:23: Created resource group: rg1768559793898w413b1Apo
    resourcegroups_test.go:33: Attempting to get resource group details
    resourcegroups_test.go:39: Attempting to list resource groups
    resourcegroups_test.go:46: Attempting to update resource group
    resourcegroups_test.go:52: Attempting to verify resource group was updated
    resourcegroups_test.go:26: Attempting to delete resource group
--- PASS: TestResourceGroupsCRUD (2.10s)
=== RUN   TestResourceGroupsWithTags
    resourcegroups_test.go:62: Attempting to create resource group with tags
    resourcegroups_test.go:80: Created resource group with tags: rg1768559795861LvO7XO2DQ
    resourcegroups_test.go:90: Attempting to get resource group details
    resourcegroups_test.go:97: Attempting to update resource group tags
    resourcegroups_test.go:109: Attempting to verify resource group was updated
    resourcegroups_test.go:83: Attempting to delete resource group
--- PASS: TestResourceGroupsWithTags (1.91s)
=== RUN   TestResourceGroupsList
    resourcegroups_test.go:119: Attempting to list all resource groups
    resourcegroups_test.go:125: Found 1 resource groups
    resourcegroups_test.go:127: Resource Group ID: rg1685982663971z56PagjxK, Name: test, Type: Manual
--- PASS: TestResourceGroupsList (0.50s)
PASS

Process finished with the exit code 0
```