### PR TITLE
[CES]: v2 dashboards and one click alarms

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,5 @@
+version: "2"
+
 linters-settings:
   staticcheck:
     checks:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,3 @@
-version: "2"
-
 linters-settings:
   staticcheck:
     checks:

--- a/acceptance/openstack/ces/v2/dashboards_test.go
+++ b/acceptance/openstack/ces/v2/dashboards_test.go
@@ -1,0 +1,69 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ces/v2/dashboards"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestDashboardsCRUD(t *testing.T) {
+	client, err := clients.NewCesV2Client()
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to create dashboard")
+	dashboardId, err := dashboards.Create(client, dashboards.CreateOpts{
+		DashboardName: "test-dashboard-acc",
+	})
+	th.AssertNoErr(t, err)
+	t.Logf("Created dashboard: %s", dashboardId)
+
+	t.Log("Attempting to copy dashboard")
+	copyDashboardId, err := dashboards.Create(client, dashboards.CreateOpts{
+		DashboardName: "test-dashboard-copy-acc",
+		DashboardId:   dashboardId,
+	})
+	th.AssertNoErr(t, err)
+	t.Logf("Copied dashboard: %s", copyDashboardId)
+
+	t.Cleanup(func() {
+		t.Log("Attempting to batch delete dashboards")
+		results, err := dashboards.BatchDelete(client, dashboards.BatchDeleteOpts{
+			DashboardIds: []string{dashboardId, copyDashboardId},
+		})
+		th.AssertNoErr(t, err)
+		for _, result := range results {
+			t.Logf("Delete result: ID=%s, Status=%s", result.DashboardId, result.RetStatus)
+		}
+	})
+
+	t.Log("Attempting to list dashboards")
+	dashboardsList, err := dashboards.List(client, dashboards.ListOpts{})
+	th.AssertNoErr(t, err)
+	t.Logf("Found %d dashboards", len(dashboardsList))
+
+	found := 0
+	for _, d := range dashboardsList {
+		if d.DashboardId == dashboardId || d.DashboardId == copyDashboardId {
+			found++
+			t.Logf("Dashboard: ID=%s, Name=%s, Creator=%s",
+				d.DashboardId, d.DashboardName, d.CreatorName)
+		}
+	}
+	th.AssertEquals(t, found, 2)
+
+	t.Log("Attempting to modify dashboard")
+	err = dashboards.Update(client, dashboardId, dashboards.UpdateOpts{
+		DashboardName: "test-dashboard-updated-acc",
+	})
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to verify dashboard update")
+	dashboardsList, err = dashboards.List(client, dashboards.ListOpts{
+		DashboardId: dashboardId,
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, len(dashboardsList), 1)
+	th.AssertEquals(t, dashboardsList[0].DashboardName, "test-dashboard-updated-acc")
+}

--- a/acceptance/openstack/ces/v2/oneclickalarms_test.go
+++ b/acceptance/openstack/ces/v2/oneclickalarms_test.go
@@ -1,0 +1,111 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ces/v2/oneclickalarms"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestOneClickAlarmsList(t *testing.T) {
+	client, err := clients.NewCesV2Client()
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to list one-click alarms")
+	alarmsList, err := oneclickalarms.List(client)
+	th.AssertNoErr(t, err)
+	t.Logf("Found %d one-click alarms", len(alarmsList))
+}
+
+func TestOneClickAlarmsCRUD(t *testing.T) {
+	client, err := clients.NewCesV2Client()
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to enable one-click monitoring for ECS")
+	createOpts := oneclickalarms.CreateOpts{
+		OneClickAlarmId: "ECSSystemOneClickAlarm",
+		DimensionNames: oneclickalarms.DimensionNames{
+			Metric: []string{"instance_id"},
+			Event:  []string{},
+		},
+		NotificationEnabled: false,
+	}
+
+	oneClickAlarmId, err := oneclickalarms.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+	t.Logf("Enabled one-click monitoring: %s", oneClickAlarmId)
+
+	t.Cleanup(func() {
+		t.Log("Attempting to disable one-click monitoring")
+		_, err := oneclickalarms.BatchDelete(client, oneclickalarms.BatchDeleteOpts{
+			OneClickAlarmIds: []string{oneClickAlarmId},
+		})
+		th.AssertNoErr(t, err)
+	})
+
+	t.Log("Attempting to list one-click alarms to verify creation")
+	alarmsList, err := oneclickalarms.List(client)
+	th.AssertNoErr(t, err)
+
+	found := false
+	for _, alarm := range alarmsList {
+		if alarm.OneClickAlarmId == oneClickAlarmId && alarm.Enabled {
+			found = true
+			t.Logf("Found enabled one-click alarm: %s, Namespace: %s", alarm.OneClickAlarmId, alarm.Namespace)
+			break
+		}
+	}
+	th.AssertEquals(t, found, true)
+
+	t.Log("Attempting to get alarm rules for one-click monitoring")
+	alarmRules, err := oneclickalarms.ListAlarmRules(client, oneClickAlarmId)
+	th.AssertNoErr(t, err)
+	t.Logf("Found %d alarm rules", len(alarmRules))
+	th.AssertEquals(t, len(alarmRules) > 0, true)
+
+	alarmRule := alarmRules[0]
+	t.Logf("First alarm rule: ID=%s, Name=%s, Enabled=%v",
+		alarmRule.AlarmId, alarmRule.Name, alarmRule.Enabled)
+
+	t.Log("Attempting to disable alarm rule")
+	_, err = oneclickalarms.BatchEnableAlarmRules(client, oneClickAlarmId, oneclickalarms.BatchEnableAlarmRulesOpts{
+		AlarmIds:     []string{alarmRule.AlarmId},
+		AlarmEnabled: false,
+	})
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to enable alarm rule")
+	_, err = oneclickalarms.BatchEnableAlarmRules(client, oneClickAlarmId, oneclickalarms.BatchEnableAlarmRulesOpts{
+		AlarmIds:     []string{alarmRule.AlarmId},
+		AlarmEnabled: true,
+	})
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, len(alarmRule.Policies) > 0, true)
+	policy := alarmRule.Policies[0]
+	t.Logf("First policy: ID=%s, MetricName=%s, Enabled=%v",
+		policy.AlarmPolicyId, policy.MetricName, policy.Enabled)
+
+	t.Log("Attempting to disable alarm policy")
+	_, err = oneclickalarms.BatchEnablePolicies(client, oneClickAlarmId, alarmRule.AlarmId, oneclickalarms.BatchEnablePoliciesOpts{
+		AlarmPolicyIds: []string{policy.AlarmPolicyId},
+		Enabled:        false,
+	})
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to enable alarm policy")
+	_, err = oneclickalarms.BatchEnablePolicies(client, oneClickAlarmId, alarmRule.AlarmId, oneclickalarms.BatchEnablePoliciesOpts{
+		AlarmPolicyIds: []string{policy.AlarmPolicyId},
+		Enabled:        true,
+	})
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to update notifications")
+	err = oneclickalarms.UpdateNotifications(client, oneClickAlarmId, oneclickalarms.UpdateNotificationsOpts{
+		NotificationEnabled:   false,
+		NotificationBeginTime: "00:00",
+		NotificationEndTime:   "23:59",
+	})
+	th.AssertNoErr(t, err)
+}

--- a/openstack/ces/v2/dashboards/BatchDelete.go
+++ b/openstack/ces/v2/dashboards/BatchDelete.go
@@ -1,0 +1,47 @@
+package dashboards
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// BatchDeleteOpts contains the options for batch deleting dashboards.
+type BatchDeleteOpts struct {
+	// Specifies the list of dashboard IDs to delete.
+	// A maximum of 30 dashboard IDs are supported.
+	DashboardIds []string `json:"dashboard_ids,omitempty"`
+}
+
+// BatchDeleteResult represents the result of deleting a single dashboard.
+type BatchDeleteResult struct {
+	// Specifies the dashboard ID.
+	DashboardId string `json:"dashboard_id"`
+	// Specifies the deletion result.
+	// Possible values: successful, error
+	RetStatus string `json:"ret_status"`
+	// Specifies the error message if deletion failed.
+	ErrorMsg string `json:"error_msg,omitempty"`
+}
+
+// BatchDelete batch deletes dashboards.
+func BatchDelete(client *golangsdk.ServiceClient, opts BatchDeleteOpts) ([]BatchDeleteResult, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST /v2/{project_id}/dashboards/batch-delete
+	raw, err := client.Post(client.ServiceURL("dashboards", "batch-delete"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		Dashboards []BatchDeleteResult `json:"dashboards"`
+	}
+	err = extract.Into(raw.Body, &res)
+	return res.Dashboards, err
+}

--- a/openstack/ces/v2/dashboards/Create.go
+++ b/openstack/ces/v2/dashboards/Create.go
@@ -1,0 +1,48 @@
+package dashboards
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// CreateOpts contains the options for creating or copying a dashboard.
+type CreateOpts struct {
+	// Specifies the dashboard name.
+	// It can contain 1 to 128 characters.
+	// Only letters, digits, underscores (_), hyphens (-), and Chinese characters are allowed.
+	DashboardName string `json:"dashboard_name" required:"true"`
+	// Specifies the enterprise project ID.
+	// The value can be a UUID or "0".
+	EnterpriseId string `json:"enterprise_id,omitempty"`
+	// Specifies the dashboard ID to copy from.
+	// If this parameter is specified, the dashboard is copied.
+	// The value starts with "db" and is followed by 22 characters.
+	DashboardId string `json:"dashboard_id,omitempty"`
+	// Specifies how many graphs will be displayed in each row.
+	// Possible values: 0, 1, 2, 3. Default: 0
+	// 0 indicates auto layout.
+	RowWidgetNum *int `json:"row_widget_num,omitempty"`
+}
+
+// Create creates a new dashboard or copies an existing one.
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (string, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return "", err
+	}
+
+	// POST /v2/{project_id}/dashboards
+	raw, err := client.Post(client.ServiceURL("dashboards"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{201},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var res struct {
+		DashboardId string `json:"dashboard_id"`
+	}
+	err = extract.Into(raw.Body, &res)
+	return res.DashboardId, err
+}

--- a/openstack/ces/v2/dashboards/List.go
+++ b/openstack/ces/v2/dashboards/List.go
@@ -1,0 +1,66 @@
+package dashboards
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// ListOpts contains the options for querying dashboards.
+type ListOpts struct {
+	// Specifies whether to filter by favorite status.
+	// This parameter requires enterprise_id to be specified.
+	IsFavorite *bool `q:"is_favorite,omitempty"`
+	// Specifies the dashboard name for filtering.
+	// It can contain 1 to 128 characters.
+	DashboardName string `q:"dashboard_name,omitempty"`
+	// Specifies the dashboard ID for filtering.
+	// The value starts with "db" and is followed by 22 characters.
+	DashboardId string `q:"dashboard_id,omitempty"`
+	// Specifies the enterprise project ID.
+	EnterpriseId string `q:"enterprise_id,omitempty"`
+}
+
+// Dashboard represents a dashboard in the list response.
+type Dashboard struct {
+	// Specifies the dashboard ID.
+	DashboardId string `json:"dashboard_id"`
+	// Specifies the dashboard name.
+	DashboardName string `json:"dashboard_name"`
+	// Specifies the enterprise project ID.
+	EnterpriseId string `json:"enterprise_id"`
+	// Specifies the name of the user who created the dashboard.
+	CreatorName string `json:"creator_name"`
+	// Specifies the time when the dashboard was created.
+	// The value is a UNIX timestamp in milliseconds.
+	CreateTime int64 `json:"create_time"`
+	// Specifies how many graphs will be displayed in each row.
+	// Possible values: 0, 1, 2, 3. Default: 3
+	RowWidgetNum int `json:"row_widget_num"`
+	// Specifies whether the dashboard is a favorite.
+	IsFavorite bool `json:"is_favorite"`
+}
+
+// List queries dashboards.
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]Dashboard, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("dashboards").
+		WithQueryParams(&opts).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	// GET /v2/{project_id}/dashboards
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		Dashboards []Dashboard `json:"dashboards"`
+	}
+	err = extract.Into(raw.Body, &res)
+	return res.Dashboards, err
+}

--- a/openstack/ces/v2/dashboards/Update.go
+++ b/openstack/ces/v2/dashboards/Update.go
@@ -1,0 +1,34 @@
+package dashboards
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+// UpdateOpts contains the options for modifying a dashboard.
+type UpdateOpts struct {
+	// Specifies the dashboard name.
+	// It can contain 1 to 128 characters.
+	// Only letters, digits, underscores (_), hyphens (-), and Chinese characters are allowed.
+	DashboardName string `json:"dashboard_name,omitempty"`
+	// Specifies whether the dashboard is a favorite.
+	IsFavorite *bool `json:"is_favorite,omitempty"`
+	// Specifies how many graphs will be displayed in each row.
+	// Possible values: 0, 1, 2, 3. Default: 3
+	// 0 indicates auto layout.
+	RowWidgetNum *int `json:"row_widget_num,omitempty"`
+}
+
+// Update modifies a dashboard.
+func Update(client *golangsdk.ServiceClient, dashboardId string, opts UpdateOpts) error {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	// PUT /v2/{project_id}/dashboards/{dashboard_id}
+	_, err = client.Put(client.ServiceURL("dashboards", dashboardId), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return err
+}

--- a/openstack/ces/v2/oneclickalarms/BatchDelete.go
+++ b/openstack/ces/v2/oneclickalarms/BatchDelete.go
@@ -1,0 +1,36 @@
+package oneclickalarms
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// BatchDeleteOpts contains the options for batch disabling one-click monitoring.
+type BatchDeleteOpts struct {
+	// Specifies the IDs of services that need to disable one-click monitoring.
+	// A maximum of 100 IDs are supported.
+	OneClickAlarmIds []string `json:"one_click_alarm_ids" required:"true"`
+}
+
+// BatchDelete batch disables one-click monitoring.
+func BatchDelete(client *golangsdk.ServiceClient, opts BatchDeleteOpts) ([]string, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST /v2/{project_id}/one-click-alarms/batch-delete
+	raw, err := client.Post(client.ServiceURL("one-click-alarms", "batch-delete"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		OneClickAlarmIds []string `json:"one_click_alarm_ids"`
+	}
+	err = extract.Into(raw.Body, &res)
+	return res.OneClickAlarmIds, err
+}

--- a/openstack/ces/v2/oneclickalarms/BatchEnableAlarmRules.go
+++ b/openstack/ces/v2/oneclickalarms/BatchEnableAlarmRules.go
@@ -1,0 +1,39 @@
+package oneclickalarms
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// BatchEnableAlarmRulesOpts contains the options for batch enabling or disabling alarm rules.
+type BatchEnableAlarmRulesOpts struct {
+	// Specifies the IDs of alarm rules.
+	// A maximum of 100 alarm rule IDs are supported.
+	AlarmIds []string `json:"alarm_ids" required:"true"`
+	// Specifies whether to enable the alarm rules.
+	// true: enable, false: disable
+	AlarmEnabled bool `json:"alarm_enabled"`
+}
+
+// BatchEnableAlarmRules batch enables or disables alarm rules of one service in one-click monitoring.
+func BatchEnableAlarmRules(client *golangsdk.ServiceClient, oneClickAlarmId string, opts BatchEnableAlarmRulesOpts) ([]string, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// PUT /v2/{project_id}/one-click-alarms/{one_click_alarm_id}/alarm-rules/action
+	raw, err := client.Put(client.ServiceURL("one-click-alarms", oneClickAlarmId, "alarm-rules", "action"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		AlarmIds []string `json:"alarm_ids"`
+	}
+	err = extract.Into(raw.Body, &res)
+	return res.AlarmIds, err
+}

--- a/openstack/ces/v2/oneclickalarms/BatchEnablePolicies.go
+++ b/openstack/ces/v2/oneclickalarms/BatchEnablePolicies.go
@@ -1,0 +1,40 @@
+package oneclickalarms
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// BatchEnablePoliciesOpts contains the options for batch enabling or disabling alarm policies.
+type BatchEnablePoliciesOpts struct {
+	// Specifies the IDs of alarm policies.
+	// A maximum of 100 alarm policy IDs are supported.
+	AlarmPolicyIds []string `json:"alarm_policy_ids" required:"true"`
+	// Specifies whether to enable the alarm policies.
+	// true: enable, false: disable
+	Enabled bool `json:"enabled"`
+}
+
+// BatchEnablePolicies batch enables or disables alarm policies in alarm rules
+// for one service with one-click monitoring enabled.
+func BatchEnablePolicies(client *golangsdk.ServiceClient, oneClickAlarmId, alarmId string, opts BatchEnablePoliciesOpts) ([]string, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// PUT /v2/{project_id}/one-click-alarms/{one_click_alarm_id}/alarms/{alarm_id}/policies/action
+	raw, err := client.Put(client.ServiceURL("one-click-alarms", oneClickAlarmId, "alarms", alarmId, "policies", "action"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		AlarmPolicyIds []string `json:"alarm_policy_ids"`
+	}
+	err = extract.Into(raw.Body, &res)
+	return res.AlarmPolicyIds, err
+}

--- a/openstack/ces/v2/oneclickalarms/Create.go
+++ b/openstack/ces/v2/oneclickalarms/Create.go
@@ -1,0 +1,72 @@
+package oneclickalarms
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// CreateOpts contains the options for enabling one-click monitoring.
+type CreateOpts struct {
+	// Specifies the one-click monitoring ID.
+	// It can contain 1 to 64 alphanumeric characters.
+	OneClickAlarmId string `json:"one_click_alarm_id" required:"true"`
+	// Specifies the dimension names for metric and event alarm rules.
+	DimensionNames DimensionNames `json:"dimension_names" required:"true"`
+	// Specifies whether to enable the alarm notification.
+	NotificationEnabled bool `json:"notification_enabled"`
+	// Specifies the action to be triggered when an alarm is generated.
+	// A maximum of 10 actions are supported.
+	AlarmNotifications []Notification `json:"alarm_notifications,omitempty"`
+	// Specifies the action to be triggered after an alarm is cleared.
+	// A maximum of 10 actions are supported.
+	OkNotifications []Notification `json:"ok_notifications,omitempty"`
+	// Specifies the time when the alarm notification was enabled.
+	// The value is in the format of HH:MM.
+	NotificationBeginTime string `json:"notification_begin_time,omitempty"`
+	// Specifies the time when the alarm notification was disabled.
+	// The value is in the format of HH:MM.
+	NotificationEndTime string `json:"notification_end_time,omitempty"`
+}
+
+// DimensionNames specifies dimension names for metric and event alarm rules.
+type DimensionNames struct {
+	// Specifies the dimension strings for metric alarm rules.
+	// A maximum of 100 items are supported.
+	Metric []string `json:"metric,omitempty"`
+	// Specifies the dimension strings for event alarm rules.
+	// A maximum of 100 items are supported.
+	Event []string `json:"event,omitempty"`
+}
+
+// Notification represents an alarm notification.
+type Notification struct {
+	// Specifies the notification type.
+	// Possible values: notification, contact
+	Type string `json:"type" required:"true"`
+	// Specifies the list of SMN topic URNs.
+	// A maximum of 20 items are supported.
+	NotificationList []string `json:"notification_list" required:"true"`
+}
+
+// Create enables one-click monitoring.
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (string, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return "", err
+	}
+
+	// POST /v2/{project_id}/one-click-alarms
+	raw, err := client.Post(client.ServiceURL("one-click-alarms"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{201},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var res struct {
+		OneClickAlarmId string `json:"one_click_alarm_id"`
+	}
+	err = extract.Into(raw.Body, &res)
+	return res.OneClickAlarmId, err
+}

--- a/openstack/ces/v2/oneclickalarms/List.go
+++ b/openstack/ces/v2/oneclickalarms/List.go
@@ -1,0 +1,35 @@
+package oneclickalarms
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// OneClickAlarm represents a one-click monitoring configuration.
+type OneClickAlarm struct {
+	// Specifies the one-click monitoring ID.
+	OneClickAlarmId string `json:"one_click_alarm_id"`
+	// Specifies the namespace of a service.
+	Namespace string `json:"namespace"`
+	// Provides supplementary information about the one-click monitoring.
+	Description string `json:"description"`
+	// Specifies whether one-click monitoring is enabled.
+	Enabled bool `json:"enabled"`
+}
+
+// List queries services and resources in one-click monitoring.
+func List(client *golangsdk.ServiceClient) ([]OneClickAlarm, error) {
+	// GET /v2/{project_id}/one-click-alarms
+	raw, err := client.Get(client.ServiceURL("one-click-alarms"), nil, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		OneClickAlarms []OneClickAlarm `json:"one_click_alarms"`
+	}
+	err = extract.Into(raw.Body, &res)
+	return res.OneClickAlarms, err
+}

--- a/openstack/ces/v2/oneclickalarms/ListAlarmRules.go
+++ b/openstack/ces/v2/oneclickalarms/ListAlarmRules.go
@@ -1,0 +1,105 @@
+package oneclickalarms
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// AlarmRule represents an alarm rule in one-click monitoring.
+type AlarmRule struct {
+	// Specifies the alarm rule ID.
+	AlarmId string `json:"alarm_id"`
+	// Specifies the alarm rule name.
+	Name string `json:"name"`
+	// Provides supplementary information about the alarm rule.
+	Description string `json:"description"`
+	// Specifies the namespace of a service.
+	Namespace string `json:"namespace"`
+	// Specifies the alarm policies.
+	Policies []Policy `json:"policies"`
+	// Specifies the resource list.
+	Resources []Resource `json:"resources"`
+	// Specifies the alarm rule type.
+	// Possible values: ALL_INSTANCE, RESOURCE_GROUP, MULTI_INSTANCE, EVENT.SYS, EVENT.CUSTOM
+	Type string `json:"type"`
+	// Specifies whether to generate alarms.
+	Enabled bool `json:"enabled"`
+	// Specifies whether notification is enabled.
+	NotificationEnabled bool `json:"notification_enabled"`
+	// Specifies the action triggered by an alarm.
+	AlarmNotifications []Notification `json:"alarm_notifications"`
+	// Specifies the action triggered after an alarm is cleared.
+	OkNotifications []Notification `json:"ok_notifications"`
+	// Specifies the time when the alarm notification was enabled.
+	// The value is in the format of HH:MM.
+	NotificationBeginTime string `json:"notification_begin_time"`
+	// Specifies the time when the alarm notification was disabled.
+	// The value is in the format of HH:MM.
+	NotificationEndTime string `json:"notification_end_time"`
+}
+
+// Policy represents an alarm policy.
+type Policy struct {
+	// Specifies the alarm policy ID.
+	AlarmPolicyId string `json:"alarm_policy_id"`
+	// Specifies the metric name.
+	MetricName string `json:"metric_name"`
+	// Specifies the rollup period in seconds.
+	// Possible values: 0, 1, 300, 1200, 3600, 14400, 86400
+	Period int `json:"period"`
+	// Specifies the data rollup method.
+	// Possible values: average, max, min, sum, variance
+	Filter string `json:"filter"`
+	// Specifies the comparison operator.
+	// Possible values: >, <, >=, <=, =, !=
+	ComparisonOperator string `json:"comparison_operator"`
+	// Specifies the alarm threshold.
+	Value float64 `json:"value"`
+	// Specifies the data unit.
+	Unit string `json:"unit"`
+	// Specifies the number of consecutive times that the alarm condition is met.
+	Count int `json:"count"`
+	// Specifies the interval for triggering an alarm if the alarm persists in seconds.
+	// Possible values: 0, 300, 600, 900, 1800, 3600, 10800, 21600, 43200, 86400
+	SuppressDuration int `json:"suppress_duration"`
+	// Specifies the alarm severity.
+	// 1: critical, 2: major, 3: minor, 4: informational
+	Level int `json:"level"`
+	// Specifies whether the alarm policy is enabled.
+	Enabled bool `json:"enabled"`
+}
+
+// Resource represents a resource in the alarm rule.
+type Resource struct {
+	// Specifies the resource group ID.
+	ResourceGroupId string `json:"resource_group_id"`
+	// Specifies the resource group name.
+	ResourceGroupName string `json:"resource_group_name"`
+	// Specifies the metric dimensions.
+	Dimensions []Dimension `json:"dimensions"`
+}
+
+// Dimension represents a metric dimension.
+type Dimension struct {
+	// Specifies the dimension name.
+	Name string `json:"name"`
+	// Specifies the dimension value.
+	Value string `json:"value"`
+}
+
+// ListAlarmRules queries the alarm rules of one service in one-click monitoring.
+func ListAlarmRules(client *golangsdk.ServiceClient, oneClickAlarmId string) ([]AlarmRule, error) {
+	// GET /v2/{project_id}/one-click-alarms/{one_click_alarm_id}/alarms
+	raw, err := client.Get(client.ServiceURL("one-click-alarms", oneClickAlarmId, "alarms"), nil, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		Alarms []AlarmRule `json:"alarms"`
+	}
+	err = extract.Into(raw.Body, &res)
+	return res.Alarms, err
+}

--- a/openstack/ces/v2/oneclickalarms/UpdateNotifications.go
+++ b/openstack/ces/v2/oneclickalarms/UpdateNotifications.go
@@ -1,0 +1,39 @@
+package oneclickalarms
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+// UpdateNotificationsOpts contains the options for batch modifying alarm notifications.
+type UpdateNotificationsOpts struct {
+	// Specifies whether to enable the alarm notification.
+	NotificationEnabled bool `json:"notification_enabled"`
+	// Specifies the action to be triggered when an alarm is generated.
+	// A maximum of 10 actions are supported.
+	AlarmNotifications []Notification `json:"alarm_notifications,omitempty"`
+	// Specifies the action to be triggered after an alarm is cleared.
+	// A maximum of 10 actions are supported.
+	OkNotifications []Notification `json:"ok_notifications,omitempty"`
+	// Specifies the time when the alarm notification was enabled.
+	// The value is in the format of HH:MM.
+	NotificationBeginTime string `json:"notification_begin_time,omitempty"`
+	// Specifies the time when the alarm notification was disabled.
+	// The value is in the format of HH:MM.
+	NotificationEndTime string `json:"notification_end_time,omitempty"`
+}
+
+// UpdateNotifications batch modifies alarm notifications in alarm rules
+// for one service with one-click monitoring enabled.
+func UpdateNotifications(client *golangsdk.ServiceClient, oneClickAlarmId string, opts UpdateNotificationsOpts) error {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	// PUT /v2/{project_id}/one-click-alarms/{one_click_alarm_id}/notifications
+	_, err = client.Put(client.ServiceURL("one-click-alarms", oneClickAlarmId, "notifications"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return err
+}


### PR DESCRIPTION
### Acceptance tests
```
=== RUN   TestDashboardsCRUD
    dashboards_test.go:16: Attempting to create dashboard
    dashboards_test.go:21: Created dashboard: db1768801018361P0MjrlJjY
    dashboards_test.go:24: Attempting to copy dashboard
    dashboards_test.go:30: Copied dashboard: db1768801018642e7dPjwjXR
    dashboards_test.go:44: Attempting to list dashboards
    dashboards_test.go:47: Found 4 dashboards
    dashboards_test.go:53: Dashboard: ID=db1768801018361P0MjrlJjY, Name=test-dashboard-acc, Creator=alifshit
    dashboards_test.go:53: Dashboard: ID=db1768801018642e7dPjwjXR, Name=test-dashboard-copy-acc, Creator=alifshit
    dashboards_test.go:60: Attempting to modify dashboard
    dashboards_test.go:67: Attempting to verify dashboard update
    dashboards_test.go:33: Attempting to batch delete dashboards
    dashboards_test.go:39: Delete result: ID=db1768801018361P0MjrlJjY, Status=successful
    dashboards_test.go:39: Delete result: ID=db1768801018642e7dPjwjXR, Status=successful
--- PASS: TestDashboardsCRUD (2.23s)
PASS

Process finished with the exit code 0

=== RUN   TestOneClickAlarmsList
    oneclickalarms_test.go:15: Attempting to list one-click alarms
    oneclickalarms_test.go:18: Found 49 one-click alarms
--- PASS: TestOneClickAlarmsList (0.53s)
=== RUN   TestOneClickAlarmsCRUD
    oneclickalarms_test.go:25: Attempting to enable one-click monitoring for ECS
    oneclickalarms_test.go:37: Enabled one-click monitoring: oca176880110462808lQ9ZgVN
    oneclickalarms_test.go:47: Attempting to list one-click alarms to verify creation
    oneclickalarms_test.go:55: Found enabled one-click alarm: oca176880110462808lQ9ZgVN, Namespace: SYS.ECS
    oneclickalarms_test.go:61: Attempting to get alarm rules for one-click monitoring
    oneclickalarms_test.go:64: Found 5 alarm rules
    oneclickalarms_test.go:68: First alarm rule: ID=al1768801104648VqMGpPAEY, Name=alarm-ecs-event-default, Enabled=false
    oneclickalarms_test.go:71: Attempting to disable alarm rule
    oneclickalarms_test.go:78: Attempting to enable alarm rule
    oneclickalarms_test.go:87: First policy: ID=0367da53-ed54-4136-ae1a-e650e337e06f, MetricName=FPGALinkFault, Enabled=true
    oneclickalarms_test.go:90: Attempting to disable alarm policy
    oneclickalarms_test.go:97: Attempting to enable alarm policy
    oneclickalarms_test.go:104: Attempting to update notifications
    oneclickalarms_test.go:40: Attempting to disable one-click monitoring
--- PASS: TestOneClickAlarmsCRUD (3.13s)
PASS

Process finished with the exit code 0
```
