### PR TITLE
[ECS]: add security options

### DIFF
--- a/acceptance/openstack/ecs/v1/cloudservers_test.go
+++ b/acceptance/openstack/ecs/v1/cloudservers_test.go
@@ -58,6 +58,65 @@ func TestCloudServerLifecycle(t *testing.T) {
 	tools.PrintResource(t, ecs)
 }
 
+func TestCloudServerSecurityOptions(t *testing.T) {
+	client, err := clients.NewComputeV1Client()
+	th.AssertNoErr(t, err)
+
+	prefix := "ecs-vtpm-"
+	ecsName := tools.RandomString(prefix, 3)
+	imageName := "Enterprise_Windows-Server_2022_STD_amd64_uefi_latest"
+	flavorID := "pi5e.2xlarge.4"
+
+	vpcID := clients.EnvOS.GetEnv("VPC_ID")
+	subnetID := clients.EnvOS.GetEnv("NETWORK_ID")
+
+	imageV2Client, err := clients.NewIMSV2Client()
+	th.AssertNoErr(t, err)
+
+	image, err := images.ListImages(imageV2Client, images.ListImagesOpts{
+		Name: imageName,
+	})
+	th.AssertNoErr(t, err)
+	if len(image) == 0 {
+		t.Skip("Change image query filter, no results returned")
+	}
+	if vpcID == "" || subnetID == "" {
+		t.Skip("One of OS_VPC_ID, OS_NETWORK_ID env vars is missing but ECSv1 test requires")
+	}
+
+	tpmEnabled := true
+	createOpts := cloudservers.CreateOpts{
+		ImageRef:  image[0].Id,
+		FlavorRef: flavorID,
+		Name:      ecsName,
+		VpcId:     vpcID,
+		Nics: []cloudservers.Nic{
+			{
+				SubnetId: subnetID,
+			},
+		},
+		RootVolume: cloudservers.RootVolume{
+			VolumeType: "SSD",
+			Size:       40,
+		},
+		SecurityOptions: &cloudservers.SecurityOptions{
+			TpmEnabled: &tpmEnabled,
+		},
+	}
+
+	// Check ECSv1 createOpts
+	openstack.DryRunCloudServerConfig(t, client, createOpts)
+
+	// Create ECSv1 instance
+	ecs := openstack.CreateCloudServer(t, client, createOpts)
+	defer openstack.DeleteCloudServer(t, client, ecs.ID)
+
+	// Verify SecurityOptions in Get response
+	th.AssertEquals(t, true, ecs.SecurityOptions != nil)
+	th.AssertEquals(t, true, *ecs.SecurityOptions.TpmEnabled)
+	t.Logf("ECS created with SecurityOptions: tpm_enabled=%v", *ecs.SecurityOptions.TpmEnabled)
+}
+
 func TestCloudServersRandomAzLifecycle(t *testing.T) {
 	client, err := clients.NewComputeV1Client()
 	th.AssertNoErr(t, err)

--- a/openstack/ecs/v1/cloudservers/Update.go
+++ b/openstack/ecs/v1/cloudservers/Update.go
@@ -23,31 +23,35 @@ type UpdateOpts struct {
 	// A hostname cannot start or end with a period (.) or hyphen (-).
 	// A hostname cannot contain consecutive periods (..) or hyphens (--).
 	Hostname string `json:"hostname,omitempty"`
+
+	// SecurityOptions specifies the security options of the ECS, e.g. vTPM.
+	SecurityOptions *SecurityOptions `json:"security_options,omitempty"`
 }
 
 // UpdateResponse represents the response from the Update ECS API.
 // Unlike CloudServer, the image field is returned as a string (empty when booted from volume).
 type UpdateResponse struct {
-	Status      string                     `json:"status"`
-	Updated     time.Time                  `json:"updated"`
-	HostID      string                     `json:"hostId"`
-	Addresses   map[string][]UpdateAddress `json:"addresses"`
-	ID          string                     `json:"id"`
-	Name        string                     `json:"name"`
-	AccessIPv4  string                     `json:"accessIPv4"`
-	AccessIPv6  string                     `json:"accessIPv6"`
-	Created     time.Time                  `json:"created"`
-	Description string                     `json:"description"`
-	TenantID    string                     `json:"tenant_id"`
-	UserID      string                     `json:"user_id"`
-	Flavor      Flavor                     `json:"flavor"`
-	Metadata    Metadata                   `json:"metadata"`
-	Image       string                     `json:"image"`
-	Progress    int                        `json:"progress"`
-	DiskConfig  string                     `json:"OS-DCF:diskConfig"`
-	Hostname    string                     `json:"OS-EXT-SRV-ATTR:hostname"`
-	UserData    string                     `json:"OS-EXT-SRV-ATTR:user_data"`
-	Links       []Link                     `json:"links"`
+	Status          string                     `json:"status"`
+	Updated         time.Time                  `json:"updated"`
+	HostID          string                     `json:"hostId"`
+	Addresses       map[string][]UpdateAddress `json:"addresses"`
+	ID              string                     `json:"id"`
+	Name            string                     `json:"name"`
+	AccessIPv4      string                     `json:"accessIPv4"`
+	AccessIPv6      string                     `json:"accessIPv6"`
+	Created         time.Time                  `json:"created"`
+	Description     string                     `json:"description"`
+	TenantID        string                     `json:"tenant_id"`
+	UserID          string                     `json:"user_id"`
+	Flavor          Flavor                     `json:"flavor"`
+	Metadata        Metadata                   `json:"metadata"`
+	Image           string                     `json:"image"`
+	Progress        int                        `json:"progress"`
+	DiskConfig      string                     `json:"OS-DCF:diskConfig"`
+	Hostname        string                     `json:"OS-EXT-SRV-ATTR:hostname"`
+	UserData        string                     `json:"OS-EXT-SRV-ATTR:user_data"`
+	Links           []Link                     `json:"links"`
+	SecurityOptions *SecurityOptions           `json:"security_options"`
 }
 
 type UpdateAddress struct {

--- a/openstack/ecs/v1/cloudservers/requests.go
+++ b/openstack/ecs/v1/cloudservers/requests.go
@@ -67,6 +67,14 @@ type CreateOpts struct {
 
 	// Specifies whether ECSs can be deployed in multiple random AZs. The default value is false.
 	CreateInMultiAz *bool `json:"batch_create_in_multi_az,omitempty"`
+
+	// SecurityOptions specifies the security options of the ECS, e.g. vTPM.
+	SecurityOptions *SecurityOptions `json:"security_options,omitempty"`
+}
+
+type SecurityOptions struct {
+	// TpmEnabled specifies whether vTPM is enabled on the ECS.
+	TpmEnabled *bool `json:"tpm_enabled,omitempty"`
 }
 
 // CreateOptsBuilder allows extensions to add additional parameters to the

--- a/openstack/ecs/v1/cloudservers/results.go
+++ b/openstack/ecs/v1/cloudservers/results.go
@@ -121,6 +121,7 @@ type CloudServer struct {
 	HypervisorHostname string               `json:"OS-EXT-SRV-ATTR:hypervisor_hostname"`
 	VolumeAttached     []VolumeAttached     `json:"os-extended-volumes:volumes_attached"`
 	OsSchedulerHints   OsSchedulerHints     `json:"os:scheduler_hints"`
+	SecurityOptions    *SecurityOptions     `json:"security_options"`
 }
 
 // NewCloudServer defines the response from details on a single server, by ID.


### PR DESCRIPTION
### Acceptance tests
```
=== RUN   TestCloudServerSecurityOptions
    common.go:190: Attempting to check ECSv1 createOpts
    cloudservers_test.go:111: Attempting to create ECSv1
    cloudservers_test.go:111: Created ECSv1 instance: ecec58e1-68de-4bca-a469-75b937c5d931
    cloudservers_test.go:117: ECS created with SecurityOptions: tpm_enabled=true
    common.go:216: Attempting to delete ECSv1: ecec58e1-68de-4bca-a469-75b937c5d931
    common.go:233: ECSv1 instance deleted: ecec58e1-68de-4bca-a469-75b937c5d931
--- PASS: TestCloudServerSecurityOptions (59.93s)
PASS

Process finished with the exit code 0
```
