### PR TITLE
CESv2: resource group resources

### DIFF
--- a/acceptance/openstack/ces/v2/resourcegroups_test.go
+++ b/acceptance/openstack/ces/v2/resourcegroups_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ces/v2/resourcegroups"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
@@ -127,4 +128,91 @@ func TestResourceGroupsList(t *testing.T) {
 		t.Logf("Resource Group ID: %s, Name: %s, Type: %s",
 			rg.GroupId, rg.GroupName, rg.Type)
 	}
+}
+
+func TestResourceGroupResources(t *testing.T) {
+	client, err := clients.NewCesV2Client()
+	th.AssertNoErr(t, err)
+
+	ecsClient, err := clients.NewComputeV1Client()
+	th.AssertNoErr(t, err)
+
+	t.Log("Attempting to create ECS instance")
+	createEcsOpts := openstack.GetCloudServerCreateOpts(t)
+	ecs := openstack.CreateCloudServer(t, ecsClient, createEcsOpts)
+	t.Logf("Created ECS: %s", ecs.ID)
+
+	t.Cleanup(func() {
+		t.Log("Attempting to delete ECS instance")
+		openstack.DeleteCloudServer(t, ecsClient, ecs.ID)
+	})
+
+	t.Log("Attempting to create resource group")
+	createOpts := resourcegroups.CreateOpts{
+		GroupName:           "test-rg-resources-acc",
+		EnterpriseProjectId: "0",
+	}
+
+	groupId, err := resourcegroups.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+	t.Logf("Created resource group: %s", groupId)
+
+	t.Cleanup(func() {
+		t.Log("Attempting to delete resource group")
+		_, err := resourcegroups.Delete(client, resourcegroups.DeleteOpts{
+			GroupIds: []string{groupId},
+		})
+		th.AssertNoErr(t, err)
+	})
+
+	t.Log("Attempting to batch add resources to resource group")
+	addOpts := resourcegroups.BatchCreateResourcesOpts{
+		Resources: []resourcegroups.ResourceItem{
+			{
+				Namespace: "SYS.ECS",
+				Dimensions: []resourcegroups.ResourceDimension{
+					{
+						Name:  "instance_id",
+						Value: ecs.ID,
+					},
+				},
+			},
+		},
+	}
+
+	addResp, err := resourcegroups.BatchCreateResources(client, groupId, addOpts)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, addResp.SucceedCount, 1)
+	t.Logf("Added %d resources to resource group", addResp.SucceedCount)
+
+	t.Log("Attempting to list resources in resource group")
+	listResp, err := resourcegroups.ListResources(client, groupId, "SYS.ECS", resourcegroups.ListResourcesOpts{})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, listResp.Count, 1)
+	t.Logf("Found %d resources in resource group", listResp.Count)
+
+	t.Log("Attempting to batch delete resources from resource group")
+	deleteOpts := resourcegroups.BatchDeleteResourcesOpts{
+		Resources: []resourcegroups.ResourceItem{
+			{
+				Namespace: "SYS.ECS",
+				Dimensions: []resourcegroups.ResourceDimension{
+					{
+						Name:  "instance_id",
+						Value: ecs.ID,
+					},
+				},
+			},
+		},
+	}
+
+	deleteResp, err := resourcegroups.BatchDeleteResources(client, groupId, deleteOpts)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, deleteResp.SucceedCount, 1)
+	t.Logf("Deleted %d resources from resource group", deleteResp.SucceedCount)
+
+	t.Log("Attempting to verify resources were deleted")
+	listResp, err = resourcegroups.ListResources(client, groupId, "SYS.ECS", resourcegroups.ListResourcesOpts{})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, listResp.Count, 0)
 }

--- a/openstack/ces/v2/resourcegroups/BatchCreateResources.go
+++ b/openstack/ces/v2/resourcegroups/BatchCreateResources.go
@@ -1,0 +1,62 @@
+package resourcegroups
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// ResourceDimension represents a resource dimension.
+type ResourceDimension struct {
+	// Specifies the dimension name.
+	// It can contain 1 to 32 characters.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	Name string `json:"name" required:"true"`
+	// Specifies the dimension value, which is the resource instance ID.
+	// It can contain 1 to 256 characters.
+	Value string `json:"value" required:"true"`
+}
+
+// ResourceItem represents a resource to be added to or deleted from a resource group.
+type ResourceItem struct {
+	// Specifies the namespace of a service.
+	// The value must be in the service.item format and can contain 3 to 32 characters.
+	// service and item must start with a letter and contain only letters, digits, and underscores (_).
+	Namespace string `json:"namespace" required:"true"`
+	// Specifies the resource dimension information.
+	// A maximum of 4 dimensions can be specified.
+	Dimensions []ResourceDimension `json:"dimensions" required:"true"`
+}
+
+// BatchCreateResourcesOpts contains the options for batch adding resources to a resource group.
+type BatchCreateResourcesOpts struct {
+	// Specifies the list of resources to add.
+	// A maximum of 1000 resources can be added at a time.
+	Resources []ResourceItem `json:"resources" required:"true"`
+}
+
+// BatchCreateResourcesResponse contains the response from the BatchCreateResources request.
+type BatchCreateResourcesResponse struct {
+	// Specifies the number of resources that were added successfully.
+	SucceedCount int `json:"succeed_count"`
+}
+
+// BatchCreateResources adds resources to a resource group in batches.
+func BatchCreateResources(client *golangsdk.ServiceClient, groupId string, opts BatchCreateResourcesOpts) (*BatchCreateResourcesResponse, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST /v2/{project_id}/resource-groups/{group_id}/resources/batch-create
+	raw, err := client.Post(client.ServiceURL("resource-groups", groupId, "resources", "batch-create"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res BatchCreateResourcesResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/ces/v2/resourcegroups/BatchDeleteResources.go
+++ b/openstack/ces/v2/resourcegroups/BatchDeleteResources.go
@@ -1,0 +1,40 @@
+package resourcegroups
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// BatchDeleteResourcesOpts contains the options for batch deleting resources from a resource group.
+type BatchDeleteResourcesOpts struct {
+	// Specifies the list of resources to delete.
+	// A maximum of 1000 resources can be deleted at a time.
+	Resources []ResourceItem `json:"resources" required:"true"`
+}
+
+// BatchDeleteResourcesResponse contains the response from the BatchDeleteResources request.
+type BatchDeleteResourcesResponse struct {
+	// Specifies the number of resources that were deleted successfully.
+	SucceedCount int `json:"succeed_count"`
+}
+
+// BatchDeleteResources removes resources from a resource group in batches.
+func BatchDeleteResources(client *golangsdk.ServiceClient, groupId string, opts BatchDeleteResourcesOpts) (*BatchDeleteResourcesResponse, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST /v2/{project_id}/resource-groups/{group_id}/resources/batch-delete
+	raw, err := client.Post(client.ServiceURL("resource-groups", groupId, "resources", "batch-delete"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res BatchDeleteResourcesResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/ces/v2/resourcegroups/ListResources.go
+++ b/openstack/ces/v2/resourcegroups/ListResources.go
@@ -1,0 +1,68 @@
+package resourcegroups
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// ListResourcesOpts contains the options for querying resources in a resource group.
+type ListResourcesOpts struct {
+	// Specifies the resource dimension.
+	// Multiple dimensions are separated by commas and sorted alphabetically.
+	DimName string `q:"dim_name"`
+	// Specifies the resource dimension value.
+	// Fuzzy matching is not supported.
+	// It can contain 1 to 256 characters.
+	DimValue string `q:"dim_value"`
+	// Specifies the resource health status.
+	// Possible values: health, unhealthy, no_alarm_rule
+	Status string `q:"status"`
+	// Specifies the number of records on each page.
+	// Default: 100, Range: 1-1000
+	Limit int `q:"limit,omitempty"`
+	// Specifies the pagination offset.
+	// Default: 0, Range: 0-10000
+	Offset int `q:"offset,omitempty"`
+	// Specifies the enterprise project ID.
+	ExtendRelationId string `q:"extend_relation_id"`
+}
+
+// ListResourcesResponse contains the response from the ListResources request.
+type ListResourcesResponse struct {
+	// Specifies the total number of resources.
+	Count int `json:"count"`
+	// Specifies the list of resources.
+	Resources []ResourceInfo `json:"resources"`
+}
+
+// ResourceInfo represents a resource in the list response.
+type ResourceInfo struct {
+	// Specifies the resource health status.
+	// Possible values: health, unhealthy, no_alarm_rule
+	Status string `json:"status"`
+	// Specifies the resource dimension information.
+	Dimensions []ResourceDimension `json:"dimensions"`
+}
+
+// ListResources returns a list of resources for a specified service type in a resource group.
+func ListResources(client *golangsdk.ServiceClient, groupId string, service string, opts ListResourcesOpts) (*ListResourcesResponse, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("resource-groups", groupId, "services", service, "resources").
+		WithQueryParams(&opts).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	// GET /v2/{project_id}/resource-groups/{group_id}/services/{service}/resources
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListResourcesResponse
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}


### PR DESCRIPTION
### Acceptance tests
```
=== RUN   TestResourceGroupResources
    resourcegroups_test.go:140: Attempting to create ECS instance
    resourcegroups_test.go:142: Attempting to create ECSv1
    resourcegroups_test.go:142: Created ECSv1 instance: baaffd24-ffb7-4a68-bfad-b4504e50107c
    resourcegroups_test.go:143: Created ECS: baaffd24-ffb7-4a68-bfad-b4504e50107c
    resourcegroups_test.go:150: Attempting to create resource group
    resourcegroups_test.go:158: Created resource group: rg1769700021342nbeEGpL84
    resourcegroups_test.go:168: Attempting to batch add resources to resource group
    resourcegroups_test.go:186: Added 1 resources to resource group
    resourcegroups_test.go:188: Attempting to list resources in resource group
    resourcegroups_test.go:192: Found 1 resources in resource group
    resourcegroups_test.go:194: Attempting to batch delete resources from resource group
    resourcegroups_test.go:212: Deleted 1 resources from resource group
    resourcegroups_test.go:214: Attempting to verify resources were deleted
    resourcegroups_test.go:161: Attempting to delete resource group
    resourcegroups_test.go:146: Attempting to delete ECS instance
    common.go:216: Attempting to delete ECSv1: baaffd24-ffb7-4a68-bfad-b4504e50107c
    common.go:233: ECSv1 instance deleted: baaffd24-ffb7-4a68-bfad-b4504e50107c
--- PASS: TestResourceGroupResources (80.77s)
PASS

Process finished with the exit code 0
```