### PR TITLE
[Feat.] New attributes for ports api

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/dnatrulest_test.go
+++ b/acceptance/openstack/networking/v2/extensions/dnatrulest_test.go
@@ -68,7 +68,7 @@ func TestDnatRuleLifeCycle(t *testing.T) {
 
 		type portWithExt struct {
 			ports.Port
-			portsecurity.PortSecurityExt
+			PortSecurity portsecurity.PortSecurityExt
 		}
 
 		var allPorts []portWithExt

--- a/acceptance/openstack/networking/v2/extensions/vpnaas/ikepolicies_test.go
+++ b/acceptance/openstack/networking/v2/extensions/vpnaas/ikepolicies_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestIkePolicyList(t *testing.T) {
+	t.Skip("API disabled")
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a NetworkingV2 client: %s", err)

--- a/acceptance/openstack/networking/v2/extensions/vpnaas/ikepolicies_test.go
+++ b/acceptance/openstack/networking/v2/extensions/vpnaas/ikepolicies_test.go
@@ -31,6 +31,7 @@ func TestIkePolicyList(t *testing.T) {
 }
 
 func TestIkePolicyLifeCycle(t *testing.T) {
+	t.Skip("API disabled")
 	client, err := clients.NewNetworkV2Client()
 	if err != nil {
 		t.Fatalf("Unable to create a NetworkingV2 client: %s", err)

--- a/acceptance/openstack/networking/v2/ports/ports_test.go
+++ b/acceptance/openstack/networking/v2/ports/ports_test.go
@@ -1,0 +1,185 @@
+package ports
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/networks"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/ports"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/subnets"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestPortLifecycle(t *testing.T) {
+	client, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	network := createNetwork(t, client)
+	t.Cleanup(func() {
+		deleteNetwork(t, client, network.ID)
+	})
+
+	subnet := createSubnet(t, client, network.ID)
+	t.Cleanup(func() {
+		deleteSubnet(t, client, subnet.ID)
+	})
+
+	adminStateUp := true
+	createOpts := ports.CreateOpts{
+		NetworkID:    network.ID,
+		Name:         tools.RandomString("acc-port-create-", 3),
+		AdminStateUp: &adminStateUp,
+		FixedIps: []ports.FixedIp{
+			{SubnetId: subnet.ID},
+		},
+	}
+
+	t.Logf("Attempting to create port: %s", createOpts.Name)
+	port, err := ports.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		deletePort(t, client, port.ID)
+	})
+
+	th.AssertEquals(t, createOpts.Name, port.Name)
+	th.AssertEquals(t, createOpts.NetworkID, port.NetworkID)
+	th.AssertEquals(t, *createOpts.AdminStateUp, port.AdminStateUp)
+	th.AssertEquals(t, 1, len(port.FixedIPs))
+	th.AssertEquals(t, subnet.ID, port.FixedIPs[0].SubnetId)
+	t.Logf("Created port: %s", port.ID)
+
+	updatedName := tools.RandomString("acc-port-update-", 3)
+	adminStateDown := false
+	updateOpts := ports.UpdateOpts{
+		Name:         updatedName,
+		AdminStateUp: &adminStateDown,
+	}
+
+	t.Logf("Attempting to update port: %s", port.ID)
+	updatedPort, err := ports.Update(client, port.ID, updateOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, updateOpts.Name, updatedPort.Name)
+	th.AssertEquals(t, *updateOpts.AdminStateUp, updatedPort.AdminStateUp)
+
+	gotPort, err := ports.Get(client, port.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, updateOpts.Name, gotPort.Name)
+	th.AssertEquals(t, *updateOpts.AdminStateUp, gotPort.AdminStateUp)
+	th.AssertEquals(t, network.ID, gotPort.NetworkID)
+
+	portPages, err := ports.List(client, ports.ListOpts{
+		ID:        port.ID,
+		NetworkID: network.ID,
+	}).AllPages()
+	th.AssertNoErr(t, err)
+
+	portList, err := ports.ExtractPorts(portPages)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(portList))
+	th.AssertEquals(t, port.ID, portList[0].ID)
+	th.AssertEquals(t, updateOpts.Name, portList[0].Name)
+}
+
+func createNetwork(t *testing.T, client *golangsdk.ServiceClient) *networks.Network {
+	adminStateUp := true
+	createOpts := networks.CreateOpts{
+		Name:         tools.RandomString("acc-port-net-", 3),
+		AdminStateUp: &adminStateUp,
+	}
+
+	t.Logf("Attempting to create network: %s", createOpts.Name)
+	network, err := networks.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Created network: %s", network.ID)
+
+	return network
+}
+
+func deleteNetwork(t *testing.T, client *golangsdk.ServiceClient, networkID string) {
+	t.Logf("Attempting to delete network: %s", networkID)
+	err := networks.Delete(client, networkID).ExtractErr()
+	th.AssertNoErr(t, err)
+	th.AssertNoErr(t, waitForNetworkDeleted(client, networkID, 120))
+	t.Logf("Deleted network: %s", networkID)
+}
+
+func createSubnet(t *testing.T, client *golangsdk.ServiceClient, networkID string) *subnets.Subnet {
+	gatewayIP := "192.168.42.1"
+	enableDHCP := true
+	createOpts := subnets.CreateOpts{
+		NetworkID:      networkID,
+		Name:           tools.RandomString("acc-port-subnet-", 3),
+		CIDR:           "192.168.42.0/24",
+		IPVersion:      golangsdk.IPv4,
+		GatewayIP:      &gatewayIP,
+		EnableDHCP:     &enableDHCP,
+		DNSNameservers: []string{"1.1.1.1", "8.8.8.8"},
+	}
+
+	t.Logf("Attempting to create subnet: %s", createOpts.Name)
+	subnet, err := subnets.Create(client, createOpts).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Created subnet: %s", subnet.ID)
+
+	return subnet
+}
+
+func deleteSubnet(t *testing.T, client *golangsdk.ServiceClient, subnetID string) {
+	t.Logf("Attempting to delete subnet: %s", subnetID)
+	err := subnets.Delete(client, subnetID).ExtractErr()
+	th.AssertNoErr(t, err)
+	th.AssertNoErr(t, waitForSubnetDeleted(client, subnetID, 120))
+	t.Logf("Deleted subnet: %s", subnetID)
+}
+
+func deletePort(t *testing.T, client *golangsdk.ServiceClient, portID string) {
+	t.Logf("Attempting to delete port: %s", portID)
+	err := ports.Delete(client, portID).ExtractErr()
+	th.AssertNoErr(t, err)
+	th.AssertNoErr(t, waitForPortDeleted(client, portID, 120))
+	t.Logf("Deleted port: %s", portID)
+}
+
+func waitForPortDeleted(client *golangsdk.ServiceClient, portID string, secs int) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		_, err := ports.Get(client, portID).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return true, nil
+			}
+			return false, err
+		}
+
+		return false, nil
+	})
+}
+
+func waitForSubnetDeleted(client *golangsdk.ServiceClient, subnetID string, secs int) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		_, err := subnets.Get(client, subnetID).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return true, nil
+			}
+			return false, err
+		}
+
+		return false, nil
+	})
+}
+
+func waitForNetworkDeleted(client *golangsdk.ServiceClient, networkID string, secs int) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		_, err := networks.Get(client, networkID).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return true, nil
+			}
+			return false, err
+		}
+
+		return false, nil
+	})
+}

--- a/acceptance/openstack/networking/v2/ports/ports_test.go
+++ b/acceptance/openstack/networking/v2/ports/ports_test.go
@@ -31,8 +31,8 @@ func TestPortLifecycle(t *testing.T) {
 		NetworkID:    network.ID,
 		Name:         tools.RandomString("acc-port-create-", 3),
 		AdminStateUp: &adminStateUp,
-		FixedIps: []ports.FixedIp{
-			{SubnetId: subnet.ID},
+		FixedIPs: []ports.IP{
+			{SubnetID: subnet.ID},
 		},
 	}
 
@@ -47,7 +47,7 @@ func TestPortLifecycle(t *testing.T) {
 	th.AssertEquals(t, createOpts.NetworkID, port.NetworkID)
 	th.AssertEquals(t, *createOpts.AdminStateUp, port.AdminStateUp)
 	th.AssertEquals(t, 1, len(port.FixedIPs))
-	th.AssertEquals(t, subnet.ID, port.FixedIPs[0].SubnetId)
+	th.AssertEquals(t, subnet.ID, port.FixedIPs[0].SubnetID)
 	t.Logf("Created port: %s", port.ID)
 
 	updatedName := tools.RandomString("acc-port-update-", 3)

--- a/openstack/networking/v2/extensions/portsbinding/testing/requests_test.go
+++ b/openstack/networking/v2/extensions/portsbinding/testing/requests_test.go
@@ -9,19 +9,21 @@ import (
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
 
+type portWithBindingExt struct {
+	ports.Port
+	HostID  string `json:"binding:host_id"`
+	VIFType string `json:"binding:vif_type"`
+}
+
 func TestList(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
 	HandleListSuccessfully(t)
 
-	type PortWithExt struct {
-		ports.Port
-		portsbinding.PortsBindingExt
-	}
-	var actual []PortWithExt
+	var actual []portWithBindingExt
 
-	expected := []PortWithExt{
+	expected := []portWithBindingExt{
 		{
 			Port: ports.Port{
 				Status:       "ACTIVE",
@@ -40,11 +42,9 @@ func TestList(t *testing.T) {
 				ID:             "d80b1a3b-4fc1-49f3-952e-1e2ab7081d8b",
 				SecurityGroups: []string{},
 				DeviceID:       "9ae135f4-b6e0-4dad-9e91-3c223e385824",
+				VnicType:       "normal",
 			},
-			PortsBindingExt: portsbinding.PortsBindingExt{
-				VNICType: "normal",
-				HostID:   "devstack",
-			},
+			HostID: "devstack",
 		},
 	}
 
@@ -63,10 +63,7 @@ func TestGet(t *testing.T) {
 
 	HandleGet(t)
 
-	var s struct {
-		ports.Port
-		portsbinding.PortsBindingExt
-	}
+	var s portWithBindingExt
 
 	err := ports.Get(fake.ServiceClient(), "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2").ExtractInto(&s)
 	th.AssertNoErr(t, err)
@@ -86,9 +83,9 @@ func TestGet(t *testing.T) {
 	th.AssertEquals(t, s.DeviceID, "5e3898d7-11be-483e-9732-b2f5eccd2b2e")
 
 	th.AssertEquals(t, s.HostID, "devstack")
-	th.AssertEquals(t, s.VNICType, "normal")
+	th.AssertEquals(t, s.VnicType, "normal")
 	th.AssertEquals(t, s.VIFType, "ovs")
-	th.AssertDeepEquals(t, s.VIFDetails, map[string]interface{}{"port_filter": true, "ovs_hybrid_plug": true})
+	th.AssertDeepEquals(t, s.VifDetails, ports.VifDetail{})
 }
 
 func TestCreate(t *testing.T) {
@@ -97,10 +94,7 @@ func TestCreate(t *testing.T) {
 
 	HandleCreate(t)
 
-	var s struct {
-		ports.Port
-		portsbinding.PortsBindingExt
-	}
+	var s portWithBindingExt
 
 	asu := true
 	portCreateOpts := ports.CreateOpts{
@@ -135,7 +129,7 @@ func TestCreate(t *testing.T) {
 	th.AssertEquals(t, s.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
 	th.AssertDeepEquals(t, s.SecurityGroups, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"})
 	th.AssertEquals(t, s.HostID, "HOST1")
-	th.AssertEquals(t, s.VNICType, "normal")
+	th.AssertEquals(t, s.VnicType, "normal")
 }
 
 func TestRequiredCreateOpts(t *testing.T) {
@@ -151,10 +145,7 @@ func TestUpdate(t *testing.T) {
 
 	HandleUpdate(t)
 
-	var s struct {
-		ports.Port
-		portsbinding.PortsBindingExt
-	}
+	var s portWithBindingExt
 
 	portUpdateOpts := ports.UpdateOpts{
 		Name: "new_port_name",
@@ -179,5 +170,5 @@ func TestUpdate(t *testing.T) {
 	})
 	th.AssertDeepEquals(t, s.SecurityGroups, []string{"f0ac4394-7e4a-4409-9701-ba8be283dbc3"})
 	th.AssertEquals(t, s.HostID, "HOST1")
-	th.AssertEquals(t, s.VNICType, "normal")
+	th.AssertEquals(t, s.VnicType, "normal")
 }

--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -17,20 +17,23 @@ type ListOptsBuilder interface {
 // by a particular port attribute. SortDir sets the direction, and is either
 // `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	Status       string `q:"status"`
-	Name         string `q:"name"`
-	AdminStateUp *bool  `q:"admin_state_up"`
-	NetworkID    string `q:"network_id"`
-	TenantID     string `q:"tenant_id"`
-	ProjectID    string `q:"project_id"`
-	DeviceOwner  string `q:"device_owner"`
-	MACAddress   string `q:"mac_address"`
-	ID           string `q:"id"`
-	DeviceID     string `q:"device_id"`
-	Limit        int    `q:"limit"`
-	Marker       string `q:"marker"`
-	SortKey      string `q:"sort_key"`
-	SortDir      string `q:"sort_dir"`
+	Status              string `q:"status"`
+	Name                string `q:"name"`
+	AdminStateUp        *bool  `q:"admin_state_up"`
+	NetworkID           string `q:"network_id"`
+	TenantID            string `q:"tenant_id"`
+	ProjectID           string `q:"project_id"`
+	DeviceOwner         string `q:"device_owner"`
+	MACAddress          string `q:"mac_address"`
+	ID                  string `q:"id"`
+	DeviceID            string `q:"device_id"`
+	Limit               int    `q:"limit"`
+	Marker              string `q:"marker"`
+	SortKey             string `q:"sort_key"`
+	SortDir             string `q:"sort_dir"`
+	EnterpriseProjectID string `q:"enterprise_project_id"`
+	// fixed_ips=ip_address={ip_address}&fixed_ips=subnet_id={subnet_id}
+	FixedIps []string `q:"fixed_ips"`
 }
 
 // ToPortListQuery formats a ListOpts into a query string.
@@ -77,17 +80,28 @@ type CreateOptsBuilder interface {
 
 // CreateOpts represents the attributes used when creating a new port.
 type CreateOpts struct {
-	NetworkID           string        `json:"network_id" required:"true"`
-	Name                string        `json:"name,omitempty"`
-	AdminStateUp        *bool         `json:"admin_state_up,omitempty"`
-	MACAddress          string        `json:"mac_address,omitempty"`
-	FixedIPs            interface{}   `json:"fixed_ips,omitempty"`
-	DeviceID            string        `json:"device_id,omitempty"`
-	DeviceOwner         string        `json:"device_owner,omitempty"`
-	TenantID            string        `json:"tenant_id,omitempty"`
-	ProjectID           string        `json:"project_id,omitempty"`
-	SecurityGroups      *[]string     `json:"security_groups,omitempty"`
-	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs,omitempty"`
+	NetworkID           string         `json:"network_id" required:"true"`
+	Name                string         `json:"name,omitempty"`
+	AdminStateUp        *bool          `json:"admin_state_up,omitempty"`
+	MACAddress          string         `json:"mac_address,omitempty"`
+	FixedIps            []FixedIp      `json:"fixed_ips,omitempty"`
+	DeviceID            string         `json:"device_id,omitempty"`
+	DeviceOwner         string         `json:"device_owner,omitempty"`
+	TenantID            string         `json:"tenant_id,omitempty"`
+	ProjectID           string         `json:"project_id,omitempty"`
+	SecurityGroups      *[]string      `json:"security_groups,omitempty"`
+	AllowedAddressPairs []AddressPair  `json:"allowed_address_pairs,omitempty"`
+	ExtraDhcpOpts       []ExtraDhcpOpt `json:"extra_dhcp_opts,omitempty"`
+}
+
+// FixedIp is an Object specifying the IP information of the port.
+type FixedIp struct {
+	// Specifies the subnet ID.
+	// You cannot change the parameter value.
+	SubnetId string `json:"subnet_id,omitempty"`
+	// Specifies the port IP address.
+	// You cannot change the parameter value.
+	IpAddress string `json:"ip_address,omitempty"`
 }
 
 // ToPortCreateMap builds a request body from CreateOpts.
@@ -122,6 +136,7 @@ type UpdateOpts struct {
 	DeviceOwner         string         `json:"device_owner,omitempty"`
 	SecurityGroups      *[]string      `json:"security_groups,omitempty"`
 	AllowedAddressPairs *[]AddressPair `json:"allowed_address_pairs,omitempty"`
+	ExtraDhcpOpts       []ExtraDhcpOpt `json:"extra_dhcp_opts,omitempty"`
 }
 
 // ToPortUpdateMap builds a request body from UpdateOpts.

--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -84,7 +84,7 @@ type CreateOpts struct {
 	Name                string         `json:"name,omitempty"`
 	AdminStateUp        *bool          `json:"admin_state_up,omitempty"`
 	MACAddress          string         `json:"mac_address,omitempty"`
-	FixedIps            []FixedIp      `json:"fixed_ips,omitempty"`
+	FixedIPs            []IP           `json:"fixed_ips,omitempty"`
 	DeviceID            string         `json:"device_id,omitempty"`
 	DeviceOwner         string         `json:"device_owner,omitempty"`
 	TenantID            string         `json:"tenant_id,omitempty"`
@@ -94,14 +94,14 @@ type CreateOpts struct {
 	ExtraDhcpOpts       []ExtraDhcpOpt `json:"extra_dhcp_opts,omitempty"`
 }
 
-// FixedIp is an Object specifying the IP information of the port.
-type FixedIp struct {
+// IP is an Object specifying the IP information of the port.
+type IP struct {
 	// Specifies the subnet ID.
 	// You cannot change the parameter value.
-	SubnetId string `json:"subnet_id,omitempty"`
+	SubnetID string `json:"subnet_id,omitempty"`
 	// Specifies the port IP address.
 	// You cannot change the parameter value.
-	IpAddress string `json:"ip_address,omitempty"`
+	IPAddress string `json:"ip_address,omitempty"`
 }
 
 // ToPortCreateMap builds a request body from CreateOpts.

--- a/openstack/networking/v2/ports/results.go
+++ b/openstack/networking/v2/ports/results.go
@@ -44,12 +44,6 @@ type DeleteResult struct {
 	golangsdk.ErrResult
 }
 
-// IP is a sub-struct that represents an individual IP.
-type IP struct {
-	SubnetID  string `json:"subnet_id"`
-	IPAddress string `json:"ip_address,omitempty"`
-}
-
 // AddressPair contains the IP Address and the MAC address.
 type AddressPair struct {
 	IPAddress  string `json:"ip_address,omitempty"`
@@ -82,7 +76,7 @@ type Port struct {
 
 	// Specifies IP addresses for the port thus associating the port itself with
 	// the subnets where the IP addresses are picked from
-	FixedIPs []IP `json:"fixed_ips"`
+	FixedIPs []FixedIp `json:"fixed_ips"`
 
 	// TenantID is the project owner of the port.
 	TenantID string `json:"tenant_id"`
@@ -101,6 +95,65 @@ type Port struct {
 
 	// Identifies the list of IP addresses the port will recognize/accept
 	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs"`
+
+	// Specifies the extended option (extended attribute) of DHCP.
+	ExtraDhcpOpts []ExtraDhcpOpt `json:"extra_dhcp_opts"`
+	// Specifies the VIF details. Parameter ovs_hybrid_plug specifies whether the OVS/bridge hybrid mode is used.
+	VifDetails VifDetail `json:"binding:vif_details"`
+	// Specifies the custom information configured by users. This is an extended attribute.
+	Profile interface{} `json:"binding:profile"`
+	// Specifies the type of the bound vNIC. The value can be normal or direct.
+	// Parameter normal indicates software switching.
+	// Parameter direct indicates SR-IOV PCIe passthrough, which is not supported.
+	VnicType string `json:"binding:vnic_type"`
+	// Specifies the default private network domain name information of the primary NIC.
+	// The system automatically sets this parameter, and you are not allowed to configure or change the parameter value.
+	DnsAssignment []DnsAssignment `json:"dns_assignment"`
+	// Specifies the default private network DNS name of the primary NIC.
+	// The system automatically sets this parameter, and you are not allowed to configure or change the parameter value.
+	DnsName string `json:"dns_name"`
+	// Specifies the ID of the instance to which the port belongs, for example, RDS instance ID.
+	// The system automatically sets this parameter, and you are not allowed to configure or change the parameter value.
+	InstanceId string `json:"instance_id"`
+	// Specifies the type of the instance to which the port belongs, for example, RDS.
+	// The system automatically sets this parameter, and you are not allowed to configure or change the parameter value.
+	InstanceType string `json:"instance_type"`
+	// Specifies whether the security option is enabled for the port.
+	// If the option is not enabled, the security group and DHCP snooping do not take effect.
+	PortSecurityEnabled bool `json:"port_security_enabled"`
+	// Availability zone to which the port belongs.
+	ZoneId string `json:"zone_id"`
+	// Whether to enable efi
+	EnableEfi bool `json:"enable_efi"`
+	// The Shared bandwidth ID bound to IPv6
+	Ipv6BandwidthId string `json:"ipv6_bandwidth_id"`
+}
+
+// VifDetail is an Object specifying the VIF details.
+type VifDetail struct {
+	// If the value is true, indicating that it is the main network card of the virtual machine.
+	PrimaryInterface bool `json:"primary_interface"`
+}
+
+// DnsAssignment is an Object specifying the private network domain information.
+type DnsAssignment struct {
+	// Specifies the hostname.
+	Hostname string `json:"hostname"`
+	// Specifies the IP address of the port.
+	IpAddress string `json:"ip_address"`
+	// Specifies the FQDN.
+	Fqdn string `json:"fqdn"`
+}
+
+// ExtraDhcpOpt is an Object specifying the DHCP extended properties.
+type ExtraDhcpOpt struct {
+	// Specifies the DHCP option name.
+	// Currently, only '51' is supported to indicate the DHCP lease time.
+	OptName string `json:"opt_name,omitempty"`
+	// Specifies the DHCP option value.
+	// When 'OptName' is '51', the parameter format is 'Xh', indicating that the DHCP lease time is X hours.
+	// The value range of 'X' is '1~30000' or '-1', '-1' means the DHCP lease time is infinite.
+	OptValue string `json:"opt_value,omitempty"`
 }
 
 // PortPage is the page returned by a pager when traversing over a collection

--- a/openstack/networking/v2/ports/results.go
+++ b/openstack/networking/v2/ports/results.go
@@ -76,7 +76,7 @@ type Port struct {
 
 	// Specifies IP addresses for the port thus associating the port itself with
 	// the subnets where the IP addresses are picked from
-	FixedIPs []FixedIp `json:"fixed_ips"`
+	FixedIPs []IP `json:"fixed_ips"`
 
 	// TenantID is the project owner of the port.
 	TenantID string `json:"tenant_id"`

--- a/openstack/networking/v2/ports/testing/fixtures.go
+++ b/openstack/networking/v2/ports/testing/fixtures.go
@@ -666,8 +666,7 @@ const UpdateWithExtraDHCPOptsRequest = `
         ],
         "extra_dhcp_opts": [
             {
-                "opt_name": "option1",
-                "opt_value": null
+                "opt_name": "option1"
             },
             {
                 "opt_name": "option2",

--- a/openstack/networking/v2/ports/testing/requests_test.go
+++ b/openstack/networking/v2/ports/testing/requests_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	fake "github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/common"
-	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/extradhcpopts"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/extensions/portsecurity"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/ports"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
@@ -55,6 +54,7 @@ func TestList(t *testing.T) {
 				ID:             "d80b1a3b-4fc1-49f3-952e-1e2ab7081d8b",
 				SecurityGroups: []string{},
 				DeviceID:       "9ae135f4-b6e0-4dad-9e91-3c223e385824",
+				VnicType:       "normal",
 			},
 		}
 
@@ -84,7 +84,7 @@ func TestListWithExtensions(t *testing.T) {
 
 	type portWithExt struct {
 		ports.Port
-		portsecurity.PortSecurityExt
+		PortSecurity portsecurity.PortSecurityExt
 	}
 
 	var allPorts []portWithExt
@@ -96,7 +96,7 @@ func TestListWithExtensions(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, allPorts[0].Status, "ACTIVE")
-	th.AssertEquals(t, allPorts[0].PortSecurityEnabled, false)
+	th.AssertEquals(t, allPorts[0].PortSecurity.PortSecurityEnabled, false)
 }
 
 func TestGet(t *testing.T) {
@@ -148,14 +148,14 @@ func TestGetWithExtensions(t *testing.T) {
 
 	var portWithExtensions struct {
 		ports.Port
-		portsecurity.PortSecurityExt
+		PortSecurity portsecurity.PortSecurityExt
 	}
 
 	err := ports.Get(fake.ServiceClient(), "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2").ExtractInto(&portWithExtensions)
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, portWithExtensions.Status, "ACTIVE")
-	th.AssertEquals(t, portWithExtensions.PortSecurityEnabled, false)
+	th.AssertEquals(t, portWithExtensions.PortSecurity.PortSecurityEnabled, false)
 }
 
 func TestCreate(t *testing.T) {
@@ -332,7 +332,7 @@ func TestCreatePortSecurity(t *testing.T) {
 
 	var portWithExt struct {
 		ports.Port
-		portsecurity.PortSecurityExt
+		PortSecurity portsecurity.PortSecurityExt
 	}
 
 	asu := true
@@ -358,7 +358,7 @@ func TestCreatePortSecurity(t *testing.T) {
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, portWithExt.Status, "DOWN")
-	th.AssertEquals(t, portWithExt.PortSecurityEnabled, false)
+	th.AssertEquals(t, portWithExt.PortSecurity.PortSecurityEnabled, false)
 }
 
 func TestUpdate(t *testing.T) {
@@ -461,7 +461,7 @@ func TestUpdatePortSecurity(t *testing.T) {
 
 	var portWithExt struct {
 		ports.Port
-		portsecurity.PortSecurityExt
+		PortSecurity portsecurity.PortSecurityExt
 	}
 
 	iFalse := false
@@ -476,7 +476,7 @@ func TestUpdatePortSecurity(t *testing.T) {
 
 	th.AssertEquals(t, portWithExt.Status, "DOWN")
 	th.AssertEquals(t, portWithExt.Name, "private-port")
-	th.AssertEquals(t, portWithExt.PortSecurityEnabled, false)
+	th.AssertEquals(t, portWithExt.PortSecurity.PortSecurityEnabled, false)
 }
 
 func TestRemoveSecurityGroups(t *testing.T) {
@@ -623,12 +623,7 @@ func TestGetWithExtraDHCPOpts(t *testing.T) {
 		_, _ = fmt.Fprint(w, GetWithExtraDHCPOptsResponse)
 	})
 
-	var s struct {
-		ports.Port
-		extradhcpopts.ExtraDHCPOptsExt
-	}
-
-	err := ports.Get(fake.ServiceClient(), "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2").ExtractInto(&s)
+	s, err := ports.Get(fake.ServiceClient(), "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2").Extract()
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, s.Status, "ACTIVE")
@@ -644,12 +639,10 @@ func TestGetWithExtraDHCPOpts(t *testing.T) {
 	th.AssertEquals(t, s.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
 	th.AssertEquals(t, s.DeviceID, "")
 
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptName, "option1")
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptValue, "value1")
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].IPVersion, "4")
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[1].OptName, "option2")
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[1].OptValue, "value2")
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[1].IPVersion, "4")
+	th.AssertDeepEquals(t, s.ExtraDhcpOpts[0].OptName, "option1")
+	th.AssertDeepEquals(t, s.ExtraDhcpOpts[0].OptValue, "value1")
+	th.AssertDeepEquals(t, s.ExtraDhcpOpts[1].OptName, "option2")
+	th.AssertDeepEquals(t, s.ExtraDhcpOpts[1].OptValue, "value2")
 }
 
 func TestCreateWithExtraDHCPOpts(t *testing.T) {
@@ -670,18 +663,14 @@ func TestCreateWithExtraDHCPOpts(t *testing.T) {
 	})
 
 	adminStateUp := true
-	portCreateOpts := ports.CreateOpts{
+	createOpts := ports.CreateOpts{
 		Name:         "port-with-extra-dhcp-opts",
 		AdminStateUp: &adminStateUp,
 		NetworkID:    "a87cc70a-3e15-4acf-8205-9b711a3531b7",
 		FixedIPs: []ports.IP{
 			{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
 		},
-	}
-
-	createOpts := extradhcpopts.CreateOptsExt{
-		CreateOptsBuilder: portCreateOpts,
-		ExtraDHCPOpts: []extradhcpopts.CreateExtraDHCPOpt{
+		ExtraDhcpOpts: []ports.ExtraDhcpOpt{
 			{
 				OptName:  "option1",
 				OptValue: "value1",
@@ -689,12 +678,7 @@ func TestCreateWithExtraDHCPOpts(t *testing.T) {
 		},
 	}
 
-	var s struct {
-		ports.Port
-		extradhcpopts.ExtraDHCPOptsExt
-	}
-
-	err := ports.Create(fake.ServiceClient(), createOpts).ExtractInto(&s)
+	s, err := ports.Create(fake.ServiceClient(), createOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, s.Status, "DOWN")
@@ -710,9 +694,8 @@ func TestCreateWithExtraDHCPOpts(t *testing.T) {
 	th.AssertEquals(t, s.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
 	th.AssertEquals(t, s.DeviceID, "")
 
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptName, "option1")
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptValue, "value1")
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].IPVersion, "4")
+	th.AssertDeepEquals(t, s.ExtraDhcpOpts[0].OptName, "option1")
+	th.AssertDeepEquals(t, s.ExtraDhcpOpts[0].OptValue, "value1")
 }
 
 func TestUpdateWithExtraDHCPOpts(t *testing.T) {
@@ -737,28 +720,18 @@ func TestUpdateWithExtraDHCPOpts(t *testing.T) {
 		FixedIPs: []ports.IP{
 			{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.3"},
 		},
-	}
-
-	edoValue2 := "value2"
-	updateOpts := extradhcpopts.UpdateOptsExt{
-		UpdateOptsBuilder: portUpdateOpts,
-		ExtraDHCPOpts: []extradhcpopts.UpdateExtraDHCPOpt{
+		ExtraDhcpOpts: []ports.ExtraDhcpOpt{
 			{
 				OptName: "option1",
 			},
 			{
 				OptName:  "option2",
-				OptValue: &edoValue2,
+				OptValue: "value2",
 			},
 		},
 	}
 
-	var s struct {
-		ports.Port
-		extradhcpopts.ExtraDHCPOptsExt
-	}
-
-	err := ports.Update(fake.ServiceClient(), "65c0ee9f-d634-4522-8954-51021b570b0d", updateOpts).ExtractInto(&s)
+	s, err := ports.Update(fake.ServiceClient(), "65c0ee9f-d634-4522-8954-51021b570b0d", portUpdateOpts).Extract()
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, s.Status, "DOWN")
@@ -774,7 +747,6 @@ func TestUpdateWithExtraDHCPOpts(t *testing.T) {
 	th.AssertEquals(t, s.ID, "65c0ee9f-d634-4522-8954-51021b570b0d")
 	th.AssertEquals(t, s.DeviceID, "")
 
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptName, "option2")
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].OptValue, "value2")
-	th.AssertDeepEquals(t, s.ExtraDHCPOpts[0].IPVersion, "4")
+	th.AssertDeepEquals(t, s.ExtraDhcpOpts[0].OptName, "option2")
+	th.AssertDeepEquals(t, s.ExtraDhcpOpts[0].OptValue, "value2")
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
```
=== RUN   TestPortLifecycle
    ports_test.go:92: Attempting to create network: acc-port-net-8AK
    ports_test.go:95: Created network: 93fa17a1-62eb-4edd-aadf-e4bf93b6536c
    ports_test.go:121: Attempting to create subnet: acc-port-subnet-jAI
    ports_test.go:124: Created subnet: db9b089c-65fb-451b-9df3-b0f66290481b
    ports_test.go:39: Attempting to create port: acc-port-create-LOD
    ports_test.go:51: Created port: ebbe4b1e-f958-4b4e-a570-3e650474420b
    ports_test.go:60: Attempting to update port: ebbe4b1e-f958-4b4e-a570-3e650474420b
    ports_test.go:138: Attempting to delete port: ebbe4b1e-f958-4b4e-a570-3e650474420b
    ports_test.go:142: Deleted port: ebbe4b1e-f958-4b4e-a570-3e650474420b
    ports_test.go:130: Attempting to delete subnet: db9b089c-65fb-451b-9df3-b0f66290481b
    ports_test.go:134: Deleted subnet: db9b089c-65fb-451b-9df3-b0f66290481b
    ports_test.go:101: Attempting to delete network: 93fa17a1-62eb-4edd-aadf-e4bf93b6536c
    ports_test.go:105: Deleted network: 93fa17a1-62eb-4edd-aadf-e4bf93b6536c
--- PASS: TestPortLifecycle (12.38s)
PASS

Process finished with the exit code 0
```