### PR TITLE
[Fix] CES alarm rule v2 resources tag

### DIFF
--- a/acceptance/openstack/ces/v2/alarms_test.go
+++ b/acceptance/openstack/ces/v2/alarms_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/ces/v2/alarms"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
@@ -82,4 +83,68 @@ func TestAlarmsCRUD(t *testing.T) {
 		AlarmEnabled: false,
 	})
 	th.AssertNoErr(t, err)
+}
+
+func TestAlarmsCreateEventSysWithEmptyResources(t *testing.T) {
+	client, err := clients.NewCesV2Client()
+	th.AssertNoErr(t, err)
+
+	alarmName := tools.RandomString("test-alarm-event-sys-", 4)
+
+	t.Log("Attempting to create EVENT.SYS alarm rule with empty resources")
+	createOpts := alarms.CreateOpts{
+		Name:      alarmName,
+		Namespace: "SYS.ECS",
+		Type:      "EVENT.SYS",
+		Resources: [][]alarms.Dimension{},
+		Policies: []alarms.Policy{
+			{
+				MetricName:         "stopServer",
+				Period:             0,
+				Filter:             "average",
+				ComparisonOperator: ">=",
+				Value:              1,
+				Unit:               "count",
+				Count:              1,
+				SuppressDuration:   0,
+				Level:              2,
+			},
+		},
+		NotificationEnabled: pointerto.Bool(false),
+		Enabled:             pointerto.Bool(true),
+	}
+
+	alarmId, err := alarms.Create(client, createOpts)
+	th.AssertNoErr(t, err)
+
+	t.Cleanup(func() {
+		t.Log("Attempting to delete EVENT.SYS alarm rule")
+		_, err := alarms.Delete(client, alarms.DeleteOpts{
+			AlarmIds: []string{alarmId},
+		})
+		th.AssertNoErr(t, err)
+	})
+
+	t.Log("Attempting to verify EVENT.SYS alarm rule")
+	listResp, err := alarms.List(client, alarms.ListOpts{
+		AlarmId: alarmId,
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, listResp.Count, 1)
+	th.AssertEquals(t, listResp.Alarms[0].Name, alarmName)
+	th.AssertEquals(t, listResp.Alarms[0].Namespace, "SYS.ECS")
+	th.AssertEquals(t, listResp.Alarms[0].Type, "EVENT.SYS")
+	th.AssertEquals(t, listResp.Alarms[0].Enabled, true)
+	th.AssertEquals(t, listResp.Alarms[0].NotificationEnabled, false)
+	th.AssertEquals(t, len(listResp.Alarms[0].Resources), 1)
+	th.AssertEquals(t, len(listResp.Alarms[0].Policies), 1)
+	th.AssertEquals(t, listResp.Alarms[0].Policies[0].MetricName, "stopServer")
+	th.AssertEquals(t, listResp.Alarms[0].Policies[0].Period, 0)
+	th.AssertEquals(t, listResp.Alarms[0].Policies[0].Filter, "average")
+	th.AssertEquals(t, listResp.Alarms[0].Policies[0].ComparisonOperator, ">=")
+	th.AssertEquals(t, listResp.Alarms[0].Policies[0].Value, float64(1))
+	th.AssertEquals(t, listResp.Alarms[0].Policies[0].Unit, "count")
+	th.AssertEquals(t, listResp.Alarms[0].Policies[0].Count, 1)
+	th.AssertEquals(t, listResp.Alarms[0].Policies[0].SuppressDuration, 0)
+	th.AssertEquals(t, listResp.Alarms[0].Policies[0].Level, 2)
 }

--- a/openstack/ces/v2/alarms/Create.go
+++ b/openstack/ces/v2/alarms/Create.go
@@ -21,7 +21,7 @@ type CreateOpts struct {
 	ResourceGroupId string `json:"resource_group_id,omitempty"`
 	// Specifies the resource list. This parameter is mandatory when type is set to MULTI_INSTANCE.
 	// A maximum of 1000 resources are supported.
-	Resources [][]Dimension `json:"resources,omitempty"`
+	Resources [][]Dimension `json:"resources"`
 	// Specifies the alarm policies.
 	// Either policies or alarm_template_id must be configured.
 	Policies []Policy `json:"policies,omitempty"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
API wants explicitly to receive empty list if nothing are set

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
```
=== RUN   TestAlarmsCRUD
    alarms_test.go:17: Attempting to create alarm rule
    alarms_test.go:57: Attempting to get alarm rule
    alarms_test.go:66: Attempting to enable alarm rule
    alarms_test.go:73: Attempting to verify alarm rule is enabled
    alarms_test.go:80: Attempting to disable alarm rule
    alarms_test.go:50: Attempting to delete alarm rule
--- PASS: TestAlarmsCRUD (2.12s)
=== RUN   TestAlarmsCreateEventSysWithEmptyResources
    alarms_test.go:94: Attempting to create EVENT.SYS alarm rule with empty resources
    alarms_test.go:128: Attempting to verify EVENT.SYS alarm rule
    alarms_test.go:121: Attempting to delete EVENT.SYS alarm rule
--- PASS: TestAlarmsCreateEventSysWithEmptyResources (1.20s)
PASS

Process finished with the exit code 0
```