### PR TITLE
[CCE]: cluster deletion protection

### DIFF
--- a/acceptance/openstack/cce/v3/clusters_test.go
+++ b/acceptance/openstack/cce/v3/clusters_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/clusters"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cce/v3/nodepools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/compute/v2/extensions/floatingips"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v1/subnets"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
@@ -199,4 +200,67 @@ func TestTurboClusterWithCillium(t *testing.T) {
 	if clusterID != "" {
 		cce.DeleteCluster(t, clusterID)
 	}
+}
+
+func TestClusterDeletionProtection(t *testing.T) {
+	if clients.EnvOS.GetEnv("RUN_CCE_DELETION_PROTECTION") == "" {
+		t.Skip("OS_RUN_CCE_DELETION_PROTECTION is required for this test")
+	}
+
+	vpcID := clients.EnvOS.GetEnv("VPC_ID")
+	if vpcID == "" {
+		t.Skip("OS_VPC_ID is required for this test")
+	}
+
+	clientNet, err := clients.NewNetworkV1Client()
+	th.AssertNoErr(t, err)
+
+	subnetsList, err := subnets.List(clientNet, subnets.ListOpts{VpcID: vpcID})
+	th.AssertNoErr(t, err)
+	if len(subnetsList) < 1 {
+		t.Skip("no subnets found in selected VPC")
+	}
+
+	client, err := clients.NewCceV3Client()
+	th.AssertNoErr(t, err)
+
+	cluster, err := clusters.Create(client, clusters.CreateOpts{
+		Kind:       "Cluster",
+		ApiVersion: "v3",
+		Metadata: clusters.CreateMetaData{
+			Name: strings.ToLower(tools.RandomString("cce-del-prot-", 4)),
+		},
+		Spec: clusters.Spec{
+			Type:   "VirtualMachine",
+			Flavor: "cce.s1.small",
+			HostNetwork: clusters.HostNetworkSpec{
+				VpcId:    vpcID,
+				SubnetId: subnetsList[0].NetworkID,
+			},
+			ContainerNetwork: clusters.ContainerNetworkSpec{
+				Mode: "overlay_l2",
+			},
+			Authentication: clusters.AuthenticationSpec{
+				Mode:                "rbac",
+				AuthenticatingProxy: make(map[string]string),
+			},
+			KubernetesSvcIpRange: "10.247.0.0/16",
+			DeletionProtection:   pointerto.Bool(true),
+		},
+	})
+	th.AssertNoErr(t, err)
+
+	clusterID := cluster.Metadata.Id
+	th.AssertNoErr(t, cce.WaitForClusterToActivate(client, clusterID, 30*60))
+
+	clusterGet, err := clusters.Get(client, clusterID)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, *clusterGet.Spec.DeletionProtection)
+
+	// Attempt to delete — should fail due to deletion protection
+	err = clusters.Delete(client, clusterID, clusters.DeleteQueryParams{})
+	if err == nil {
+		t.Fatal("expected error when deleting cluster with deletion protection enabled, but got nil")
+	}
+	t.Logf("deletion correctly rejected: %s", err)
 }

--- a/openstack/cce/v3/clusters/common.go
+++ b/openstack/cce/v3/clusters/common.go
@@ -72,6 +72,9 @@ type Spec struct {
 	SupportIstio *bool `json:"supportIstio,omitempty"`
 	// configurationsOverride
 	ConfigurationsOverride []PackageConfiguration `json:"configurationsOverride,omitempty"`
+	// Cluster deletion protection: true/false.
+	// When enabled, the cluster cannot be deleted.
+	DeletionProtection *bool `json:"deletionProtection,omitempty"`
 }
 
 type PackageConfiguration struct {


### PR DESCRIPTION
## What this PR does / why we need it
Implementation of new parameter which disables cluster deletion via API.
Refers to: [#3300](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3300)

### Acceptance tests
```
=== RUN   TestClusterDeletionProtection
    clusters_test.go:265: deletion correctly rejected: Bad request with: [DELETE https://cce.eu-de.otc.t-systems.com/api/v3/projects/45c274f200d2498683982c8741fb76ac/clusters/08807e70-26af-11f1-913a-02550a100042], error message: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","code":400,"errorCode":"CCE.01400034","errorMessage":"Cannot delete cluster when enable deletion protection.","message":"Cluster enables deletion protection, forbidden to delete","reason":"BadRequest"}
--- PASS: TestClusterDeletionProtection (250.65s)
PASS

Process finished with the exit code 0
```
