### PR TITLE
[Feat] IAM: Add IPv6 options to ACL console policy

### DIFF
--- a/acceptance/openstack/identity/v3.0/acl_test.go
+++ b/acceptance/openstack/identity/v3.0/acl_test.go
@@ -31,6 +31,18 @@ func TestACLConsoleLifecycle(t *testing.T) {
 				Description: "test ip range description",
 			},
 		},
+		AllowAddressNetmasksIPv6: []acl.AllowAddressNetmasks{
+			{
+				AddressNetmask: "0000:0000:0000:0000:0000:0000:0000:0000/100",
+				Description:    "test IPv6 netmask",
+			},
+		},
+		AllowIPRangesIPv6: []acl.AllowIPRanges{
+			{
+				IPRange:     "0000:0000:0000:0000:0000:0000:0000:0000-FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF",
+				Description: "test IPv6 range",
+			},
+		},
 	}
 
 	resp, err := acl.ConsoleACLPolicyUpdate(client, createOpts)
@@ -42,9 +54,10 @@ func TestACLConsoleLifecycle(t *testing.T) {
 
 	getAcl, err := acl.ConsoleACLPolicyGet(client, client.DomainID)
 	th.AssertNoErr(t, err)
-
 	th.AssertEquals(t, getAcl.AllowIPRanges[0].IPRange, resp.AllowIPRanges[0].IPRange)
 	th.AssertEquals(t, getAcl.AllowIPRanges[0].Description, resp.AllowIPRanges[0].Description)
+	th.AssertEquals(t, createOpts.AllowAddressNetmasksIPv6[0].AddressNetmask, resp.AllowAddressNetmasksIPv6[0].AddressNetmask)
+	th.AssertEquals(t, createOpts.AllowIPRangesIPv6[0].IPRange, resp.AllowIPRangesIPv6[0].IPRange)
 
 	t.Cleanup(func() {
 		netmasksList := make([]acl.AllowAddressNetmasks, 0, 1)

--- a/openstack/identity/v3.0/acl/UpdateConsoleACLPolicy.go
+++ b/openstack/identity/v3.0/acl/UpdateConsoleACLPolicy.go
@@ -7,9 +7,11 @@ import (
 )
 
 type ACLPolicy struct {
-	DomainId             string                 `json:"-"`
-	AllowAddressNetmasks []AllowAddressNetmasks `json:"allow_address_netmasks,omitempty"`
-	AllowIPRanges        []AllowIPRanges        `json:"allow_ip_ranges,omitempty"`
+	DomainId                 string                 `json:"-"`
+	AllowAddressNetmasks     []AllowAddressNetmasks `json:"allow_address_netmasks,omitempty"`
+	AllowIPRanges            []AllowIPRanges        `json:"allow_ip_ranges,omitempty"`
+	AllowAddressNetmasksIPv6 []AllowAddressNetmasks `json:"allow_address_netmasks_ipv6,omitempty"`
+	AllowIPRangesIPv6        []AllowIPRanges        `json:"allow_ip_ranges_ipv6,omitempty"`
 }
 
 type AllowAddressNetmasks struct {


### PR DESCRIPTION
### What this PR does / why we need it

Add IPv6 options to ACL console policy

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->
OTC TF provider issue #[3247](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3247)

### Test

```
=== RUN   TestACLConsoleLifecycle
--- PASS: TestACLConsoleLifecycle (1.03s)
PASS
```
