### PR TITLE
[Feat] VPC: Add argument `description` to vpc peerings

### DIFF
--- a/acceptance/openstack/networking/v2/peering/peerings.go
+++ b/acceptance/openstack/networking/v2/peering/peerings.go
@@ -28,7 +28,11 @@ func CreatePeeringResourcesNConn(t *testing.T, clientV2 *golangsdk.ServiceClient
 		return nil, err
 	}
 
-	peerVpc, err := vpcs.Create(peerClientV1, createOpts).Extract()
+	createPeerOpts := vpcs.CreateOpts{
+		Name: peerVpcName,
+		CIDR: "10.0.20.0/24",
+	}
+	peerVpc, err := vpcs.Create(peerClientV1, createPeerOpts).Extract()
 	if err != nil {
 		return nil, err
 	}
@@ -39,6 +43,7 @@ func CreatePeeringResourcesNConn(t *testing.T, clientV2 *golangsdk.ServiceClient
 
 	peerCreateOpts := peerings.CreateOpts{
 		Name:           peeringConnName,
+		Description:    "Test Peering",
 		RequestVpcInfo: peerings.VpcInfo{VpcId: vpc.ID},
 		AcceptVpcInfo:  peerings.VpcInfo{VpcId: peerVpc.ID, TenantId: peerClientV2.ProjectID},
 	}
@@ -128,7 +133,7 @@ func WaitForPeeringConnToCreate(client *golangsdk.ServiceClient, peeringConnID s
 			return false, err
 		}
 
-		if conn.Status == "PENDING_ACCEPTANCE" {
+		if conn.Status == "PENDING_ACCEPTANCE" || conn.Status == "ACTIVE" {
 			return true, nil
 		}
 

--- a/acceptance/openstack/networking/v2/peering/peerings_test.go
+++ b/acceptance/openstack/networking/v2/peering/peerings_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/peerings"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
 
 func TestPeeringList(t *testing.T) {
@@ -57,24 +58,20 @@ func TestRejectPeering(t *testing.T) {
 func TestPeeringCRUD(t *testing.T) {
 
 	clientV2, peerClientV2, clientV1, peerClientV1, peeringConn := InitiatePeeringConnCommonTasks(t)
-
 	// Delete a vpc peering connection
 	defer DeletePeeringConnNResources(t, clientV2, clientV1, peerClientV1, peeringConn)
 
-	tools.PrintResource(t, peeringConn)
+	th.AssertEquals(t, "Test Peering", peeringConn.Description)
+
 	updateOpts := peerings.UpdateOpts{
-		Name: "test2",
+		Name:        "test2",
+		Description: "Test Updated",
 	}
 
 	_, err := peerings.Update(clientV2, peeringConn.ID, updateOpts).Extract()
-	if err != nil {
-		t.Fatalf("Unable to update vpc peering connection: %v", err)
-	}
+	th.AssertNoErr(t, err)
 
 	peeringConnGet, err := peerings.Get(peerClientV2, peeringConn.ID).Extract()
-	if err != nil {
-		t.Fatalf("Unable to retrieve vpc peering connection: %v", err)
-	}
-
-	tools.PrintResource(t, peeringConnGet)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, updateOpts.Description, peeringConnGet.Description)
 }

--- a/openstack/networking/v2/peerings/requests.go
+++ b/openstack/networking/v2/peerings/requests.go
@@ -3,7 +3,7 @@ package peerings
 import (
 	"reflect"
 
-	"github.com/opentelekomcloud/gophertelekomcloud"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
 
@@ -146,6 +146,7 @@ type CreateOptsBuilder interface {
 // CreateOpts is a struct which is used to create vpc peering connection.
 type CreateOpts struct {
 	Name           string  `json:"name"`
+	Description    string  `json:"description,omitempty"`
 	RequestVpcInfo VpcInfo `json:"request_vpc_info" required:"true"`
 	AcceptVpcInfo  VpcInfo `json:"accept_vpc_info" required:"true"`
 }
@@ -181,7 +182,8 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts is a struct which represents the request body of update method.
 type UpdateOpts struct {
-	Name string `json:"name,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 // ToVpcPeeringUpdateMap builds a update request body from UpdateOpts.

--- a/openstack/networking/v2/peerings/results.go
+++ b/openstack/networking/v2/peerings/results.go
@@ -1,7 +1,7 @@
 package peerings
 
 import (
-	"github.com/opentelekomcloud/gophertelekomcloud"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
 
@@ -21,6 +21,9 @@ type Peering struct {
 	// Name is the human readable name for the vpc_peering_connection. It does not have to be
 	// unique.
 	Name string `json:"name"`
+
+	// Provides supplementary information about the VPC peering connection.
+	Description string `json:"description"`
 
 	// Status indicates whether or not a vpc_peering_connections is currently operational.
 	Status string `json:"status"`
@@ -90,6 +93,9 @@ func (r commonResult) ExtractResult() (Peering, error) {
 		// Name is the human readable name for the vpc. It does not have to be
 		// unique.
 		Name string `json:"name"`
+
+		// Provides supplementary information about the VPC peering connection.
+		Description string `json:"description"`
 
 		// Status indicates whether or not a vpc is currently operational.
 		Status string `json:"status"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it

Add description to vpc peering

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

OTC TF issue #[3276](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3276)

### Test
```
=== RUN   TestPeeringCRUD
    peerings.go:24: Attempting to create vpc: TESTACC-vpciUdnEJF5 and peer vpc: TESTACC-peervpcE2ZtcX2x
    peerings.go:40: Created vpcs: TESTACC-vpciUdnEJF5 TESTACC-peervpcE2ZtcX2x
    peerings.go:51: Attempting to create vpc peering connection: TESTACC-WTkKuy4m
    peerings.go:62: Created vpc peering connection: TESTACC-WTkKuy4m
    peerings.go:69: Attempting to delete vpc peering connection: 12810925-bf62-4174-bf18-57cd35c9166e
    peerings.go:76: Deleted vpc peering connection: 12810925-bf62-4174-bf18-57cd35c9166e
    peerings.go:78: Attempting to delete vpc: b9edc2d8-c098-40ca-8476-5f5ce8a186ac
    peerings.go:90: Deleted vpcs: b9edc2d8-c098-40ca-8476-5f5ce8a186ac and 309afeab-3b31-4a38-990c-822fb56fa816
--- PASS: TestPeeringCRUD (7.48s)
PASS
```
