### PR TITLE
[Feat.] Update bandwidths.RemoveOpts with Public Ip Type

### DIFF
--- a/acceptance/openstack/networking/v2/bandwidths_test.go
+++ b/acceptance/openstack/networking/v2/bandwidths_test.go
@@ -123,7 +123,7 @@ func TestBandwidthAssociate(t *testing.T) {
 	remOpts := bandwidths.RemoveOpts{
 		ChargeMode: "bandwidth",
 		Size:       1,
-		PublicIpInfo: []bandwidths.PublicIpInfoID{
+		PublicIpInfo: []bandwidths.PublicIpInfoRemove{
 			{PublicIpID: eip.ID},
 		},
 	}

--- a/openstack/networking/v2/bandwidths/requests.go
+++ b/openstack/networking/v2/bandwidths/requests.go
@@ -108,13 +108,14 @@ type RemoveOptsBuilder interface {
 }
 
 type RemoveOpts struct {
-	ChargeMode   string           `json:"charge_mode" required:"true"`
-	Size         int              `json:"size" required:"true"`
-	PublicIpInfo []PublicIpInfoID `json:"publicip_info" required:"true"`
+	ChargeMode   string               `json:"charge_mode" required:"true"`
+	Size         int                  `json:"size" required:"true"`
+	PublicIpInfo []PublicIpInfoRemove `json:"publicip_info" required:"true"`
 }
 
-type PublicIpInfoID struct {
-	PublicIpID string `json:"publicip_id" required:"true"`
+type PublicIpInfoRemove struct {
+	PublicIpID   string `json:"publicip_id" required:"true"`
+	PublicIpType string `json:"publicip_type,omitempty"`
 }
 
 func (opts RemoveOpts) ToBandwidthRemoveMap() (map[string]interface{}, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Adde not documented optional attribute

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
```
=== RUN   TestBandwidthLifecycle
    bandwidths_test.go:17: Attempting to create BandwidthV2
    bandwidths_test.go:34: Created BandwidthV2: 046b1e74-2355-44a2-a6d9-9923380acdc2
    bandwidths_test.go:36: Attempting to update BandwidthV2: 046b1e74-2355-44a2-a6d9-9923380acdc2
    bandwidths_test.go:49: Updated BandwidthV2: 046b1e74-2355-44a2-a6d9-9923380acdc2
    bandwidths_test.go:27: Attempting to delete BandwidthV2: 046b1e74-2355-44a2-a6d9-9923380acdc2
    bandwidths_test.go:30: Deleted BandwidthV2: 046b1e74-2355-44a2-a6d9-9923380acdc2
--- PASS: TestBandwidthLifecycle (2.56s)
=== RUN   TestBandwidthAssociate
    bandwidths_test.go:80: Attempting to delete BandwidthV2: 969b7ae0-f796-408f-86ed-bd5f9f7332ca
    bandwidths_test.go:83: Deleted BandwidthV2: 969b7ae0-f796-408f-86ed-bd5f9f7332ca
--- PASS: TestBandwidthAssociate (9.32s)
PASS

Process finished with the exit code 0
```