### PR TITLE
[Feat] Network: Add neutron_subnet_id_v6 attribute

### DIFF
--- a/acceptance/openstack/networking/v1/subnet_test.go
+++ b/acceptance/openstack/networking/v1/subnet_test.go
@@ -59,4 +59,5 @@ func TestSubnetsLifecycle(t *testing.T) {
 	th.AssertEquals(t, updateOpts.Name, newSubnet.Name)
 	th.AssertEquals(t, emptyDescription, newSubnet.Description)
 	th.AssertEquals(t, true, newSubnet.EnableIpv6)
+	th.AssertNotEquals(t, "", newSubnet.SubnetIDV6)
 }

--- a/openstack/networking/v1/subnets/results.go
+++ b/openstack/networking/v1/subnets/results.go
@@ -1,7 +1,7 @@
 package subnets
 
 import (
-	"github.com/opentelekomcloud/gophertelekomcloud"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
 
@@ -54,6 +54,9 @@ type Subnet struct {
 
 	// Specifies the subnet ID.
 	SubnetID string `json:"neutron_subnet_id"`
+
+	// Specifies the IPV6 subnet ID.
+	SubnetIDV6 string `json:"neutron_subnet_id_v6"`
 
 	// Specifies the network ID.
 	NetworkID string `json:"neutron_network_id"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it

Returns attribute `neutron_subnet_id_v6` in subnets.

### Which issue this PR fixes

T Cloud Public TF Provider Issue #[3377](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3377)

### Test
```
=== RUN   TestSubnetsLifecycle
    helpers.go:208: Attempting to create vpc: acc-vpc-hxr
    helpers.go:212: Created vpc: ca9da440-0115-4544-aee7-67907496b75b
    helpers.go:140: Attempting to create subnet: acc-subnet-0Ub
    helpers.go:147: Waitting for subnet 68fd0b86-081c-4d00-9f8a-7ddf29eaa3db to be active
    helpers.go:150: Created subnet: 68fd0b86-081c-4d00-9f8a-7ddf29eaa3db
    subnet_test.go:52: Attempting to update name of subnet to acc-subnet-hhx
    helpers.go:156: Attempting to delete subnet: 68fd0b86-081c-4d00-9f8a-7ddf29eaa3db
    helpers.go:161: Waiting for subnet 68fd0b86-081c-4d00-9f8a-7ddf29eaa3db to be deleted
    helpers.go:165: Deleted subnet: 68fd0b86-081c-4d00-9f8a-7ddf29eaa3db
    helpers.go:218: Attempting to delete vpc: ca9da440-0115-4544-aee7-67907496b75b
    helpers.go:223: Deleted vpc: ca9da440-0115-4544-aee7-67907496b75b
--- PASS: TestSubnetsLifecycle (23.41s)
PASS
```