### PR TITLE
[Fix] Handle wildcard region in endpoint lookup

### DIFF
--- a/openstack/endpoint_location.go
+++ b/openstack/endpoint_location.go
@@ -19,6 +19,7 @@ func V3EndpointURL(catalog *tokens3.ServiceCatalog, opts golangsdk.EndpointOpts)
 	// Extract Endpoints from the catalog entries that match the requested Type, Interface,
 	// Name if provided, and Region if provided.
 	var endpoints = make([]tokens3.Endpoint, 0, 1)
+	var wildcardEndpoints []tokens3.Endpoint
 	for _, entry := range catalog.Entries {
 		if (entry.Type == opts.Type) && (opts.Name == "" || entry.Name == opts.Name) {
 			for _, endpoint := range entry.Endpoints {
@@ -30,12 +31,20 @@ func V3EndpointURL(catalog *tokens3.ServiceCatalog, opts golangsdk.EndpointOpts)
 					err.Value = opts.Availability
 					return "", err
 				}
-				if opts.Availability == golangsdk.Availability(endpoint.Interface) &&
-					(opts.Region == "" || endpoint.Region == opts.Region) {
-					endpoints = append(endpoints, endpoint)
+				if opts.Availability == golangsdk.Availability(endpoint.Interface) {
+					if opts.Region == "" || endpoint.Region == opts.Region {
+						endpoints = append(endpoints, endpoint)
+					} else if endpoint.Region == "*" {
+						wildcardEndpoints = append(wildcardEndpoints, endpoint)
+					}
 				}
 			}
 		}
+	}
+
+	// Fall back to wildcard endpoints if no exact region match was found.
+	if len(endpoints) == 0 {
+		endpoints = wildcardEndpoints
 	}
 
 	// If multiple endpoints were found, use the first result

--- a/openstack/testing/endpoint_location_test.go
+++ b/openstack/testing/endpoint_location_test.go
@@ -77,6 +77,30 @@ var catalog3 = tokens3.ServiceCatalog{
 				},
 			},
 		},
+		{
+			Type: "wildcard",
+			Name: "wildcard",
+			Endpoints: []tokens3.Endpoint{
+				{
+					ID:        "9",
+					Region:    "*",
+					Interface: "public",
+					URL:       "https://wildcard.correct.com/",
+				},
+			},
+		},
+		{
+			Type: "same",
+			Name: "same",
+			Endpoints: []tokens3.Endpoint{
+				{
+					ID:        "10",
+					Region:    "*",
+					Interface: "public",
+					URL:       "https://wildcard.same.com/",
+				},
+			},
+		},
 	},
 }
 
@@ -109,6 +133,41 @@ func TestV3EndpointNone(t *testing.T) {
 		t.Fatalf("Expected error")
 	}
 	th.CheckEquals(t, expected.Error(), actual.Error())
+}
+
+func TestV3EndpointWildcardRegion(t *testing.T) {
+	// Endpoint with Region "*" should match when requesting a specific region with no exact match.
+	actual, err := openstack.V3EndpointURL(&catalog3, golangsdk.EndpointOpts{
+		Type:         "wildcard",
+		Name:         "wildcard",
+		Region:       "eu-de",
+		Availability: golangsdk.AvailabilityPublic,
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, "https://wildcard.correct.com/", actual)
+
+	// Endpoint with Region "*" should also match when no region is specified.
+	actual, err = openstack.V3EndpointURL(&catalog3, golangsdk.EndpointOpts{
+		Type:         "wildcard",
+		Name:         "wildcard",
+		Region:       "",
+		Availability: golangsdk.AvailabilityPublic,
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, "https://wildcard.correct.com/", actual)
+}
+
+func TestV3EndpointExactRegionPriority(t *testing.T) {
+	// When both an exact region match and a wildcard endpoint exist,
+	// the exact match must take priority.
+	actual, err := openstack.V3EndpointURL(&catalog3, golangsdk.EndpointOpts{
+		Type:         "same",
+		Name:         "same",
+		Region:       "same",
+		Availability: golangsdk.AvailabilityPublic,
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, "https://public.correct.com/", actual)
 }
 
 func TestV3EndpointBadAvailability(t *testing.T) {


### PR DESCRIPTION
Endpoints with Region "*" in the service catalog were not matched when a specific region was requested. This caused "No suitable endpoint could be found" errors for domain-scoped clients whose catalog only contains wildcard region endpoints.

Exact region matches take priority over wildcard ones.