### PR TITLE
[Fix] OBS: Preserve OBS signature for path-style / dotted buckets

### DIFF
--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -588,9 +588,10 @@ func NewOBSClientWithoutHeader() (*obs.ObsClient, error) {
 		return nil, err
 	}
 	opts := cc.AKSKAuthOptions
+	// Pinned to V2 to keep its pre-default-change behavior (not the OBS default).
 	return obs.New(
 		opts.AccessKey, opts.SecretKey, client.Endpoint,
-		obs.WithSecurityToken(opts.SecurityToken),
+		obs.WithSecurityToken(opts.SecurityToken), obs.WithSignature(obs.SignatureV2),
 	)
 }
 

--- a/acceptance/openstack/obs/v1/bucket/obs_path_style_test.go
+++ b/acceptance/openstack/obs/v1/bucket/obs_path_style_test.go
@@ -1,0 +1,43 @@
+package bucket
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/obs"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+// A dotted bucket (auto path-style) must still serve SSE KMS, which needs x-obs-*
+// headers — i.e. the OBS signature is kept, not downgraded to V2.
+func TestObsPathStyleSSEKMS(t *testing.T) {
+	// No WithPathStyle: the dotted bucket name alone must trigger path-style.
+	client, err := clients.NewOBSClient()
+	th.AssertNoErr(t, err)
+
+	bucketName := strings.ToLower(tools.RandomString("obs-sdk", 5)) + ".path.style"
+
+	_, err = client.CreateBucket(&obs.CreateBucketInput{
+		Bucket: bucketName,
+	})
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		_, err = client.DeleteBucket(bucketName)
+		th.AssertNoErr(t, err)
+	})
+
+	// Fails if path-style had silently downgraded the signature to V2.
+	_, err = client.SetBucketEncryption(&obs.SetBucketEncryptionInput{
+		Bucket: bucketName,
+		BucketEncryptionConfiguration: obs.BucketEncryptionConfiguration{
+			SSEAlgorithm: "kms",
+		},
+	})
+	th.AssertNoErr(t, err)
+
+	encryption, err := client.GetBucketEncryption(bucketName)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, encryption.SSEAlgorithm, "kms")
+}

--- a/openstack/obs/conf.go
+++ b/openstack/obs/conf.go
@@ -213,10 +213,6 @@ func (conf *config) prepareConfig() {
 	if conf.maxRedirectCount < 0 {
 		conf.maxRedirectCount = DEFAULT_MAX_REDIRECT_COUNT
 	}
-
-	if conf.pathStyle && conf.signature == SignatureObs {
-		conf.signature = SignatureV2
-	}
 }
 
 func (conf *config) initConfigWithDefault() error {
@@ -343,7 +339,10 @@ func (conf *config) prepareBaseURL(bucketName string) (requestURL string, canoni
 			requestURL = fmt.Sprintf("%s://%s:%d", urlHolder.scheme, urlHolder.host, urlHolder.port)
 			canonicalizedURL = "/"
 		} else {
-			if conf.pathStyle {
+			// Dotted bucket names must use path-style: their virtual-hosted URL
+			// isn't covered by the *.<host> wildcard cert and TLS would fail.
+			usePathStyle := conf.pathStyle || strings.Contains(bucketName, ".")
+			if usePathStyle {
 				requestURL = fmt.Sprintf("%s://%s:%d/%s", urlHolder.scheme, urlHolder.host, urlHolder.port, bucketName)
 				canonicalizedURL = "/" + bucketName
 			} else {

--- a/openstack/obs/conf_test.go
+++ b/openstack/obs/conf_test.go
@@ -1,0 +1,65 @@
+package obs
+
+import (
+	"strings"
+	"testing"
+)
+
+// A client without WithSignature must default to the OBS signature.
+func TestDefaultSignatureIsObs(t *testing.T) {
+	client, err := New("ak", "sk", "https://obs.eu-de.otc.t-systems.com")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	if client.conf.signature != SignatureObs {
+		t.Errorf("expected default signature %q, got %q", SignatureObs, client.conf.signature)
+	}
+}
+
+// path-style must not downgrade the OBS signature to V2 (SSE KMS needs x-obs-*).
+func TestPathStyleKeepsObsSignature(t *testing.T) {
+	client, err := New("ak", "sk", "https://obs.eu-de.otc.t-systems.com",
+		WithPathStyle(true), WithSignature(SignatureObs))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	if !client.conf.pathStyle {
+		t.Errorf("expected pathStyle to be true")
+	}
+	if client.conf.signature != SignatureObs {
+		t.Errorf("expected signature %q, got %q", SignatureObs, client.conf.signature)
+	}
+}
+
+// A dotted bucket name must use path-style automatically (its virtual-hosted
+// URL isn't covered by the wildcard cert), while a dotless one stays virtual-hosted.
+func TestDottedBucketUsesPathStyle(t *testing.T) {
+	const host = "obs.eu-de.otc.t-systems.com"
+	client, err := New("ak", "sk", "https://"+host, WithSignature(SignatureObs))
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	// pathStyle is off, but a dotted bucket must still go path-style.
+	if client.conf.pathStyle {
+		t.Fatalf("expected pathStyle to be false by default")
+	}
+
+	requestURL, canonicalizedURL := client.conf.formatUrls("department.service.development", "", nil, true)
+	if !strings.HasPrefix(requestURL, "https://"+host) {
+		t.Errorf("expected host-rooted path-style URL, got %q", requestURL)
+	}
+	if !strings.Contains(requestURL, host+":443/department.service.development") {
+		t.Errorf("expected bucket in the path, got %q", requestURL)
+	}
+	if canonicalizedURL != "/department.service.development" {
+		t.Errorf("unexpected canonicalized URL %q", canonicalizedURL)
+	}
+
+	// A dotless bucket stays virtual-hosted.
+	plainURL, _ := client.conf.formatUrls("plainbucket", "", nil, true)
+	if !strings.HasPrefix(plainURL, "https://plainbucket."+host) {
+		t.Errorf("expected virtual-hosted URL for a dotless bucket, got %q", plainURL)
+	}
+}

--- a/openstack/obs/const.go
+++ b/openstack/obs/const.go
@@ -129,7 +129,8 @@ const (
 	PARAM_SIGNEDHEADERS_AMZ_CAMEL = "X-Amz-SignedHeaders"
 	PARAM_SIGNATURE_AMZ_CAMEL     = "X-Amz-Signature"
 
-	DEFAULT_SIGNATURE            = SignatureV2
+	// OTC OBS uses the OBS-native signature, so default to it.
+	DEFAULT_SIGNATURE            = SignatureObs
 	DEFAULT_REGION               = "region"
 	DEFAULT_CONNECT_TIMEOUT      = 60
 	DEFAULT_SOCKET_TIMEOUT       = 60


### PR DESCRIPTION
### Acceptance tests
```
=== RUN   TestObsBucketLifecycleAcl
    obs_acl_test.go:17: OS_DOMAIN_ID is mandatory for this test
--- SKIP: TestObsBucketLifecycleAcl (0.00s)

Test ignored.
=== RUN   TestObsBucketLifecycle
--- PASS: TestObsBucketLifecycle (1.73s)
=== RUN   TestObsParralelFSBucketLifecycle
--- PASS: TestObsParralelFSBucketLifecycle (1.99s)
=== RUN   TestObsBucketLifecycleConfigurationBasic
--- PASS: TestObsBucketLifecycleConfigurationBasic (2.08s)
=== RUN   TestObsBucketLifecycleConfigurationFilter
--- PASS: TestObsBucketLifecycleConfigurationFilter (2.61s)
PASS

Process finished with the exit code 0

=== RUN   TestObsPolicyLifecycle
--- PASS: TestObsPolicyLifecycle (2.05s)
PASS

Process finished with the exit code 0


```