### PR TITLE
[Feat] Add sso_type to opentelekomcloud_identity_provider_v3

### DIFF
--- a/openstack/identity/v3/federation/providers/requests.go
+++ b/openstack/identity/v3/federation/providers/requests.go
@@ -16,6 +16,10 @@ type CreateOpts struct {
 	ID          string `json:"-"`
 	Description string `json:"description,omitempty"`
 	Enabled     bool   `json:"enabled,omitempty"`
+	// SSOType is the SSO type of the identity provider. Allowed values are
+	// "virtual_user_sso" (default on the API side) and "iam_user_sso".
+	// It is set only on creation and cannot be modified afterwards.
+	SSOType string `json:"sso_type,omitempty"`
 }
 
 func (opts CreateOpts) ToProviderCreateMap() (map[string]interface{}, error) {

--- a/openstack/identity/v3/federation/providers/results.go
+++ b/openstack/identity/v3/federation/providers/results.go
@@ -9,6 +9,7 @@ type Provider struct {
 	ID          string            `json:"id"`
 	Description string            `json:"description"`
 	Enabled     bool              `json:"enabled"`
+	SSOType     string            `json:"sso_type"`
 	RemoteIDs   []string          `json:"remote_ids"`
 	Links       map[string]string `json:"links"`
 }

--- a/openstack/identity/v3/federation/providers/testing/fixtures.go
+++ b/openstack/identity/v3/federation/providers/testing/fixtures.go
@@ -8,6 +8,7 @@ import (
 const (
 	providerID          = "ACME"
 	providerDescription = "Stores ACME identities"
+	providerSSOType     = "iam_user_sso"
 
 	listURI = "/OS-FEDERATION/identity_providers"
 )
@@ -21,6 +22,7 @@ var (
         "description": "%s",
         "enabled": true,
         "id": "%s",
+        "sso_type": "%s",
         "remote_ids": [],
         "links": {
             "protocols": "https://example.com/v3/OS-FEDERATION/identity_providers/ACME/protocols",
@@ -28,7 +30,7 @@ var (
         }
     }
 }
-`, providerDescription, providerID)
+`, providerDescription, providerID, providerSSOType)
 
 	providerListResponse = fmt.Sprintf(`
 {

--- a/openstack/identity/v3/federation/providers/testing/requests_test.go
+++ b/openstack/identity/v3/federation/providers/testing/requests_test.go
@@ -27,11 +27,13 @@ func TestProviderCreateRequest(t *testing.T) {
 		ID:          providerID,
 		Description: providerDescription,
 		Enabled:     true,
+		SSOType:     providerSSOType,
 	}
 	p, err := providers.Create(fake.ServiceClient(), opts).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, opts.ID, p.ID)
 	th.AssertEquals(t, opts.Enabled, p.Enabled)
+	th.AssertEquals(t, providerSSOType, p.SSOType)
 	th.AssertEquals(t, 0, len(p.RemoteIDs))
 }
 
@@ -50,6 +52,7 @@ func TestProviderGetRequest(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, true, p.Enabled)
 	th.AssertEquals(t, providerDescription, p.Description)
+	th.AssertEquals(t, providerSSOType, p.SSOType)
 }
 
 func TestProviderListRequest(t *testing.T) {


### PR DESCRIPTION
### What this PR does / why we need it
The opentelekomcloud_identity_provider_v3 resource does not support the sso_type attribute when creating an identity provider. The API supports it but the sdk does not allow to provision it. This issue adds the sso_type parameter when creating the identity provider

### Which issue this PR fixes
Fixes # 946 (https://github.com/opentelekomcloud/gophertelekomcloud/issues/946)

### Special notes for your reviewer
There are two PRs that need to be checked in tandem, one in SDK and one in terraform provider. They both correspond to the same issue i.e. ability to add sso_type parameter during identity provider creation.