### PR TITLE
[Fix] IAM: Add XuserType and XuserID to users.CreateOpts

### DIFF
--- a/openstack/identity/v3.0/users/CreateUser.go
+++ b/openstack/identity/v3.0/users/CreateUser.go
@@ -38,6 +38,14 @@ type CreateOpts struct {
 	// PasswordReset Indicates whether password reset is required at the first login.
 	// By default, password reset is true.
 	PasswordReset *bool `json:"pwd_status,omitempty"`
+
+	// XuserType is the type of the IAM user in the external system.
+	// Must be used together with XuserID. Currently only "TenantIdp" is supported.
+	XuserType string `json:"xuser_type,omitempty"`
+
+	// XuserID is the ID of the IAM user in the external system (max 128 characters).
+	// Must be used together with XuserType.
+	XuserID string `json:"xuser_id,omitempty"`
 }
 
 func CreateUser(client *golangsdk.ServiceClient, opts CreateOpts) (*User, error) {

--- a/openstack/identity/v3.0/users/testing/fixtures.go
+++ b/openstack/identity/v3.0/users/testing/fixtures.go
@@ -1,0 +1,140 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3.0/users"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/gophertelekomcloud/testhelper/client"
+)
+
+const CreateUserWithExternalIdentityRequest = `
+{
+	"user": {
+		"domain_id": "1789d1",
+		"enabled": true,
+		"name": "jsmith",
+		"xuser_id": "external-user-123",
+		"xuser_type": "TenantIdp"
+	}
+}
+`
+
+const CreateUserWithExternalIdentityResponse = `
+{
+	"user": {
+		"id": "9fe1d3",
+		"domain_id": "1789d1",
+		"enabled": true,
+		"name": "jsmith",
+		"xuser_id": "external-user-123",
+		"xuser_type": "TenantIdp"
+	}
+}
+`
+
+const ModifyUserAdminWithExternalIdentityRequest = `
+{
+	"user": {
+		"xuser_id": "external-user-456",
+		"xuser_type": "TenantIdp"
+	}
+}
+`
+
+const ModifyUserAdminWithExternalIdentityResponse = `
+{
+	"user": {
+		"id": "9fe1d3",
+		"domain_id": "1789d1",
+		"enabled": true,
+		"name": "jsmith",
+		"xuser_id": "external-user-456",
+		"xuser_type": "TenantIdp"
+	}
+}
+`
+
+const ModifyUserAdminClearExternalIdentityRequest = `
+{
+	"user": {
+		"xuser_id": "",
+		"xuser_type": ""
+	}
+}
+`
+
+const ModifyUserAdminClearExternalIdentityResponse = `
+{
+	"user": {
+		"id": "9fe1d3",
+		"domain_id": "1789d1",
+		"enabled": true,
+		"name": "jsmith",
+		"xuser_id": "",
+		"xuser_type": ""
+	}
+}
+`
+
+var CreatedUserWithExternalIdentity = users.User{
+	ID:        "9fe1d3",
+	DomainID:  "1789d1",
+	Enabled:   true,
+	Name:      "jsmith",
+	XuserID:   "external-user-123",
+	XuserType: "TenantIdp",
+}
+
+var UpdatedUserWithExternalIdentity = users.User{
+	ID:        "9fe1d3",
+	DomainID:  "1789d1",
+	Enabled:   true,
+	Name:      "jsmith",
+	XuserID:   "external-user-456",
+	XuserType: "TenantIdp",
+}
+
+var UpdatedUserWithClearedExternalIdentity = users.User{
+	ID:        "9fe1d3",
+	DomainID:  "1789d1",
+	Enabled:   true,
+	Name:      "jsmith",
+	XuserID:   "",
+	XuserType: "",
+}
+
+func HandleCreateUserWithExternalIdentitySuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/OS-USER/users", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, CreateUserWithExternalIdentityRequest)
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, CreateUserWithExternalIdentityResponse)
+	})
+}
+
+func HandleModifyUserAdminWithExternalIdentitySuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/OS-USER/users/9fe1d3", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, ModifyUserAdminWithExternalIdentityRequest)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, ModifyUserAdminWithExternalIdentityResponse)
+	})
+}
+
+func HandleModifyUserAdminClearExternalIdentitySuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/OS-USER/users/9fe1d3", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, ModifyUserAdminClearExternalIdentityRequest)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, ModifyUserAdminClearExternalIdentityResponse)
+	})
+}

--- a/openstack/identity/v3.0/users/testing/requests_test.go
+++ b/openstack/identity/v3.0/users/testing/requests_test.go
@@ -1,0 +1,60 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3.0/users"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/gophertelekomcloud/testhelper/client"
+)
+
+func TestCreateUserWithExternalIdentity(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCreateUserWithExternalIdentitySuccessfully(t)
+
+	iTrue := true
+	createOpts := users.CreateOpts{
+		Name:      "jsmith",
+		DomainID:  "1789d1",
+		Enabled:   &iTrue,
+		XuserType: "TenantIdp",
+		XuserID:   "external-user-123",
+	}
+
+	actual, err := users.CreateUser(client.ServiceClient(), createOpts)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, CreatedUserWithExternalIdentity, *actual)
+}
+
+func TestModifyUserAdminWithExternalIdentity(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleModifyUserAdminWithExternalIdentitySuccessfully(t)
+
+	updateOpts := users.UpdateAdminOpts{
+		Id:        "9fe1d3",
+		XuserType: "TenantIdp",
+		XuserId:   "external-user-456",
+	}
+
+	actual, err := users.ModifyUserAdmin(client.ServiceClient(), updateOpts)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, UpdatedUserWithExternalIdentity, *actual)
+}
+
+func TestModifyUserAdminClearExternalIdentity(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleModifyUserAdminClearExternalIdentitySuccessfully(t)
+
+	updateOpts := users.UpdateAdminOpts{
+		Id:        "9fe1d3",
+		XuserType: "",
+		XuserId:   "",
+	}
+
+	actual, err := users.ModifyUserAdmin(client.ServiceClient(), updateOpts)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, UpdatedUserWithClearedExternalIdentity, *actual)
+}


### PR DESCRIPTION
## What this PR does / why we need it

Add `XuserType` and `XuserID` fields to `CreateOpts` in `openstack/identity/v3.0/users/CreateUser.go`.

The OTC IAM API (`POST /v3.0/OS-USER/users`) accepts `xuser_type` and `xuser_id` in the request body. Both fields are already present in the `User` response struct and in `UpdateAdminOpts`, but missing from `CreateOpts`. This forces callers to issue a second `ModifyUserAdmin` call after creation to set the external identity fields, which is non-atomic.

With this change, callers can set `XuserType` and `XuserID` in a single create call.

## Which issue this PR fixes

fixes #937 

## Tests

```text
ok  	github.com/opentelekomcloud/gophertelekomcloud/openstack/identity/v3.0/users/testing	0.129s
```

### Special notes for your reviewer

* Both fields use `omitempty` so the request body is unchanged for existing
  callers that do not set these fields -> no breaking change.
* Field names and json tags match the existing convention used in
  `UpdateAdminOpts` (`xuser_type`, `xuser_id`).

### Note

A follow-up PR will be created for the terraform-provider itself so that resource `opentelekomcloud_identity_user_v3` will make use of the updated struct.