### PR TITLE
[FGS] fix LaunchSync() and LaunchAsync()

### DIFF
--- a/acceptance/openstack/fgs/v2/functiongraph_test.go
+++ b/acceptance/openstack/fgs/v2/functiongraph_test.go
@@ -137,7 +137,7 @@ func createFunctionGraph(t *testing.T, client *golangsdk.ServiceClient) (*functi
 		Package:    "default",
 		Runtime:    "Python3.9",
 		Timeout:    200,
-		Handler:    "index.py",
+		Handler:    "index.handler",
 		MemorySize: 512,
 		CodeType:   "zip",
 		CodeURL:    "https://regr-func-graph.obs.eu-de.otc.t-systems.com/index.py",

--- a/acceptance/openstack/fgs/v2/invocation_test.go
+++ b/acceptance/openstack/fgs/v2/invocation_test.go
@@ -29,10 +29,23 @@ func TestFunctionGraphSync(t *testing.T) {
 		th.AssertNoErr(t, err)
 	}(client, funcUrn)
 
-	syncResp, err := invoke.LaunchSync(client, funcUrn)
+	body := map[string]interface{}{
+		"k": "v",
+		"t": "start",
+	}
+
+	syncResp, syncRespHeaders, err := invoke.LaunchSync(client, funcUrn, body, invoke.NewLaunchSyncHeaders())
+
 	th.AssertNoErr(t, err)
 
+	// test for function error
+	th.AssertEquals(t, false, syncRespHeaders.IsFuncErr)
+
+	// test for http status
+	th.AssertEquals(t, 200, syncResp.Status)
+
 	tools.PrintResource(t, syncResp)
+	tools.PrintResource(t, syncRespHeaders)
 }
 
 func TestFunctionGraphAsync(t *testing.T) {

--- a/acceptance/openstack/fgs/v2/invocation_test.go
+++ b/acceptance/openstack/fgs/v2/invocation_test.go
@@ -31,7 +31,7 @@ func TestFunctionGraphSync(t *testing.T) {
 
 	body := map[string]interface{}{
 		"k": "v",
-		"t": "start",
+		"t": map[string]int{"a": 1, "b": 2},
 	}
 
 	h := invoke.NewLaunchSyncHeaders()
@@ -73,13 +73,16 @@ func TestFunctionGraphAsync(t *testing.T) {
 		th.AssertNoErr(t, err)
 	}(client, funcUrn)
 
-	asyncOpts := map[string]string{
+	asyncOpts := map[string]interface{}{
 		"k":    "v",
-		"test": "start",
+		"test": map[string]int{"a": 1, "b": 2},
 	}
 
 	syncResp, err := invoke.LaunchAsync(client, funcUrn, asyncOpts)
 	th.AssertNoErr(t, err)
+
+	// check that we have a request ID
+	th.AssertNotEquals(t, "", syncResp.RequestID)
 
 	tools.PrintResource(t, syncResp)
 }

--- a/acceptance/openstack/fgs/v2/invocation_test.go
+++ b/acceptance/openstack/fgs/v2/invocation_test.go
@@ -34,7 +34,11 @@ func TestFunctionGraphSync(t *testing.T) {
 		"t": "start",
 	}
 
-	syncResp, syncRespHeaders, err := invoke.LaunchSync(client, funcUrn, body, invoke.NewLaunchSyncHeaders())
+	h := invoke.NewLaunchSyncHeaders()
+	// request logs with the response
+	h.LogType = "tail"
+
+	syncResp, syncRespHeaders, err := invoke.LaunchSync(client, funcUrn, body, h)
 
 	th.AssertNoErr(t, err)
 
@@ -43,6 +47,11 @@ func TestFunctionGraphSync(t *testing.T) {
 
 	// test for http status
 	th.AssertEquals(t, 200, syncResp.Status)
+
+	// test for log presence if requested
+	if h.LogType == "tail" {
+		th.AssertNotEquals(t, "", syncResp.Log)
+	}
 
 	tools.PrintResource(t, syncResp)
 	tools.PrintResource(t, syncRespHeaders)

--- a/openstack/fgs/v2/invoke/InvokeAsync.go
+++ b/openstack/fgs/v2/invoke/InvokeAsync.go
@@ -2,18 +2,15 @@ package invoke
 
 import (
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
-	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 )
 
-func LaunchAsync(client *golangsdk.ServiceClient, funcUrn string, opts map[string]string) (*LaunchAsyncResp, error) {
-	b, err := build.RequestBody(opts, "body")
-	if err != nil {
-		return nil, err
-	}
+// LaunchAsync is used to execute a function asynchronously.
+func LaunchAsync(client *golangsdk.ServiceClient, funcUrn string, JSONBody interface{}) (*LaunchAsyncResp, error) {
 
-	raw, err := client.Post(client.ServiceURL("fgs", "functions", funcUrn, "invocations-async"), b, nil, &golangsdk.RequestOpts{
-		OkCodes: []int{202},
+	raw, err := client.Post(client.ServiceURL("fgs", "functions", funcUrn, "invocations-async"), JSONBody, nil, &golangsdk.RequestOpts{
+		OkCodes:     []int{202},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
 	})
 	if err != nil {
 		return nil, err

--- a/openstack/fgs/v2/invoke/InvokeSync.go
+++ b/openstack/fgs/v2/invoke/InvokeSync.go
@@ -1,25 +1,164 @@
 package invoke
 
 import (
+	"encoding/json"
+	"net/http"
+
+	"reflect"
+
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 )
 
-func LaunchSync(client *golangsdk.ServiceClient, funcUrn string) (*LaunchSyncResp, error) {
-	raw, err := client.Post(client.ServiceURL("fgs", "functions", funcUrn, "invocations"), nil, nil, &golangsdk.RequestOpts{
-		OkCodes: []int{200},
-	})
+// LaunchSync is used to execute a function synchronously.
+// Clients must wait for explicit responses to their requests from the function.
+// Responses are returned only after function invocation is complete.
+func LaunchSync(client *golangsdk.ServiceClient, funcUrn string, body map[string]interface{}, headers LaunchSyncHeaders) (*LaunchSyncResp, *LaunchSyncResponseHeaders, error) {
+	b, err := build.RequestBody(body, "")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
+	// overwrite RequestVersion to "v1",as response is expected in json format
+	// v0 will not work here
+	headers.RequestVersion = "v1"
+
+	headerJson, _ := json.Marshal(headers)
+	headerMap := make(map[string]string)
+	json.Unmarshal(headerJson, &headerMap)
+
+	raw, err := client.Post(client.ServiceURL("fgs", "functions", funcUrn, "invocations"), b, nil, &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: headerMap,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp_header := &LaunchSyncResponseHeaders{}
+	unmarshalHeaders(raw.Header, resp_header)
+
 	var res LaunchSyncResp
-	return &res, extract.Into(raw.Body, &res)
+	err = extract.Into(raw.Body, &res)
+
+	return &res, resp_header, err
 }
 
+// LaunchSyncHeaders represents the request headers for a synchronous function invocation
+type LaunchSyncHeaders struct {
+	// Content type of the request body.
+	ContentType string `json:"Content-Type"` // e.g. "application/json"
+
+	// Options: tail (4 KB logs will be returned) and null (no logs will be returned).
+	LogType string `json:"X-Cff-Log-Type"`
+
+	// Response body format. Options: v0 and v1.
+	// v0: text format.
+	// v1: JSON format. Select this format when using an SDK.
+	// Must be set to "v1" to get JSON format response.
+	RequestVersion string `json:"X-Cff-Request-Version"`
+
+	// Dynamic memory allocation for function.
+	// Options:
+	// - empty or
+	// - any value of 128, 256, 512, 768, 1,024, 1,280, 1,536, 1,792,
+	//   2,048, 2,560, 3,072, 3,584, 4,096, 8,192, or 10,240
+	// If not empty, dynamic memory allocation must be enabled for the function.
+	InstanceMemory string `json:"X-Cff-Instance-Memory"`
+}
+
+// NewLaunchSyncHeaders creates default headers for LaunchSync function invocation
+func NewLaunchSyncHeaders() LaunchSyncHeaders {
+	return LaunchSyncHeaders{
+		ContentType:    "application/json",
+		LogType:        "",
+		RequestVersion: "v1",
+		InstanceMemory: "",
+	}
+}
+
+// LaunchSyncResp represents the response from a synchronous function invocation
 type LaunchSyncResp struct {
+	// Request ID
 	RequestID string `json:"request_id"`
-	Result    string `json:"result"`
-	Log       string `json:"log"`
-	Status    string `json:"status"`
+
+	// Function execution result.
+	Result string `json:"result"`
+
+	// Function execution log.
+	Log string `json:"log"`
+
+	// Function execution status.
+	Status int `json:"status"`
+}
+
+// LaunchSyncResponseHeaders represents the response headers from a synchronous function invocation
+type LaunchSyncResponseHeaders struct {
+	// Execution summary of the synchronous invocation.
+	InvokeSummary string `json:"X-Cff-Invoke-Summary"`
+
+	// Request ID of the synchronous invocation.
+	RequestId string `json:"X-Cff-Request-Id"`
+
+	// User log of the synchronous invocation.
+	// Set X-Cff-Log-Type:tail in the request header.
+	// Intercept and encode the last 2,000 bytes of the log using Base64.
+	FunctionLog string `json:"X-Cff-Function-Log"`
+
+	// Billing information of the synchronous invocation.
+	BillingDuration string `json:"X-CFF-Billing-Duration"`
+
+	// Response format:
+	// - v0: text format
+	// - v1: JSON format
+	ResponseVersion string `json:"X-Cff-Response-Version"`
+
+	// Error code of the synchronous invocation.
+	// The value is 0 if the execution is successful.
+	FuncErrCode string `json:"X-Func-Err-Code"`
+
+	// Indicates whether the error occurs in a user function.
+	IsFuncErr bool `json:"X-Is-Func-Err"`
+
+	// AdditionalHeaders holds any additional headers not explicitly defined in the struct
+	AdditionalHeaders map[string][]string `json:"-"`
+}
+
+// unmarshalHeaders unmarshals http.Header into a struct using json tags
+func unmarshalHeaders(header http.Header, target interface{}) {
+	val := reflect.ValueOf(target).Elem()
+	typ := val.Type()
+
+	// Track mapped headers
+	mappedHeaders := make(map[string]bool)
+
+	for i := 0; i < val.NumField(); i++ {
+		field := val.Field(i)
+		fieldType := typ.Field(i)
+
+		tag := fieldType.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+
+		headerValue := header.Get(tag)
+		if field.CanSet() && field.Kind() == reflect.String {
+			field.SetString(headerValue)
+			// Use http.CanonicalHeaderKey for case-insensitive comparison
+			mappedHeaders[http.CanonicalHeaderKey(tag)] = true
+		}
+	}
+
+	// Set AdditionalHeaders with unmapped headers only
+	if field := val.FieldByName("AdditionalHeaders"); field.IsValid() && field.CanSet() {
+		additionalHeaders := make(map[string][]string)
+		for key, values := range header {
+			canonicalKey := http.CanonicalHeaderKey(key)
+			if !mappedHeaders[canonicalKey] {
+				additionalHeaders[key] = values
+			}
+		}
+		field.Set(reflect.ValueOf(additionalHeaders))
+	}
 }

--- a/openstack/fgs/v2/invoke/InvokeSync.go
+++ b/openstack/fgs/v2/invoke/InvokeSync.go
@@ -3,31 +3,22 @@ package invoke
 import (
 	"net/http"
 
-	"errors"
 	"reflect"
 
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
-	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 )
 
 // LaunchSync is used to execute a function synchronously.
 // Clients must wait for explicit responses to their requests from the function.
 // Responses are returned only after function invocation is complete.
-func LaunchSync(client *golangsdk.ServiceClient, funcUrn string, body map[string]interface{}, headers LaunchSyncHeaders) (*LaunchSyncResp, *LaunchSyncResponseHeaders, error) {
-	b, err := build.RequestBody(body, "")
-	if err != nil {
-		return nil, nil, err
-	}
+func LaunchSync(client *golangsdk.ServiceClient, funcUrn string, JSONBody interface{}, headers LaunchSyncHeaders) (*LaunchSyncResp, *LaunchSyncResponseHeaders, error) {
 
 	// manually prepare headers and set defaults where needed
 	headerMap := make(map[string]string)
-	if headers.ContentType != "" {
-		headerMap["Content-Type"] = headers.ContentType
-	} else {
-		// Content-Type header is mandatory
-		return nil, nil, errors.New("Missing header 'Content-Type'.")
-	}
+
+	// Content-Type header is mandatory
+	headerMap["Content-Type"] = "application/json"
 
 	if headers.LogType != "" {
 		headerMap["X-Cff-Log-Type"] = headers.LogType
@@ -42,7 +33,7 @@ func LaunchSync(client *golangsdk.ServiceClient, funcUrn string, body map[string
 		headerMap["X-Cff-Instance-Memory"] = headers.InstanceMemory
 	}
 
-	raw, err := client.Post(client.ServiceURL("fgs", "functions", funcUrn, "invocations"), b, nil, &golangsdk.RequestOpts{
+	raw, err := client.Post(client.ServiceURL("fgs", "functions", funcUrn, "invocations"), JSONBody, nil, &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
 		MoreHeaders: headerMap,
 	})
@@ -61,9 +52,6 @@ func LaunchSync(client *golangsdk.ServiceClient, funcUrn string, body map[string
 
 // LaunchSyncHeaders represents the request headers for a synchronous function invocation
 type LaunchSyncHeaders struct {
-	// Content type of the request body.
-	ContentType string `json:"Content-Type"` // e.g. "application/json"
-
 	// Options: tail (4 KB logs will be returned) and null (no logs will be returned).
 	LogType string `json:"X-Cff-Log-Type"`
 
@@ -79,7 +67,6 @@ type LaunchSyncHeaders struct {
 // NewLaunchSyncHeaders creates default headers for LaunchSync function invocation
 func NewLaunchSyncHeaders() LaunchSyncHeaders {
 	return LaunchSyncHeaders{
-		ContentType:    "application/json",
 		LogType:        "",
 		InstanceMemory: "",
 	}

--- a/openstack/fgs/v2/invoke/InvokeSync.go
+++ b/openstack/fgs/v2/invoke/InvokeSync.go
@@ -1,9 +1,9 @@
 package invoke
 
 import (
-	"encoding/json"
 	"net/http"
 
+	"errors"
 	"reflect"
 
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
@@ -20,13 +20,27 @@ func LaunchSync(client *golangsdk.ServiceClient, funcUrn string, body map[string
 		return nil, nil, err
 	}
 
-	// overwrite RequestVersion to "v1",as response is expected in json format
-	// v0 will not work here
-	headers.RequestVersion = "v1"
-
-	headerJson, _ := json.Marshal(headers)
+	// manually prepare headers and set defaults where needed
 	headerMap := make(map[string]string)
-	json.Unmarshal(headerJson, &headerMap)
+	if headers.ContentType != "" {
+		headerMap["Content-Type"] = headers.ContentType
+	} else {
+		// Content-Type header is mandatory
+		return nil, nil, errors.New("Missing header 'Content-Type'.")
+	}
+
+	if headers.LogType != "" {
+		headerMap["X-Cff-Log-Type"] = headers.LogType
+	}
+
+	// always set RequestVersion to "v1",
+	// as response is expected in json format
+	// v0 (text format) will not work here
+	headerMap["X-Cff-Request-Version"] = "v1"
+
+	if headers.InstanceMemory != "" {
+		headerMap["X-Cff-Instance-Memory"] = headers.InstanceMemory
+	}
 
 	raw, err := client.Post(client.ServiceURL("fgs", "functions", funcUrn, "invocations"), b, nil, &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
@@ -53,12 +67,6 @@ type LaunchSyncHeaders struct {
 	// Options: tail (4 KB logs will be returned) and null (no logs will be returned).
 	LogType string `json:"X-Cff-Log-Type"`
 
-	// Response body format. Options: v0 and v1.
-	// v0: text format.
-	// v1: JSON format. Select this format when using an SDK.
-	// Must be set to "v1" to get JSON format response.
-	RequestVersion string `json:"X-Cff-Request-Version"`
-
 	// Dynamic memory allocation for function.
 	// Options:
 	// - empty or
@@ -73,7 +81,6 @@ func NewLaunchSyncHeaders() LaunchSyncHeaders {
 	return LaunchSyncHeaders{
 		ContentType:    "application/json",
 		LogType:        "",
-		RequestVersion: "v1",
 		InstanceMemory: "",
 	}
 }


### PR DESCRIPTION
### What this PR does / why we need it
Fixes issues with InvokeSync/InvokeAsync of FunctionGraph:
- 902.1 body added to request
- 902.2 request headers added to request (forced header X_CFF_Request_Version = "v1" to get response in json)
- 902.3 retrival of response headers added 
- 903.4 type of `Status` in `LaunchSyncResp` struct changed from `string` to `int`
- 906 handler name changed from `index.py` to `index.handler`
- acceptance test for InvokeSync adapted
- 908.1 body parameter changed
- 908.2 removed "body" parent
- 908.2 request header set to "application/json"
- acceptance test for InvokeAsync adapted

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->
fixes #902, fixes #906, fixes #908

### Special notes for your reviewer
