### PR TITLE
[Feat.] ECS: description option

### DIFF
--- a/acceptance/openstack/common.go
+++ b/acceptance/openstack/common.go
@@ -153,11 +153,13 @@ func GetCloudServerCreateOpts(t *testing.T) cloudservers.CreateOpts {
 		t.Skip("One of OS_VPC_ID, OS_NETWORK_ID or OS_AVAILABILITY_ZONE env vars is missing but ECSv1 test requires")
 	}
 
+	ecsDescription := "ecs created by acc test"
 	createOpts := cloudservers.CreateOpts{
-		ImageRef:  image[0].Id,
-		FlavorRef: flavorID,
-		Name:      ecsName,
-		VpcId:     vpcID,
+		ImageRef:    image[0].Id,
+		FlavorRef:   flavorID,
+		Name:        ecsName,
+		Description: &ecsDescription,
+		VpcId:       vpcID,
 		Nics: []cloudservers.Nic{
 			{
 				SubnetId: subnetID,

--- a/acceptance/openstack/ecs/v1/cloudservers_test.go
+++ b/acceptance/openstack/ecs/v1/cloudservers_test.go
@@ -30,6 +30,10 @@ func TestCloudServerLifecycle(t *testing.T) {
 	ecs := openstack.CreateCloudServer(t, client, createOpts)
 	defer openstack.DeleteCloudServer(t, client, ecs.ID)
 
+	// Verify description set during creation
+	th.AssertEquals(t, "ecs created by acc test", ecs.Description)
+	t.Logf("ECS created with description: %s", ecs.Description)
+
 	// Update ECSv1 instance
 	newName := tools.RandomString("ecs-updated-", 3)
 	newDescription := "updated ecs description"
@@ -41,6 +45,11 @@ func TestCloudServerLifecycle(t *testing.T) {
 	th.AssertEquals(t, newName, updated.Name)
 	th.AssertEquals(t, newDescription, updated.Description)
 	t.Logf("Successfully updated ECS name to %s", updated.Name)
+
+	// Verify updated description via Get
+	getEcs, err := cloudservers.Get(client, ecs.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, newDescription, getEcs.Description)
 
 	tagsList := []tags.ResourceTag{
 		{

--- a/openstack/ecs/v1/cloudservers/requests.go
+++ b/openstack/ecs/v1/cloudservers/requests.go
@@ -16,6 +16,10 @@ type CreateOpts struct {
 	// Name of the ECS instance.
 	Name string `json:"name" required:"true"`
 
+	// Description of the ECS instance.
+	// The value consists of 0 to 85 characters. Angle brackets (<>) are not allowed.
+	Description *string `json:"description,omitempty"`
+
 	// UserData to be injected during the ECS creation process.
 	UserData []byte `json:"-"`
 


### PR DESCRIPTION
### What this PR does / why we need it
Refers to: [#3383](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3383).

### Acceptance tests
```
=== RUN   TestCloudServerLifecycle
    common.go:192: Attempting to check ECSv1 createOpts
    cloudservers_test.go:27: CreateOpts are ok for creating a cloudServer
    cloudservers_test.go:30: Attempting to create ECSv1
    cloudservers_test.go:30: Created ECSv1 instance: f3ff5fc2-126f-499e-9866-7a09b9ab8c99
    cloudservers_test.go:35: ECS created with description: ecs created by acc test
    cloudservers_test.go:47: Successfully updated ECS name to ecs-updated-59b
    common.go:218: Attempting to delete ECSv1: f3ff5fc2-126f-499e-9866-7a09b9ab8c99
    common.go:235: ECSv1 instance deleted: f3ff5fc2-126f-499e-9866-7a09b9ab8c99
--- PASS: TestCloudServerLifecycle (88.89s)
PASS

Process finished with the exit code 0
```