### PR TITLE
[Fix] Reauth for uncommon dns error on token expiration

### DIFF
--- a/provider_client.go
+++ b/provider_client.go
@@ -180,6 +180,52 @@ type RequestOpts struct {
 
 var applicationJSON = "application/json"
 
+const invalidAuthTokenMessage = "X-Auth-Token is invalid"
+
+func shouldReauthenticate(statusCode int, body []byte) bool {
+	return statusCode == http.StatusUnauthorized ||
+		(statusCode == http.StatusForbidden && bytes.Contains(body, []byte(invalidAuthTokenMessage)))
+}
+
+func (client *ProviderClient) reauthenticateAndRetry(method, url string, options *RequestOpts, prereqtok string, respErr ErrUnexpectedResponseCode) (*http.Response, error) {
+	var err error
+	if client.mut != nil {
+		client.mut.Lock()
+		client.reauthmut.Lock()
+		client.reauthmut.reauthing = true
+		client.reauthmut.Unlock()
+		if curtok := client.TokenID; curtok == prereqtok {
+			err = client.ReauthFunc()
+		}
+		client.reauthmut.Lock()
+		client.reauthmut.reauthing = false
+		client.reauthmut.Unlock()
+		client.mut.Unlock()
+	} else {
+		err = client.ReauthFunc()
+	}
+	if err != nil {
+		e := &ErrUnableToReauthenticate{}
+		e.ErrOriginal = respErr
+		return nil, e
+	}
+	if options.RawBody != nil {
+		if seeker, ok := options.RawBody.(io.Seeker); ok {
+			_, e := seeker.Seek(0, 0)
+			if e != nil {
+				return nil, e
+			}
+		}
+	}
+	resp, err := client.Request(method, url, options)
+	if err != nil {
+		e := &ErrErrorAfterReauthentication{}
+		e.ErrOriginal = err
+		return nil, e
+	}
+	return resp, nil
+}
+
 // Request performs an HTTP request using the ProviderClient's current HTTPClient. An authentication
 // header will automatically be provided.
 func (client *ProviderClient) Request(method, url string, options *RequestOpts) (*http.Response, error) {
@@ -318,47 +364,16 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 			}
 		case http.StatusUnauthorized:
 			if client.ReauthFunc != nil {
-				if client.mut != nil {
-					client.mut.Lock()
-					client.reauthmut.Lock()
-					client.reauthmut.reauthing = true
-					client.reauthmut.Unlock()
-					if curtok := client.TokenID; curtok == prereqtok {
-						err = client.ReauthFunc()
-					}
-					client.reauthmut.Lock()
-					client.reauthmut.reauthing = false
-					client.reauthmut.Unlock()
-					client.mut.Unlock()
-				} else {
-					err = client.ReauthFunc()
-				}
-				if err != nil {
-					e := &ErrUnableToReauthenticate{}
-					e.ErrOriginal = respErr
-					return nil, e
-				}
-				if options.RawBody != nil {
-					if seeker, ok := options.RawBody.(io.Seeker); ok {
-						_, e := seeker.Seek(0, 0)
-						if e != nil {
-							return nil, e
-						}
-					}
-				}
-				resp, err = client.Request(method, url, options)
-				if err != nil {
-					e := &ErrErrorAfterReauthentication{}
-					e.ErrOriginal = err
-					return nil, e
-				}
-				return resp, nil
+				return client.reauthenticateAndRetry(method, url, options, prereqtok, respErr)
 			}
 			err = ErrDefault401{respErr}
 			if error401er, ok := errType.(Err401er); ok {
 				err = error401er.Error401(respErr)
 			}
 		case http.StatusForbidden:
+			if shouldReauthenticate(resp.StatusCode, body) && client.ReauthFunc != nil {
+				return client.reauthenticateAndRetry(method, url, options, prereqtok, respErr)
+			}
 			err = ErrDefault403{respErr}
 			if error403er, ok := errType.(Err403er); ok {
 				err = error403er.Error403(respErr)

--- a/testing/provider_client_test.go
+++ b/testing/provider_client_test.go
@@ -119,3 +119,81 @@ func TestConcurrentReauth(t *testing.T) {
 
 	th.AssertEquals(t, 1, info.numreauths)
 }
+
+func TestReauthOnForbiddenInvalidAuthToken(t *testing.T) {
+	prereauthTok := client.TokenID
+	postreauthTok := "12345678"
+
+	p := new(golangsdk.ProviderClient)
+	p.SetToken(prereauthTok)
+
+	numreauths := 0
+	p.ReauthFunc = func() error {
+		numreauths++
+		p.SetToken(postreauthTok)
+		return nil
+	}
+
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	numrequests := 0
+	th.Mux.HandleFunc("/route", func(w http.ResponseWriter, r *http.Request) {
+		numrequests++
+		switch r.Header.Get("X-Auth-Token") {
+		case prereauthTok:
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = fmt.Fprint(w, `{"message":"X-Auth-Token is invalid"}`)
+		case postreauthTok:
+			w.Header().Add("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{}`)
+		default:
+			t.Errorf("unexpected X-Auth-Token: %s", r.Header.Get("X-Auth-Token"))
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+	})
+
+	resp, err := p.Request("GET", fmt.Sprintf("%s/route", th.Endpoint()), new(golangsdk.RequestOpts))
+	th.CheckNoErr(t, err)
+	if resp == nil {
+		t.Fatalf("got a nil response")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	actual, err := ioutil.ReadAll(resp.Body)
+	th.CheckNoErr(t, err)
+	th.CheckByteArrayEquals(t, []byte(`{}`), actual)
+	th.AssertEquals(t, 1, numreauths)
+	th.AssertEquals(t, 2, numrequests)
+}
+
+func TestForbiddenWithoutInvalidAuthTokenDoesNotReauth(t *testing.T) {
+	p := new(golangsdk.ProviderClient)
+	p.SetToken(client.TokenID)
+
+	numreauths := 0
+	p.ReauthFunc = func() error {
+		numreauths++
+		p.SetToken("12345678")
+		return nil
+	}
+
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/route", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = fmt.Fprint(w, `{"message":"policy does not allow this request"}`)
+	})
+
+	resp, err := p.Request("GET", fmt.Sprintf("%s/route", th.Endpoint()), new(golangsdk.RequestOpts))
+	if resp == nil {
+		t.Fatalf("got a nil response")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	th.AssertEquals(t, 0, numreauths)
+	if _, ok := err.(golangsdk.ErrDefault403); !ok {
+		t.Fatalf("expected ErrDefault403, got %T: %v", err, err)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
DNS returns on expired token 403 instead of 401, this fix could allow reauth also for this DNS error
### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
```
=== RUN   TestAuthenticatedHeaders
--- PASS: TestAuthenticatedHeaders (0.00s)
=== RUN   TestUserAgent
--- PASS: TestUserAgent (0.00s)
=== RUN   TestConcurrentReauth
--- PASS: TestConcurrentReauth (1.01s)
=== RUN   TestReauthOnForbiddenInvalidAuthToken
--- PASS: TestReauthOnForbiddenInvalidAuthToken (0.00s)
=== RUN   TestForbiddenWithoutInvalidAuthTokenDoesNotReauth
--- PASS: TestForbiddenWithoutInvalidAuthTokenDoesNotReauth (0.00s)
PASS

Process finished with the exit code 0
```