### PR TITLE
FGS: remove omitempty for `init_handler` and `init_timeout`

### DIFF
--- a/acceptance/openstack/fgs/v2/functiongraph_test.go
+++ b/acceptance/openstack/fgs/v2/functiongraph_test.go
@@ -8,6 +8,7 @@ import (
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
 	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
 	"github.com/opentelekomcloud/gophertelekomcloud/openstack/fgs/v2/function"
 	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
 )
@@ -127,6 +128,56 @@ func TestFunctionGraphList(t *testing.T) {
 	listOpts := function.ListOpts{}
 	_, err = function.List(client, listOpts)
 	th.AssertNoErr(t, err)
+}
+
+func TestFunctionGraphInitializerDisable(t *testing.T) {
+	client, err := clients.NewFuncGraphClient()
+	th.AssertNoErr(t, err)
+
+	createResp, funcName := createFunctionGraph(t, client)
+
+	funcUrn := strings.TrimSuffix(createResp.FuncURN, ":latest")
+
+	defer func(client *golangsdk.ServiceClient, id string) {
+		err = function.Delete(client, id)
+		th.AssertNoErr(t, err)
+	}(client, funcUrn)
+
+	// Enable initialization
+	_, err = function.UpdateFuncMetadata(client, function.UpdateFuncMetadataOpts{
+		FuncUrn:     funcUrn,
+		Name:        funcName,
+		Runtime:     "Python3.9",
+		Timeout:     200,
+		Handler:     "index.handler",
+		MemorySize:  512,
+		InitHandler: "index.initializer",
+		InitTimeout: pointerto.Int(30),
+	})
+	th.AssertNoErr(t, err)
+
+	meta, err := function.GetMetadata(client, funcUrn)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "index.initializer", meta.InitHandler)
+	th.AssertEquals(t, 30, meta.InitTimeout)
+
+	// Disable initialization by passing empty values
+	_, err = function.UpdateFuncMetadata(client, function.UpdateFuncMetadataOpts{
+		FuncUrn:     funcUrn,
+		Name:        funcName,
+		Runtime:     "Python3.9",
+		Timeout:     200,
+		Handler:     "index.handler",
+		MemorySize:  512,
+		InitHandler: "",
+		InitTimeout: nil,
+	})
+	th.AssertNoErr(t, err)
+
+	meta, err = function.GetMetadata(client, funcUrn)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "", meta.InitHandler)
+	th.AssertEquals(t, 0, meta.InitTimeout)
 }
 
 func createFunctionGraph(t *testing.T, client *golangsdk.ServiceClient) (*function.FuncGraph, string) {

--- a/openstack/fgs/v2/function/UpdateMetadata.go
+++ b/openstack/fgs/v2/function/UpdateMetadata.go
@@ -25,8 +25,8 @@ type UpdateFuncMetadataOpts struct {
 	CustomImage          *CustomImage          `json:"custom_image,omitempty"`
 	Package              string                `json:"package"`
 	ExtendConfig         string                `json:"extend_config,omitempty"`
-	InitHandler          string                `json:"initializer_handler,omitempty"`
-	InitTimeout          *int                  `json:"initializer_timeout,omitempty"`
+	InitHandler          string                `json:"initializer_handler"`
+	InitTimeout          *int                  `json:"initializer_timeout"`
 	PreStopHandler       string                `json:"pre_stop_handler,omitempty"`
 	PreStopTimeout       *int                  `json:"pre_stop_timeout,omitempty"`
 	EphemeralStorage     *int                  `json:"ephemeral_storage,omitempty"`


### PR DESCRIPTION
### Acceptance tests
```
=== RUN   TestFunctionGraphListAliases
--- PASS: TestFunctionGraphListAliases (4.17s)
=== RUN   TestFunctionGraphLifecycle
--- PASS: TestFunctionGraphLifecycle (2.56s)
=== RUN   TestFunctionGraphExports
    functiongraph_test.go:105: Attempting to EXPORT FUNCGRAPH
--- PASS: TestFunctionGraphExports (1.55s)
=== RUN   TestFunctionGraphList
--- PASS: TestFunctionGraphList (0.85s)
=== RUN   TestFunctionGraphInitializerDisable
--- PASS: TestFunctionGraphInitializerDisable (3.06s)
=== RUN   TestFunctionGraphListReserved
    reserved_test.go:20: Attempting to LIST FUNCGRAPH RESERVED INSTANCE CONFIGURATION
    tools.go:75: {
          "reserved_instances": null,
          "page_info": null,
          "count": 0
        }
    reserved_test.go:25: Attempting to LIST FUNCGRAPH RESERVED INSTANCES
    tools.go:75: {
          "reservedinstances": [],
          "page_info": {
            "next_marker": 0,
            "previous_marker": 0,
            "current_count": 0
          },
          "count": 0
        }
--- PASS: TestFunctionGraphListReserved (0.80s)
PASS

Process finished with the exit code 0
```