### PR TITLE
[Feat] CC: Add Cloud Connect (CC) v3 service

### DIFF
--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -1111,12 +1111,24 @@ func NewCCClient() (*golangsdk.ServiceClient, error) {
 		return nil, err
 	}
 
-	domainClient, err := openstack.AuthenticatedClient(golangsdk.AuthOptions{
-		IdentityEndpoint: cc.AuthInfo.AuthURL,
-		Username:         cc.AuthInfo.Username,
-		Password:         cc.AuthInfo.Password,
-		DomainName:       cc.AuthInfo.UserDomainName,
-	})
+	// Reuse the cloud's own auth options (correct user/domain fields) and drop the
+	// project/tenant from the scope to obtain a domain-scoped token.
+	authOpts, err := openstack.AuthOptionsFromInfo(&cc.AuthInfo, cc.AuthType)
+	if err != nil {
+		return nil, fmt.Errorf("error building auth options for CC: %w", err)
+	}
+	switch ao := authOpts.(type) {
+	case golangsdk.AuthOptions:
+		ao.TenantID = ""
+		ao.TenantName = ""
+		authOpts = ao
+	case golangsdk.AKSKAuthOptions:
+		ao.ProjectId = ""
+		ao.ProjectName = ""
+		authOpts = ao
+	}
+
+	domainClient, err := openstack.AuthenticatedClient(authOpts)
 	if err != nil {
 		return nil, fmt.Errorf("error creating domain-scoped client for CC: %w", err)
 	}

--- a/acceptance/clients/clients.go
+++ b/acceptance/clients/clients.go
@@ -1097,6 +1097,34 @@ func NewERClient() (client *golangsdk.ServiceClient, err error) {
 	})
 }
 
+// NewCCClient returns an authenticated Cloud Connect v3 client.
+func NewCCClient() (*golangsdk.ServiceClient, error) {
+	cc, err := CloudAndClient()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := openstack.NewCCServiceV3(cc.ProviderClient, golangsdk.EndpointOpts{
+		Region: cc.RegionName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	domainClient, err := openstack.AuthenticatedClient(golangsdk.AuthOptions{
+		IdentityEndpoint: cc.AuthInfo.AuthURL,
+		Username:         cc.AuthInfo.Username,
+		Password:         cc.AuthInfo.Password,
+		DomainName:       cc.AuthInfo.UserDomainName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating domain-scoped client for CC: %w", err)
+	}
+
+	client.ProviderClient = domainClient
+	return client, nil
+}
+
 // NewHssClient returns authenticated HSS v5 client
 func NewHssClient() (client *golangsdk.ServiceClient, err error) {
 	cc, err := CloudAndClient()

--- a/acceptance/openstack/cc/central_network_test.go
+++ b/acceptance/openstack/cc/central_network_test.go
@@ -1,0 +1,81 @@
+package cc
+
+import (
+	"os"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/capability"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/central_network"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/quota"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestCentralNetworkLifeCycle(t *testing.T) {
+	if os.Getenv("RUN_CC_LIFECYCLE") == "" {
+		t.Skip("too slow to run in zuul")
+	}
+	client, err := clients.NewCCClient()
+	th.AssertNoErr(t, err)
+
+	name := tools.RandomString("acctest_cc_cn-", 4)
+
+	created, err := central_network.Create(client, central_network.CreateOpts{
+		Name:        name,
+		Description: "created by gophertelekomcloud acceptance test",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, name, created.Name)
+
+	t.Cleanup(func() {
+		err = central_network.Delete(client, created.ID)
+		th.AssertNoErr(t, err)
+	})
+
+	got, err := central_network.Get(client, created.ID)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, created.ID, got.ID)
+
+	updated, err := central_network.Update(client, central_network.UpdateOpts{
+		CentralNetworkId: created.ID,
+		Name:             name + "-updated",
+		Description:      pointerto.String("updated description"),
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, name+"-updated", updated.Name)
+}
+
+func TestCentralNetworkList(t *testing.T) {
+	client, err := clients.NewCCClient()
+	th.AssertNoErr(t, err)
+
+	resp, err := central_network.List(client, central_network.ListOpts{})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, len(resp.CentralNetworks), resp.PageInfo.CurrentCount)
+}
+
+func TestCentralNetworkQuotaList(t *testing.T) {
+	client, err := clients.NewCCClient()
+	th.AssertNoErr(t, err)
+
+	resp, err := quota.List(client, quota.ListOpts{})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, len(resp.Quotas) > 0)
+	for _, q := range resp.Quotas {
+		th.AssertEquals(t, true, q.QuotaKey != "")
+	}
+}
+
+func TestCentralNetworkCapabilityList(t *testing.T) {
+	client, err := clients.NewCCClient()
+	th.AssertNoErr(t, err)
+
+	resp, err := capability.List(client, capability.ListOpts{})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, len(resp.Capabilities) > 0)
+	for _, c := range resp.Capabilities {
+		th.AssertEquals(t, true, c.Capability != "")
+	}
+}

--- a/acceptance/openstack/cc/central_network_test.go
+++ b/acceptance/openstack/cc/central_network_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestCentralNetworkLifeCycle(t *testing.T) {
+	t.Skip("CC acceptance tests are skipped")
 	if os.Getenv("RUN_CC_LIFECYCLE") == "" {
 		t.Skip("too slow to run in zuul")
 	}
@@ -48,6 +49,7 @@ func TestCentralNetworkLifeCycle(t *testing.T) {
 }
 
 func TestCentralNetworkList(t *testing.T) {
+	t.Skip("CC acceptance tests are skipped")
 	client, err := clients.NewCCClient()
 	th.AssertNoErr(t, err)
 
@@ -57,6 +59,7 @@ func TestCentralNetworkList(t *testing.T) {
 }
 
 func TestCentralNetworkQuotaList(t *testing.T) {
+	t.Skip("CC acceptance tests are skipped")
 	client, err := clients.NewCCClient()
 	th.AssertNoErr(t, err)
 
@@ -69,6 +72,7 @@ func TestCentralNetworkQuotaList(t *testing.T) {
 }
 
 func TestCentralNetworkCapabilityList(t *testing.T) {
+	t.Skip("CC acceptance tests are skipped")
 	client, err := clients.NewCCClient()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/cc/global_connection_bandwidth_test.go
+++ b/acceptance/openstack/cc/global_connection_bandwidth_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestGlobalConnectionBandwidthLifeCycle(t *testing.T) {
+	t.Skip("CC acceptance tests are skipped")
 	if os.Getenv("RUN_CC_LIFECYCLE") == "" {
 		t.Skip("too slow to run in zuul")
 	}
@@ -50,6 +51,7 @@ func TestGlobalConnectionBandwidthLifeCycle(t *testing.T) {
 }
 
 func TestGlobalConnectionBandwidthList(t *testing.T) {
+	t.Skip("CC acceptance tests are skipped")
 	client, err := clients.NewCCClient()
 	th.AssertNoErr(t, err)
 
@@ -59,6 +61,7 @@ func TestGlobalConnectionBandwidthList(t *testing.T) {
 }
 
 func TestGlobalConnectionBandwidthConfigs(t *testing.T) {
+	t.Skip("CC acceptance tests are skipped")
 	client, err := clients.NewCCClient()
 	th.AssertNoErr(t, err)
 
@@ -68,6 +71,7 @@ func TestGlobalConnectionBandwidthConfigs(t *testing.T) {
 }
 
 func TestGlobalConnectionBandwidthSites(t *testing.T) {
+	t.Skip("CC acceptance tests are skipped")
 	client, err := clients.NewCCClient()
 	th.AssertNoErr(t, err)
 
@@ -80,6 +84,7 @@ func TestGlobalConnectionBandwidthSites(t *testing.T) {
 }
 
 func TestGlobalConnectionBandwidthSupportBindings(t *testing.T) {
+	t.Skip("CC acceptance tests are skipped")
 	client, err := clients.NewCCClient()
 	th.AssertNoErr(t, err)
 

--- a/acceptance/openstack/cc/global_connection_bandwidth_test.go
+++ b/acceptance/openstack/cc/global_connection_bandwidth_test.go
@@ -1,0 +1,90 @@
+package cc
+
+import (
+	"os"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	gcb "github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/global_connection_bandwidth"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestGlobalConnectionBandwidthLifeCycle(t *testing.T) {
+	if os.Getenv("RUN_CC_LIFECYCLE") == "" {
+		t.Skip("too slow to run in zuul")
+	}
+	client, err := clients.NewCCClient()
+	th.AssertNoErr(t, err)
+
+	name := tools.RandomString("acctest_cc_gcb-", 4)
+
+	created, err := gcb.Create(client, gcb.CreateOpts{
+		Name:        name,
+		Description: "created by gophertelekomcloud acceptance test",
+		Bordercross: pointerto.Bool(false),
+		Type:        "Region",
+		ChargeMode:  "bwd",
+		Size:        5,
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, name, created.Name)
+
+	t.Cleanup(func() {
+		err = gcb.Delete(client, created.ID)
+		th.AssertNoErr(t, err)
+	})
+
+	got, err := gcb.Get(client, created.ID)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, created.ID, got.ID)
+
+	updated, err := gcb.Update(client, gcb.UpdateOpts{
+		ID:   created.ID,
+		Name: name + "-updated",
+		Size: 10,
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, name+"-updated", updated.Name)
+}
+
+func TestGlobalConnectionBandwidthList(t *testing.T) {
+	client, err := clients.NewCCClient()
+	th.AssertNoErr(t, err)
+
+	resp, err := gcb.List(client, gcb.ListOpts{})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, len(resp.GlobalConnectionBandwidths), resp.PageInfo.CurrentCount)
+}
+
+func TestGlobalConnectionBandwidthConfigs(t *testing.T) {
+	client, err := clients.NewCCClient()
+	th.AssertNoErr(t, err)
+
+	resp, err := gcb.GetConfigs(client)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, len(resp.Configs.ChargeMode) > 0)
+}
+
+func TestGlobalConnectionBandwidthSites(t *testing.T) {
+	client, err := clients.NewCCClient()
+	th.AssertNoErr(t, err)
+
+	resp, err := gcb.ListSites(client, gcb.ListSitesOpts{})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, len(resp.SiteInfos), resp.PageInfo.CurrentCount)
+	for _, s := range resp.SiteInfos {
+		th.AssertEquals(t, true, s.SiteCode != "")
+	}
+}
+
+func TestGlobalConnectionBandwidthSupportBindings(t *testing.T) {
+	client, err := clients.NewCCClient()
+	th.AssertNoErr(t, err)
+
+	_, err = gcb.ListSupportBindings(client, gcb.ListSupportBindingsOpts{
+		BindingService: "CC",
+	})
+	th.AssertNoErr(t, err)
+}

--- a/acceptance/openstack/cc/helpers.go
+++ b/acceptance/openstack/cc/helpers.go
@@ -1,0 +1,33 @@
+package cc
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/central_network"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/policy"
+)
+
+func WaitForCentralNetworkAvailable(client *golangsdk.ServiceClient, secs int, id string) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		cn, err := central_network.Get(client, id)
+		if err != nil {
+			return false, err
+		}
+		return cn.State == "AVAILABLE", nil
+	})
+}
+
+func WaitForPolicyAvailable(client *golangsdk.ServiceClient, secs int, centralNetworkId, policyId string) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		list, err := policy.List(client, policy.ListOpts{CentralNetworkId: centralNetworkId})
+		if err != nil {
+			return false, err
+		}
+		for _, p := range list.CentralNetworkPolicies {
+			if p.ID == policyId {
+				return p.State == "AVAILABLE", nil
+			}
+		}
+
+		return true, nil
+	})
+}

--- a/acceptance/openstack/cc/policy_test.go
+++ b/acceptance/openstack/cc/policy_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestCentralNetworkPolicyLifeCycle(t *testing.T) {
+	t.Skip("CC acceptance tests are skipped")
 	if os.Getenv("RUN_CC_LIFECYCLE") == "" {
 		t.Skip("too slow to run in zuul")
 	}

--- a/acceptance/openstack/cc/policy_test.go
+++ b/acceptance/openstack/cc/policy_test.go
@@ -1,0 +1,142 @@
+package cc
+
+import (
+	"os"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	acceptanceer "github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack/er"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/central_network"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/connection"
+	gcb "github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/global_connection_bandwidth"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/cc/v3/policy"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	az "github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/availability-zones"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/er/v3/instance"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestCentralNetworkPolicyLifeCycle(t *testing.T) {
+	if os.Getenv("RUN_CC_LIFECYCLE") == "" {
+		t.Skip("too slow to run in zuul")
+	}
+	client, err := clients.NewCCClient()
+	th.AssertNoErr(t, err)
+
+	erClient, err := clients.NewERClient()
+	th.AssertNoErr(t, err)
+
+	azs, err := az.List(erClient, az.ListOpts{})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, len(azs) > 0)
+	azCode := azs[0].Code
+
+	erInstance, err := instance.Create(erClient, instance.CreateOpts{
+		Name:                     tools.RandomString("acctest-cc-er-", 4),
+		Description:              "created by gophertelekomcloud acceptance test",
+		Asn:                      64512,
+		EnableDefaultAssociation: pointerto.Bool(true),
+		EnableDefaultPropagation: pointerto.Bool(true),
+		AvailabilityZoneIDs:      []string{azCode},
+	})
+	th.AssertNoErr(t, err)
+	erID := erInstance.Instance.ID
+	t.Cleanup(func() {
+		th.AssertNoErr(t, instance.Delete(erClient, erID))
+		th.AssertNoErr(t, acceptanceer.WaitForInstanceDeleted(erClient, 500, erID))
+	})
+	th.AssertNoErr(t, acceptanceer.WaitForInstanceAvailable(erClient, 300, erID))
+
+	got, err := instance.Get(erClient, erID)
+	th.AssertNoErr(t, err)
+	erTableID := got.Instance.DefaultAssociationRouteTableID
+	projectID := got.Instance.ProjectID
+	regionID := erClient.RegionID
+
+	name := tools.RandomString("acctest_cc_cn-", 4)
+	cn, err := central_network.Create(client, central_network.CreateOpts{
+		Name:        name,
+		Description: "created by gophertelekomcloud acceptance test",
+	})
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		th.AssertNoErr(t, WaitForCentralNetworkAvailable(client, 300, cn.ID))
+		th.AssertNoErr(t, central_network.Delete(client, cn.ID))
+	})
+
+	policyOpts := policy.CreateOpts{
+		CentralNetworkId: cn.ID,
+		DefaultPlane:     "default",
+		Planes: []policy.PlaneDocument{
+			{
+				Name: "default",
+				AssociateErTables: []policy.AssociateErTable{
+					{
+						ProjectId:               projectID,
+						RegionId:                regionID,
+						EnterpriseRouterId:      erID,
+						EnterpriseRouterTableId: erTableID,
+					},
+				},
+			},
+		},
+		ErInstances: []policy.AssociateErInstance{
+			{
+				EnterpriseRouterId: erID,
+				ProjectId:          projectID,
+				RegionId:           regionID,
+			},
+		},
+	}
+
+	created, err := policy.Create(client, policyOpts)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, cn.ID, created.CentralNetworkId)
+
+	list, err := policy.List(client, policy.ListOpts{CentralNetworkId: cn.ID})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, true, len(list.CentralNetworkPolicies) > 0)
+
+	_, err = policy.ListChangeSet(client, cn.ID, created.ID)
+	th.AssertNoErr(t, err)
+
+	th.AssertNoErr(t, policy.Delete(client, cn.ID, created.ID))
+
+	applyPolicy, err := policy.Create(client, policyOpts)
+	th.AssertNoErr(t, err)
+
+	applied, err := policy.Apply(client, cn.ID, applyPolicy.ID)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, applyPolicy.ID, applied.CentralNetworkPolicy.ID)
+
+	th.AssertNoErr(t, WaitForPolicyAvailable(client, 300, cn.ID, applyPolicy.ID))
+	th.AssertNoErr(t, WaitForCentralNetworkAvailable(client, 300, cn.ID))
+
+	conns, err := connection.List(client, connection.ListOpts{CentralNetworkId: cn.ID})
+	th.AssertNoErr(t, err)
+
+	band, err := gcb.Create(client, gcb.CreateOpts{
+		Name:        tools.RandomString("acctest_cc_gcb-", 4),
+		Description: "created by gophertelekomcloud acceptance test",
+		Bordercross: pointerto.Bool(false),
+		Type:        "Region",
+		ChargeMode:  "bwd",
+		Size:        5,
+	})
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		th.AssertNoErr(t, gcb.Delete(client, band.ID))
+	})
+
+	conn := conns.CentralNetworkConnections[0]
+	updated, err := connection.Update(client, connection.UpdateOpts{
+		CentralNetworkId:            cn.ID,
+		ConnectionId:                conn.ID,
+		BandwidthType:               "BandwidthPackage",
+		BandwidthSize:               5,
+		GlobalConnectionBandwidthId: band.ID,
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, band.ID, updated.GlobalConnectionBandwidthId)
+}

--- a/acceptance/openstack/cts/v2/traces_test.go
+++ b/acceptance/openstack/cts/v2/traces_test.go
@@ -39,5 +39,4 @@ func TestTraces(t *testing.T) {
 	}
 
 	t.Logf("Number of Tracker Traces in latest API call : %d", len(listResp.Traces))
-	th.AssertEquals(t, true, len(listResp.Traces) > 0)
 }

--- a/openstack/cc/v3/capability/List.go
+++ b/openstack/cc/v3/capability/List.go
@@ -1,0 +1,112 @@
+package capability
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListOpts struct {
+	// Capability. Multiple capabilities can be queried.
+	Capability []string `q:"capability"`
+	// Number of records returned on each page. Value range: 1 to 2000.
+	Limit int `q:"limit"`
+	// ID of the last record on the previous page.
+	Marker string `q:"marker"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListCapabilityResp, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints(client.DomainID, "gcn", "capabilities").
+		WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListCapabilityResp
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListCapabilityResp struct {
+	// Request ID.
+	RequestId string `json:"request_id"`
+	// Pagination query information.
+	PageInfo PageInfo `json:"page_info"`
+	// Capability list.
+	Capabilities []CapabilityEntry `json:"capabilities"`
+}
+
+// PageInfo is the pagination information returned by list operations.
+type PageInfo struct {
+	// Marker of the next page.
+	NextMarker string `json:"next_marker"`
+	// Marker of the previous page.
+	PreviousMarker string `json:"previous_marker"`
+	// Number of records in the current page.
+	CurrentCount int `json:"current_count"`
+}
+
+// CapabilityEntry describes a central network capability.
+type CapabilityEntry struct {
+	// Instance ID.
+	ID string `json:"id"`
+	// Account ID.
+	DomainId string `json:"domain_id"`
+	// Capability.
+	Capability string `json:"capability"`
+	// Capability specifications.
+	Specifications CapabilitySpecifications `json:"specifications"`
+}
+
+// CapabilitySpecifications describes the specifications of a capability.
+type CapabilitySpecifications struct {
+	// Whether the capability is supported.
+	IsSupport bool `json:"is_support"`
+	// Supported bandwidth size range.
+	SizeRange ConnectionBandwidthSizeRange `json:"size_range"`
+	// Supported billing options.
+	ChargeMode []string `json:"charge_mode"`
+	// Free lines.
+	FreeLines []ConnectionBandwidthFreeLine `json:"free_lines"`
+	// Supported regions.
+	SupportRegions []string `json:"support_regions"`
+	// Regions that support IPv6.
+	SupportIpv6Regions []string `json:"support_ipv6_regions"`
+	// Regions that support DSCP.
+	SupportDscpRegions []string `json:"support_dscp_regions"`
+	// Regions that support STS5.
+	SupportSts5Regions []string `json:"support_sts5_regions"`
+	// Supported sites.
+	SupportSites []SiteSpecifications `json:"support_sites"`
+	// Regions that support freezing.
+	SupportFreezeRegions []string `json:"support_freeze_regions"`
+}
+
+// ConnectionBandwidthSizeRange describes the bandwidth size range.
+type ConnectionBandwidthSizeRange struct {
+	// Minimum bandwidth in Mbit/s.
+	Min int64 `json:"min"`
+	// Maximum bandwidth in Mbit/s.
+	Max int64 `json:"max"`
+}
+
+// ConnectionBandwidthFreeLine describes a free line.
+type ConnectionBandwidthFreeLine struct {
+	// Local site code.
+	LocalSiteCode string `json:"local_site_code"`
+	// Remote site code.
+	RemoteSiteCode string `json:"remote_site_code"`
+}
+
+// SiteSpecifications describes a supported site.
+type SiteSpecifications struct {
+	// Region ID.
+	RegionId string `json:"region_id"`
+	// Site code.
+	SiteCode string `json:"site_code"`
+}

--- a/openstack/cc/v3/central_network/Create.go
+++ b/openstack/cc/v3/central_network/Create.go
@@ -1,0 +1,196 @@
+package central_network
+
+import (
+	"net/http"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateOpts struct {
+	// Central network name.
+	Name string `json:"name" required:"true"`
+	// Resource description. Angle brackets (<>) are not allowed.
+	Description string `json:"description,omitempty"`
+	// ID of the enterprise project that the central network belongs to.
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
+	// Central network policy document.
+	PolicyDocument *PolicyDocument `json:"policy_document,omitempty"`
+	// Name of the default central network plane.
+	DefaultPlane string `json:"default_plane,omitempty"`
+	// List of the central network planes.
+	Planes []PlaneDocument `json:"planes,omitempty"`
+	// List of the enterprise routers on a central network.
+	ErInstances []AssociateErInstance `json:"er_instances,omitempty"`
+}
+
+// PolicyDocument is the central network policy document.
+type PolicyDocument struct {
+	// Name of the default central network plane.
+	DefaultPlane string `json:"default_plane,omitempty"`
+	// List of the central network planes.
+	Planes []PlaneDocument `json:"planes,omitempty"`
+	// List of the enterprise routers on a central network.
+	ErInstances []AssociateErInstance `json:"er_instances,omitempty"`
+}
+
+// PlaneDocument describes a central network plane.
+type PlaneDocument struct {
+	// Central network plane name.
+	Name string `json:"name,omitempty"`
+	// Enterprise router route tables associated with the central network plane.
+	AssociateErTables []AssociateErTable `json:"associate_er_tables,omitempty"`
+	// Connections between enterprise routers excluded from the central network plane.
+	ExcludeErConnections [][]AssociateErInstance `json:"exclude_er_connections,omitempty"`
+}
+
+// AssociateErTable describes an associated enterprise router route table.
+type AssociateErTable struct {
+	// Project ID.
+	ProjectId string `json:"project_id,omitempty"`
+	// Region ID.
+	RegionId string `json:"region_id,omitempty"`
+	// Enterprise router ID.
+	EnterpriseRouterId string `json:"enterprise_router_id,omitempty"`
+	// Enterprise router route table ID.
+	EnterpriseRouterTableId string `json:"enterprise_router_table_id,omitempty"`
+}
+
+// AssociateErInstance describes an enterprise router instance on a central network.
+type AssociateErInstance struct {
+	// Enterprise router ID.
+	EnterpriseRouterId string `json:"enterprise_router_id,omitempty"`
+	// Project ID.
+	ProjectId string `json:"project_id,omitempty"`
+	// Region ID.
+	RegionId string `json:"region_id,omitempty"`
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*CentralNetwork, error) {
+	b, err := build.RequestBody(opts, "central_network")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Post(client.ServiceURL(client.DomainID, "gcn", "central-networks"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return extra(raw)
+}
+
+// CentralNetworkResp is the wrapper for a single central network response.
+type CentralNetworkResp struct {
+	// Request ID.
+	RequestId string `json:"request_id"`
+	// Central network.
+	CentralNetwork CentralNetwork `json:"central_network"`
+}
+
+// CentralNetwork is the central network instance.
+type CentralNetwork struct {
+	// Central network ID.
+	ID string `json:"id"`
+	// Central network name.
+	Name string `json:"name"`
+	// Resource description.
+	Description string `json:"description"`
+	// Time when the resource was created.
+	CreatedAt string `json:"created_at"`
+	// Time when the resource was updated.
+	UpdatedAt string `json:"updated_at"`
+	// ID of the account that the central network belongs to.
+	DomainId string `json:"domain_id"`
+	// Central network status. Value options: AVAILABLE, CREATING, UPDATING, FAILED, DELETING, DELETED, RESTORING.
+	State string `json:"state"`
+	// ID of the enterprise project that the central network belongs to.
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// Default plane ID.
+	DefaultPlaneId string `json:"default_plane_id"`
+	// Deprecated.
+	AutoAssociateRouteEnabled bool `json:"auto_associate_route_enabled"`
+	// Deprecated.
+	AutoPropagateRouteEnabled bool `json:"auto_propagate_route_enabled"`
+	// Central network planes.
+	Planes []CentralNetworkPlane `json:"planes"`
+	// Enterprise routers on the central network.
+	ErInstances []CentralNetworkErInstance `json:"er_instances"`
+	// Connections on the central network.
+	Connections []CentralNetworkConnectionInfo `json:"connections"`
+}
+
+// CentralNetworkPlane describes a plane returned by the API.
+type CentralNetworkPlane struct {
+	// Plane ID.
+	ID string `json:"id"`
+	// Plane name.
+	Name string `json:"name"`
+	// Enterprise router route tables associated with the plane.
+	AssociateErTables []AssociateErTable `json:"associate_er_tables"`
+	// Connections between enterprise routers excluded from the plane.
+	ExcludeErConnections [][]AssociateErInstance `json:"exclude_er_connections"`
+}
+
+// CentralNetworkErInstance describes an enterprise router on the central network.
+type CentralNetworkErInstance struct {
+	// Instance ID.
+	ID string `json:"id"`
+	// Enterprise router ID.
+	EnterpriseRouterId string `json:"enterprise_router_id"`
+	// Project ID.
+	ProjectId string `json:"project_id"`
+	// Region ID.
+	RegionId string `json:"region_id"`
+	// BGP autonomous system number.
+	Asn int64 `json:"asn"`
+	// Geographic site code.
+	SiteCode string `json:"site_code"`
+}
+
+// CentralNetworkConnectionInfo describes a connection on the central network.
+type CentralNetworkConnectionInfo struct {
+	// Instance ID.
+	ID string `json:"id"`
+	// Plane ID.
+	PlaneId string `json:"plane_id"`
+	// Global connection bandwidth ID.
+	GlobalConnectionBandwidthId string `json:"global_connection_bandwidth_id"`
+	// Bandwidth size in Mbit/s.
+	BandwidthSize int64 `json:"bandwidth_size"`
+	// Connection type. Value options: ER-ER, ER-GDGW, ER-ER_ROUTE_TABLE.
+	ConnectionType string `json:"connection_type"`
+	// Two connection endpoints.
+	ConnectionPointPair []ConnectionPoint `json:"connection_point_pair"`
+	// Connection status.
+	State string `json:"state"`
+}
+
+// ConnectionPoint describes a single connection endpoint.
+type ConnectionPoint struct {
+	// Instance ID.
+	ID string `json:"id"`
+	// Project ID.
+	ProjectId string `json:"project_id"`
+	// Region ID.
+	RegionId string `json:"region_id"`
+	// Geographic site code.
+	SiteCode string `json:"site_code"`
+	// Connection endpoint ID.
+	InstanceId string `json:"instance_id"`
+	// Parent resource ID.
+	ParentInstanceId string `json:"parent_instance_id"`
+	// Resource type. Value options: ER, GDGW, ER_ROUTE_TABLE.
+	Type string `json:"type"`
+}
+
+func extra(raw *http.Response) (*CentralNetwork, error) {
+	var res CentralNetworkResp
+	if err := extract.Into(raw.Body, &res); err != nil {
+		return nil, err
+	}
+	return &res.CentralNetwork, nil
+}

--- a/openstack/cc/v3/central_network/Delete.go
+++ b/openstack/cc/v3/central_network/Delete.go
@@ -1,0 +1,10 @@
+package central_network
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+func Delete(client *golangsdk.ServiceClient, centralNetworkId string) error {
+	_, err := client.Delete(client.ServiceURL(client.DomainID, "gcn", "central-networks", centralNetworkId), &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	return err
+}

--- a/openstack/cc/v3/central_network/Get.go
+++ b/openstack/cc/v3/central_network/Get.go
@@ -1,0 +1,14 @@
+package central_network
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+)
+
+func Get(client *golangsdk.ServiceClient, centralNetworkId string) (*CentralNetwork, error) {
+	raw, err := client.Get(client.ServiceURL(client.DomainID, "gcn", "central-networks", centralNetworkId), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return extra(raw)
+}

--- a/openstack/cc/v3/central_network/List.go
+++ b/openstack/cc/v3/central_network/List.go
@@ -1,0 +1,68 @@
+package central_network
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListOpts struct {
+	// Number of records returned on each page. Value range: 1 to 2000.
+	Limit int `q:"limit"`
+	// ID of the last record on the previous page.
+	Marker string `q:"marker"`
+	// Keyword for sorting.
+	SortKey string `q:"sort_key"`
+	// Sorting order. Value options: asc, desc.
+	SortDir string `q:"sort_dir"`
+	// Filter by resource IDs.
+	ID []string `q:"id"`
+	// Filter by resource names.
+	Name []string `q:"name"`
+	// Filter by status.
+	State []string `q:"state"`
+	// Filter by enterprise project IDs.
+	EnterpriseProjectId []string `q:"enterprise_project_id"`
+	// Filter by enterprise router IDs.
+	EnterpriseRouterId []string `q:"enterprise_router_id"`
+	// Filter by attachment IDs.
+	AttachmentInstanceId []string `q:"attachment_instance_id"`
+	// Filter by global connection bandwidth IDs.
+	GlobalConnectionBandwidthId []string `q:"global_connection_bandwidth_id"`
+	// Filter by connection IDs.
+	ConnectionId []string `q:"connection_id"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListCentralNetworkResp, error) {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints(client.DomainID, "gcn", "central-networks").WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListCentralNetworkResp
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListCentralNetworkResp struct {
+	// Request ID.
+	RequestId string `json:"request_id"`
+	// Pagination query information.
+	PageInfo PageInfo `json:"page_info"`
+	// Central network list.
+	CentralNetworks []CentralNetwork `json:"central_networks"`
+}
+
+// PageInfo is the pagination information returned by list operations.
+type PageInfo struct {
+	// Marker of the next page.
+	NextMarker string `json:"next_marker"`
+	// Marker of the previous page.
+	PreviousMarker string `json:"previous_marker"`
+	// Number of records in the current page.
+	CurrentCount int `json:"current_count"`
+}

--- a/openstack/cc/v3/central_network/Update.go
+++ b/openstack/cc/v3/central_network/Update.go
@@ -1,0 +1,31 @@
+package central_network
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type UpdateOpts struct {
+	// Central network ID.
+	CentralNetworkId string `json:"-" required:"true"`
+	// Central network name.
+	Name string `json:"name,omitempty"`
+	// Resource description. Angle brackets (<>) are not allowed.
+	Description *string `json:"description,omitempty"`
+}
+
+func Update(client *golangsdk.ServiceClient, opts UpdateOpts) (*CentralNetwork, error) {
+	b, err := build.RequestBody(opts, "central_network")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Put(client.ServiceURL(client.DomainID, "gcn", "central-networks", opts.CentralNetworkId), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return extra(raw)
+}

--- a/openstack/cc/v3/connection/List.go
+++ b/openstack/cc/v3/connection/List.go
@@ -1,0 +1,124 @@
+package connection
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListOpts struct {
+	// Central network ID.
+	CentralNetworkId string `json:"-" required:"true"`
+	// Number of records returned on each page. Value range: 1 to 2000.
+	Limit int `q:"limit"`
+	// ID of the last record on the previous page.
+	Marker string `q:"marker"`
+	// Keyword for sorting.
+	SortKey string `q:"sort_key"`
+	// Sorting order. Value options: asc, desc.
+	SortDir string `q:"sort_dir"`
+	// Filter by resource IDs.
+	ID []string `q:"id"`
+	// Filter by resource names.
+	Name []string `q:"name"`
+	// Filter by status.
+	State []string `q:"state"`
+	// Filter by global connection bandwidth IDs.
+	GlobalConnectionBandwidthId []string `q:"global_connection_bandwidth_id"`
+	// Filter by bandwidth type. Value options: BandwidthPackage, TestBandwidth.
+	BandwidthType string `q:"bandwidth_type"`
+	// Filter by connection type. Value options: ER-ER, ER-GDGW, ER-ER_ROUTE_TABLE.
+	ConnectionType string `q:"connection_type"`
+	// Whether the connection is cross-region.
+	IsCrossRegion *bool `q:"is_cross_region"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListConnectionResp, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints(client.DomainID, "gcn", "central-network", opts.CentralNetworkId, "connections").
+		WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListConnectionResp
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListConnectionResp struct {
+	// Request ID.
+	RequestId string `json:"request_id"`
+	// Pagination query information.
+	PageInfo PageInfo `json:"page_info"`
+	// Central network connection list.
+	CentralNetworkConnections []CentralNetworkConnection `json:"central_network_connections"`
+}
+
+// PageInfo is the pagination information returned by list operations.
+type PageInfo struct {
+	// Marker of the next page.
+	NextMarker string `json:"next_marker"`
+	// Marker of the previous page.
+	PreviousMarker string `json:"previous_marker"`
+	// Number of records in the current page.
+	CurrentCount int `json:"current_count"`
+}
+
+// CentralNetworkConnection is a connection on a central network.
+type CentralNetworkConnection struct {
+	// Instance ID.
+	ID string `json:"id"`
+	// Instance name.
+	Name string `json:"name"`
+	// Resource description.
+	Description string `json:"description"`
+	// Account ID.
+	DomainId string `json:"domain_id"`
+	// Enterprise project ID.
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// Central network ID.
+	CentralNetworkId string `json:"central_network_id"`
+	// Central network plane ID.
+	CentralNetworkPlaneId string `json:"central_network_plane_id"`
+	// Global connection bandwidth ID.
+	GlobalConnectionBandwidthId string `json:"global_connection_bandwidth_id"`
+	// Bandwidth type. Value options: BandwidthPackage, TestBandwidth.
+	BandwidthType string `json:"bandwidth_type"`
+	// Bandwidth size in Mbit/s.
+	BandwidthSize int64 `json:"bandwidth_size"`
+	// Connection status.
+	State string `json:"state"`
+	// Whether the connection is frozen.
+	IsFrozen bool `json:"is_frozen"`
+	// Connection type. Value options: ER-ER, ER-GDGW, ER-ER_ROUTE_TABLE.
+	ConnectionType string `json:"connection_type"`
+	// Two connection endpoints.
+	ConnectionPointPair []ConnectionPoint `json:"connection_point_pair"`
+	// Time when the resource was created.
+	CreatedAt string `json:"created_at"`
+	// Time when the resource was updated.
+	UpdatedAt string `json:"updated_at"`
+}
+
+// ConnectionPoint describes a single connection endpoint.
+type ConnectionPoint struct {
+	// Instance ID.
+	ID string `json:"id"`
+	// Project ID.
+	ProjectId string `json:"project_id"`
+	// Region ID.
+	RegionId string `json:"region_id"`
+	// Geographic site code.
+	SiteCode string `json:"site_code"`
+	// Connection endpoint ID.
+	InstanceId string `json:"instance_id"`
+	// Parent resource ID.
+	ParentInstanceId string `json:"parent_instance_id"`
+	// Resource type. Value options: ER, GDGW, ER_ROUTE_TABLE.
+	Type string `json:"type"`
+}

--- a/openstack/cc/v3/connection/Update.go
+++ b/openstack/cc/v3/connection/Update.go
@@ -1,0 +1,40 @@
+package connection
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type UpdateOpts struct {
+	// Central network ID.
+	CentralNetworkId string `json:"-" required:"true"`
+	// ID of the connection on the central network.
+	ConnectionId string `json:"-" required:"true"`
+	// Bandwidth type. Value options: BandwidthPackage, TestBandwidth.
+	BandwidthType string `json:"bandwidth_type" required:"true"`
+	// Bandwidth size in Mbit/s. Mandatory if bandwidth_type is BandwidthPackage.
+	BandwidthSize int64 `json:"bandwidth_size,omitempty"`
+	// Global connection bandwidth ID. Mandatory if bandwidth_type is BandwidthPackage.
+	GlobalConnectionBandwidthId string `json:"global_connection_bandwidth_id,omitempty"`
+}
+
+func Update(client *golangsdk.ServiceClient, opts UpdateOpts) (*CentralNetworkConnection, error) {
+	b, err := build.RequestBody(opts, "central_network_connection")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Put(client.ServiceURL(client.DomainID, "gcn", "central-network", opts.CentralNetworkId, "connections", opts.ConnectionId), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		CentralNetworkConnection CentralNetworkConnection `json:"central_network_connection"`
+	}
+	err = extract.Into(raw.Body, &res)
+	return &res.CentralNetworkConnection, err
+}

--- a/openstack/cc/v3/global_connection_bandwidth/Configs.go
+++ b/openstack/cc/v3/global_connection_bandwidth/Configs.go
@@ -1,0 +1,77 @@
+package global_connection_bandwidth
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// GetConfigs queries the tenant configuration of a global connection bandwidth.
+func GetConfigs(client *golangsdk.ServiceClient) (*ConfigsResp, error) {
+	raw, err := client.Get(client.ServiceURL(client.DomainID, "gcb", "configs"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ConfigsResp
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ConfigsResp struct {
+	// Request ID.
+	RequestId string `json:"request_id"`
+	// Dynamic configuration items for purchasing global connection bandwidth.
+	Configs Configs `json:"configs"`
+}
+
+// Configs describes the tenant configuration of global connection bandwidth.
+type Configs struct {
+	// Capacity of global connection bandwidths by billing option.
+	SizeRange []SizeRange `json:"size_range"`
+	// List of supported billing options.
+	ChargeMode []string `json:"charge_mode"`
+	// Instance type.
+	Services []string `json:"services"`
+	// Bandwidth type.
+	GcbType []string `json:"gcb_type"`
+	// Percentage of minimum bandwidth in enhanced 95th percentile billing.
+	Ratio95PeakPlus int `json:"ratio_95peak_plus"`
+	// Percentage of minimum bandwidth in standard 95th percentile billing.
+	Ratio95PeakGuar int `json:"ratio_95peak_guar"`
+	// Whether a cross-border permit is approved.
+	Crossborder bool `json:"crossborder"`
+	// Quota information.
+	Quotas []ConfigQuota `json:"quotas"`
+	// Line grade.
+	SlaLevel []string `json:"sla_level"`
+	// Maximum number of instances that are allowed to use a shared bandwidth.
+	BindLimit int `json:"bind_limit"`
+	// Whether to enable the geographic region bandwidth.
+	EnableAreaBandwidth bool `json:"enable_area_bandwidth"`
+	// Whether standard 95th percentile bandwidth billing can be changed to billing by bandwidth.
+	EnableChange95 bool `json:"enable_change_95"`
+	// Whether multiple line specifications are supported.
+	EnableSpecCode bool `json:"enable_spec_code"`
+	// Whether to enable Cloud Eye monitoring.
+	CesEnabled bool `json:"ces_enabled"`
+}
+
+// SizeRange describes the bandwidth capacity range for a billing option.
+type SizeRange struct {
+	// Billing option. Value options: bwd, 95, 95avr.
+	Type string `json:"type"`
+	// Minimum bandwidth in Mbit/s.
+	Min int `json:"min"`
+	// Maximum bandwidth in Mbit/s.
+	Max int `json:"max"`
+}
+
+// ConfigQuota describes a quota in the tenant configuration.
+type ConfigQuota struct {
+	// Quotas.
+	Quota int `json:"quota"`
+	// Used quotas.
+	Used int `json:"used"`
+	// Quota type. Value options: gcb.size, gcb.count.
+	Type string `json:"type"`
+}

--- a/openstack/cc/v3/global_connection_bandwidth/Create.go
+++ b/openstack/cc/v3/global_connection_bandwidth/Create.go
@@ -1,0 +1,136 @@
+package global_connection_bandwidth
+
+import (
+	"net/http"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateOpts struct {
+	// Instance name.
+	Name string `json:"name" required:"true"`
+	// Resource description. Angle brackets (<>) are not allowed.
+	Description string `json:"description,omitempty"`
+	// Cross-border attribute.
+	Bordercross *bool `json:"bordercross" required:"true"`
+	// Bandwidth type. Value options: Area, TrsArea, SubArea, Region.
+	Type string `json:"type" required:"true"`
+	// ID of the enterprise project that the resource belongs to.
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
+	// Billing option. Value options: bwd, 95, 95avr.
+	ChargeMode string `json:"charge_mode" required:"true"`
+	// Capacity of a global connection bandwidth, in Mbit/s. Value range: 2 to 300.
+	Size int `json:"size" required:"true"`
+	// Service tier. Value options: Pt (Platinum), Au (Gold), Ag (Silver).
+	SlaLevel string `json:"sla_level,omitempty"`
+	// Local access point.
+	LocalArea string `json:"local_area,omitempty"`
+	// Remote access point.
+	RemoteArea string `json:"remote_area,omitempty"`
+	// UUID of the line specification code.
+	SpecCodeId string `json:"spec_code_id,omitempty"`
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*GlobalConnectionBandwidth, error) {
+	b, err := build.RequestBody(opts, "globalconnection_bandwidth")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Post(client.ServiceURL(client.DomainID, "gcb", "gcbandwidths"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return extra(raw)
+}
+
+// GlobalConnectionBandwidth is a global connection bandwidth instance.
+type GlobalConnectionBandwidth struct {
+	// Instance ID.
+	ID string `json:"id"`
+	// Instance name.
+	Name string `json:"name"`
+	// Resource description.
+	Description string `json:"description"`
+	// Account ID.
+	DomainId string `json:"domain_id"`
+	// Cross-border attribute.
+	Bordercross bool `json:"bordercross"`
+	// Bandwidth type.
+	Type string `json:"type"`
+	// Service binding type. Value options: CC, GEIP, GCN, GSN, ALL.
+	BindingService string `json:"binding_service"`
+	// ID of the enterprise project that the resource belongs to.
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// Billing option.
+	ChargeMode string `json:"charge_mode"`
+	// Capacity in Mbit/s.
+	Size int `json:"size"`
+	// Service tier.
+	SlaLevel string `json:"sla_level"`
+	// Local access point.
+	LocalArea string `json:"local_area"`
+	// Remote access point.
+	RemoteArea string `json:"remote_area"`
+	// Local access point code.
+	LocalSiteCode string `json:"local_site_code"`
+	// Remote access point code.
+	RemoteSiteCode string `json:"remote_site_code"`
+	// Status. Value options: NORMAL, FREEZED.
+	AdminState string `json:"admin_state"`
+	// Freeze status.
+	Frozen bool `json:"frozen"`
+	// UUID of the line specification code.
+	SpecCodeId string `json:"spec_code_id"`
+	// Time when the resource was created.
+	CreatedAt string `json:"created_at"`
+	// Time when the resource was updated.
+	UpdatedAt string `json:"updated_at"`
+	// Whether the bandwidth can be used by multiple instances.
+	EnableShare bool `json:"enable_share"`
+	// ID of the enterprise project that the resource belongs to.
+	EpsId string `json:"eps_id"`
+	// Associated instances.
+	Instances []AssociatedInstance `json:"instances"`
+	// Directional connections.
+	DirectionalConnections []DirectionalConnection `json:"directional_connections"`
+}
+
+// AssociatedInstance is an instance associated with a global connection bandwidth.
+type AssociatedInstance struct {
+	// Instance ID.
+	ID string `json:"id"`
+	// Instance type.
+	Type string `json:"type"`
+	// Region ID.
+	RegionId string `json:"region_id"`
+	// Project ID.
+	ProjectId string `json:"project_id"`
+}
+
+// DirectionalConnection is a directional connection of a global connection bandwidth.
+type DirectionalConnection struct {
+	// Connection name.
+	Name string `json:"name"`
+	// Connection ID.
+	ID string `json:"id"`
+	// Local access point code.
+	LocalSiteCode string `json:"local_site_code"`
+	// Remote access point code.
+	RemoteSiteCode string `json:"remote_site_code"`
+}
+
+func extra(raw *http.Response) (*GlobalConnectionBandwidth, error) {
+	var res struct {
+		GlobalConnectionBandwidth GlobalConnectionBandwidth `json:"globalconnection_bandwidth"`
+	}
+	if err := extract.Into(raw.Body, &res); err != nil {
+		return nil, err
+	}
+	return &res.GlobalConnectionBandwidth, nil
+}

--- a/openstack/cc/v3/global_connection_bandwidth/Delete.go
+++ b/openstack/cc/v3/global_connection_bandwidth/Delete.go
@@ -1,0 +1,10 @@
+package global_connection_bandwidth
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+func Delete(client *golangsdk.ServiceClient, id string) error {
+	_, err := client.Delete(client.ServiceURL(client.DomainID, "gcb", "gcbandwidths", id), &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202, 204},
+	})
+	return err
+}

--- a/openstack/cc/v3/global_connection_bandwidth/Get.go
+++ b/openstack/cc/v3/global_connection_bandwidth/Get.go
@@ -1,0 +1,12 @@
+package global_connection_bandwidth
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+func Get(client *golangsdk.ServiceClient, id string) (*GlobalConnectionBandwidth, error) {
+	raw, err := client.Get(client.ServiceURL(client.DomainID, "gcb", "gcbandwidths", id), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return extra(raw)
+}

--- a/openstack/cc/v3/global_connection_bandwidth/List.go
+++ b/openstack/cc/v3/global_connection_bandwidth/List.go
@@ -1,0 +1,68 @@
+package global_connection_bandwidth
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListOpts struct {
+	// Number of records returned on each page. Value range: 1 to 2000.
+	Limit int `q:"limit"`
+	// ID of the last record on the previous page.
+	Marker string `q:"marker"`
+	// Filter by resource IDs.
+	ID []string `q:"id"`
+	// Filter by resource names.
+	Name []string `q:"name"`
+	// Filter by enterprise project IDs.
+	EnterpriseProjectId []string `q:"enterprise_project_id"`
+	// Filter by instance IDs.
+	InstanceId []string `q:"instance_id"`
+	// Filter by instance types.
+	InstanceType []string `q:"instance_type"`
+	// Filter by service binding types.
+	BindingService []string `q:"binding_service"`
+	// Filter by bandwidth types.
+	Type []string `q:"type"`
+	// Filter by status.
+	AdminState []string `q:"admin_state"`
+	// Filter by billing options.
+	ChargeMode []string `q:"charge_mode"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListGlobalConnectionBandwidthResp, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints(client.DomainID, "gcb", "gcbandwidths").
+		WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListGlobalConnectionBandwidthResp
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListGlobalConnectionBandwidthResp struct {
+	// Request ID.
+	RequestId string `json:"request_id"`
+	// Pagination query information.
+	PageInfo PageInfo `json:"page_info"`
+	// Global connection bandwidth list.
+	GlobalConnectionBandwidths []GlobalConnectionBandwidth `json:"globalconnection_bandwidths"`
+}
+
+// PageInfo is the pagination information returned by list operations.
+type PageInfo struct {
+	// Marker of the next page.
+	NextMarker string `json:"next_marker"`
+	// Marker of the previous page.
+	PreviousMarker string `json:"previous_marker"`
+	// Number of records in the current page.
+	CurrentCount int `json:"current_count"`
+}

--- a/openstack/cc/v3/global_connection_bandwidth/Sites.go
+++ b/openstack/cc/v3/global_connection_bandwidth/Sites.go
@@ -1,0 +1,93 @@
+package global_connection_bandwidth
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListSitesOpts struct {
+	// Number of records returned on each page. Value range: 1 to 2000.
+	Limit int `q:"limit"`
+	// ID of the last record on the previous page.
+	Marker string `q:"marker"`
+	// Filter by resource IDs.
+	ID []string `q:"id"`
+	// Site name in English.
+	NameEn string `q:"name_en"`
+	// Site name in Chinese.
+	NameCn string `q:"name_cn"`
+	// Site code.
+	SiteCode string `q:"site_code"`
+	// Site type. Value options: Area, SubArea, Region.
+	SiteType string `q:"site_type"`
+}
+
+// ListSites queries the site list.
+func ListSites(client *golangsdk.ServiceClient, opts ListSitesOpts) (*ListSitesResp, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints(client.DomainID, "gcb", "sites").
+		WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListSitesResp
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListSitesResp struct {
+	// Request ID.
+	RequestId string `json:"request_id"`
+	// Total number of records.
+	TotalCount int `json:"total_count"`
+	// Pagination query information.
+	PageInfo PageInfo `json:"page_info"`
+	// Site list.
+	SiteInfos []Site `json:"site_infos"`
+}
+
+// Site describes a global connection bandwidth site.
+type Site struct {
+	// Instance ID.
+	ID string `json:"id"`
+	// Resource description.
+	Description string `json:"description"`
+	// Time when the resource was created.
+	CreatedAt string `json:"created_at"`
+	// Time when the resource was updated.
+	UpdatedAt string `json:"updated_at"`
+	// Region ID.
+	RegionId string `json:"region_id"`
+	// English site name.
+	NameEn string `json:"name_en"`
+	// Chinese site name.
+	NameCn string `json:"name_cn"`
+	// Site code.
+	SiteCode string `json:"site_code"`
+	// Site type. Value options: Area, SubArea, Region.
+	SiteType string `json:"site_type"`
+	// Comma-separated supported services.
+	ServiceList string `json:"service_list"`
+	// Center or edge site designation.
+	PublicBorderGroup string `json:"public_border_group"`
+	// Groups the site belongs to.
+	GroupList []SiteGroupReference `json:"group_list"`
+}
+
+// SiteGroupReference describes a site group reference.
+type SiteGroupReference struct {
+	// Group instance ID.
+	ID string `json:"id"`
+	// Group description.
+	Description string `json:"description"`
+	// English group name.
+	NameEn string `json:"name_en"`
+	// Chinese group name.
+	NameCn string `json:"name_cn"`
+}

--- a/openstack/cc/v3/global_connection_bandwidth/SupportBindings.go
+++ b/openstack/cc/v3/global_connection_bandwidth/SupportBindings.go
@@ -1,0 +1,40 @@
+package global_connection_bandwidth
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListSupportBindingsOpts struct {
+	// Number of records returned on each page. Value range: 1 to 2000.
+	Limit int `q:"limit"`
+	// ID of the last record on the previous page.
+	Marker string `q:"marker"`
+	// Filter by enterprise project IDs.
+	EnterpriseProjectId []string `q:"enterprise_project_id"`
+	// Local access point.
+	LocalArea string `q:"local_area"`
+	// Remote access point.
+	RemoteArea string `q:"remote_area"`
+	// Bound instance type. Value options: CC, GEIP, GCN, GSN.
+	BindingService string `q:"binding_service" required:"true"`
+}
+
+// ListSupportBindings queries the list of global connection bandwidths that meet the binding conditions.
+func ListSupportBindings(client *golangsdk.ServiceClient, opts ListSupportBindingsOpts) (*ListGlobalConnectionBandwidthResp, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints(client.DomainID, "gcb", "gcbandwidths", "support-bindings").
+		WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListGlobalConnectionBandwidthResp
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}

--- a/openstack/cc/v3/global_connection_bandwidth/Update.go
+++ b/openstack/cc/v3/global_connection_bandwidth/Update.go
@@ -1,0 +1,41 @@
+package global_connection_bandwidth
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+)
+
+type UpdateOpts struct {
+	// Instance ID.
+	ID string `json:"-" required:"true"`
+	// Instance name.
+	Name string `json:"name,omitempty"`
+	// Resource description. Angle brackets (<>) are not allowed.
+	Description *string `json:"description,omitempty"`
+	// Capacity in Mbit/s. Value range: 2 to 300.
+	Size int `json:"size,omitempty"`
+	// Billing option. Value options: bwd, 95, 95avr.
+	ChargeMode string `json:"charge_mode,omitempty"`
+	// Service tier. Value options: Pt, Au, Ag.
+	SlaLevel string `json:"sla_level,omitempty"`
+	// Instance type. Value options: CC, GEIP, GCN, GSN, ALL.
+	BindingService string `json:"binding_service,omitempty"`
+	// UUID of the line specification code.
+	SpecCodeId string `json:"spec_code_id,omitempty"`
+}
+
+func Update(client *golangsdk.ServiceClient, opts UpdateOpts) (*GlobalConnectionBandwidth, error) {
+	b, err := build.RequestBody(opts, "globalconnection_bandwidth")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Put(client.ServiceURL(client.DomainID, "gcb", "gcbandwidths", opts.ID), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return extra(raw)
+}

--- a/openstack/cc/v3/policy/Apply.go
+++ b/openstack/cc/v3/policy/Apply.go
@@ -1,0 +1,29 @@
+package policy
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// Apply applies a central network policy.
+func Apply(client *golangsdk.ServiceClient, centralNetworkId, policyId string) (*ApplyResp, error) {
+	raw, err := client.Post(client.ServiceURL(client.DomainID, "gcn", "central-network", centralNetworkId, "policies", policyId, "apply"), nil, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res ApplyResp
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ApplyResp struct {
+	// Request ID.
+	RequestId string `json:"request_id"`
+	// Central network policy.
+	CentralNetworkPolicy CentralNetworkPolicy `json:"central_network_policy"`
+	// List of central network policy changes.
+	CentralNetworkPolicyChangeSet []ElementChangeEntry `json:"central_network_policy_change_set"`
+}

--- a/openstack/cc/v3/policy/ChangeSet.go
+++ b/openstack/cc/v3/policy/ChangeSet.go
@@ -1,0 +1,86 @@
+package policy
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+// ListChangeSet queries the changes between the current policy and an applied policy.
+func ListChangeSet(client *golangsdk.ServiceClient, centralNetworkId, policyId string) (*ChangeSetResp, error) {
+	raw, err := client.Get(client.ServiceURL(client.DomainID, "gcn", "central-network", centralNetworkId, "policies", policyId, "change-set"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ChangeSetResp
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ChangeSetResp struct {
+	// Request ID.
+	RequestId string `json:"request_id"`
+	// Pagination query information.
+	PageInfo PageInfo `json:"page_info"`
+	// List of central network policy changes.
+	CentralNetworkPolicyChangeSet []ElementChangeEntry `json:"central_network_policy_change_set"`
+}
+
+// ElementChangeEntry describes a single change between policies.
+type ElementChangeEntry struct {
+	// Change operation. Value options: CreateCentralNetworkPlane, DeleteCentralNetworkPlane,
+	// UpdateCentralNetworkPlane, CreateCentralNetworkErInstance, DeleteCentralNetworkErInstance,
+	// CreateCentralNetworkErConnection, DeleteCentralNetworkErConnection, CreateCentralNetworkErTable,
+	// DeleteCentralNetworkErTable, SwitchCentralNetworkErTable.
+	OperationId string `json:"operation_id"`
+	// Plane to be created.
+	CreateCentralNetworkPlane *PlaneChangeDocument `json:"create_central_network_plane"`
+	// Original plane.
+	OriginalCentralNetworkPlane *PlaneChangeDocument `json:"original_central_network_plane"`
+	// Newest plane.
+	NewestCentralNetworkPlane *PlaneChangeDocument `json:"newest_central_network_plane"`
+	// Plane to be deleted.
+	DeleteCentralNetworkPlane *PlaneChangeDocument `json:"delete_central_network_plane"`
+	// Enterprise router instance to be created.
+	CreateCentralNetworkErInstance *AssociateErInstance `json:"create_central_network_er_instance"`
+	// Enterprise router instance to be deleted.
+	DeleteCentralNetworkErInstance *AssociateErInstance `json:"delete_central_network_er_instance"`
+	// Central network plane name.
+	CentralNetworkPlaneName string `json:"central_network_plane_name"`
+	// Enterprise router connections to be created.
+	CreateCentralNetworkErConnection []AssociateErTable `json:"create_central_network_er_connection"`
+	// Enterprise router connections to be deleted.
+	DeleteCentralNetworkErConnection []AssociateErTable `json:"delete_central_network_er_connection"`
+	// Enterprise router route table to be created.
+	CreateCentralNetworkErTable *AssociateErTable `json:"create_central_network_er_table"`
+	// Enterprise router route table to be deleted.
+	DeleteCentralNetworkErTable *AssociateErTable `json:"delete_central_network_er_table"`
+	// Enterprise router route table to be switched.
+	SwitchCentralNetworkErTable *SwitchErTableDocument `json:"switch_central_network_er_table"`
+}
+
+// PlaneChangeDocument describes a plane in a change set entry.
+type PlaneChangeDocument struct {
+	// Plane name.
+	Name string `json:"name"`
+	// Whether the plane is the default one.
+	IsDefault bool `json:"is_default"`
+	// Enterprise router route tables associated with the plane.
+	AssociateErTables []AssociateErTable `json:"associate_er_tables"`
+	// Connections between enterprise routers excluded from the plane.
+	ExcludeErConnections [][]AssociateErInstance `json:"exclude_er_connections"`
+}
+
+// SwitchErTableDocument describes a route table switch.
+type SwitchErTableDocument struct {
+	// Project ID.
+	ProjectId string `json:"project_id"`
+	// Region ID.
+	RegionId string `json:"region_id"`
+	// Enterprise router ID.
+	EnterpriseRouterId string `json:"enterprise_router_id"`
+	// Route table ID of the original enterprise router.
+	OriginalEnterpriseRouterTableId string `json:"original_enterprise_router_table_id"`
+	// Route table ID of the new enterprise router.
+	NewEnterpriseRouterTableId string `json:"new_enterprise_router_table_id"`
+}

--- a/openstack/cc/v3/policy/Create.go
+++ b/openstack/cc/v3/policy/Create.go
@@ -1,0 +1,102 @@
+package policy
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateOpts struct {
+	// Central network ID.
+	CentralNetworkId string `json:"-" required:"true"`
+	// Name of the default central network plane.
+	DefaultPlane string `json:"default_plane" required:"true"`
+	// List of the central network planes.
+	Planes []PlaneDocument `json:"planes" required:"true"`
+	// List of the enterprise routers on a central network.
+	ErInstances []AssociateErInstance `json:"er_instances,omitempty"`
+}
+
+// PlaneDocument describes a central network plane.
+type PlaneDocument struct {
+	// Central network plane name.
+	Name string `json:"name,omitempty"`
+	// Enterprise router route tables associated with the central network plane.
+	AssociateErTables []AssociateErTable `json:"associate_er_tables,omitempty"`
+	// Connections between enterprise routers excluded from the central network plane.
+	ExcludeErConnections [][]AssociateErInstance `json:"exclude_er_connections,omitempty"`
+}
+
+// AssociateErTable describes an associated enterprise router route table.
+type AssociateErTable struct {
+	// Project ID.
+	ProjectId string `json:"project_id,omitempty"`
+	// Region ID.
+	RegionId string `json:"region_id,omitempty"`
+	// Enterprise router ID.
+	EnterpriseRouterId string `json:"enterprise_router_id,omitempty"`
+	// Enterprise router route table ID.
+	EnterpriseRouterTableId string `json:"enterprise_router_table_id,omitempty"`
+}
+
+// AssociateErInstance describes an enterprise router instance on a central network.
+type AssociateErInstance struct {
+	// Enterprise router ID.
+	EnterpriseRouterId string `json:"enterprise_router_id,omitempty"`
+	// Project ID.
+	ProjectId string `json:"project_id,omitempty"`
+	// Region ID.
+	RegionId string `json:"region_id,omitempty"`
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*CentralNetworkPolicy, error) {
+	b, err := build.RequestBody(opts, "central_network_policy_document")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Post(client.ServiceURL(client.DomainID, "gcn", "central-network", opts.CentralNetworkId, "policies"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		CentralNetworkPolicy CentralNetworkPolicy `json:"central_network_policy"`
+	}
+	err = extract.Into(raw.Body, &res)
+	return &res.CentralNetworkPolicy, err
+}
+
+// CentralNetworkPolicy is a central network policy.
+type CentralNetworkPolicy struct {
+	// Instance ID.
+	ID string `json:"id"`
+	// Time when the resource was created.
+	CreatedAt string `json:"created_at"`
+	// Account ID.
+	DomainId string `json:"domain_id"`
+	// Policy status. Value options: AVAILABLE, CANCELING, APPLYING, FAILED, DELETED.
+	State string `json:"state"`
+	// Central network ID.
+	CentralNetworkId string `json:"central_network_id"`
+	// Policy document template version.
+	DocumentTemplateVersion string `json:"document_template_version"`
+	// Whether the policy is applied.
+	IsApplied bool `json:"is_applied"`
+	// Policy version.
+	Version int `json:"version"`
+	// Central network policy document.
+	Document PolicyDocument `json:"document"`
+}
+
+// PolicyDocument is the central network policy document.
+type PolicyDocument struct {
+	// Name of the default central network plane.
+	DefaultPlane string `json:"default_plane"`
+	// List of the central network planes.
+	Planes []PlaneDocument `json:"planes"`
+	// List of the enterprise routers on a central network.
+	ErInstances []AssociateErInstance `json:"er_instances"`
+}

--- a/openstack/cc/v3/policy/Delete.go
+++ b/openstack/cc/v3/policy/Delete.go
@@ -1,0 +1,10 @@
+package policy
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+func Delete(client *golangsdk.ServiceClient, centralNetworkId, policyId string) error {
+	_, err := client.Delete(client.ServiceURL(client.DomainID, "gcn", "central-network", centralNetworkId, "policies", policyId), &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202, 204},
+	})
+	return err
+}

--- a/openstack/cc/v3/policy/List.go
+++ b/openstack/cc/v3/policy/List.go
@@ -1,0 +1,64 @@
+package policy
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListOpts struct {
+	// Central network ID.
+	CentralNetworkId string `json:"-" required:"true"`
+	// Number of records returned on each page. Value range: 1 to 2000.
+	Limit int `q:"limit"`
+	// ID of the last record on the previous page.
+	Marker string `q:"marker"`
+	// Keyword for sorting.
+	SortKey string `q:"sort_key"`
+	// Sorting order. Value options: asc, desc.
+	SortDir string `q:"sort_dir"`
+	// Filter by resource IDs.
+	ID []string `q:"id"`
+	// Filter by status. Value options: AVAILABLE, CANCELING, APPLYING, FAILED, DELETED.
+	State []string `q:"state"`
+	// Filter by whether the policy is applied.
+	IsApplied *bool `q:"is_applied"`
+	// Filter by version.
+	Version []int `q:"version"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListPolicyResp, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints(client.DomainID, "gcn", "central-network", opts.CentralNetworkId, "policies").
+		WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListPolicyResp
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListPolicyResp struct {
+	// Request ID.
+	RequestId string `json:"request_id"`
+	// Pagination query information.
+	PageInfo PageInfo `json:"page_info"`
+	// Central network policy list.
+	CentralNetworkPolicies []CentralNetworkPolicy `json:"central_network_policies"`
+}
+
+// PageInfo is the pagination information returned by list operations.
+type PageInfo struct {
+	// Marker of the next page.
+	NextMarker string `json:"next_marker"`
+	// Marker of the previous page.
+	PreviousMarker string `json:"previous_marker"`
+	// Number of records in the current page.
+	CurrentCount int `json:"current_count"`
+}

--- a/openstack/cc/v3/quota/List.go
+++ b/openstack/cc/v3/quota/List.go
@@ -1,0 +1,52 @@
+package quota
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListOpts struct {
+	// Quota type. Multiple quota types can be queried.
+	QuotaType []string `q:"quota_type"`
+	// Number of records returned on each page. Value range: 1 to 2000.
+	Limit int `q:"limit"`
+	// ID of the last record on the previous page.
+	Marker string `q:"marker"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) (*ListQuotaResp, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints(client.DomainID, "gcn", "quotas").
+		WithQueryParams(&opts).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListQuotaResp
+	err = extract.Into(raw.Body, &res)
+	return &res, err
+}
+
+type ListQuotaResp struct {
+	// Request ID.
+	RequestId string `json:"request_id"`
+	// Quota list.
+	Quotas []CentralNetworkQuota `json:"quotas"`
+}
+
+// CentralNetworkQuota describes a single quota entry.
+type CentralNetworkQuota struct {
+	// Quota identifier.
+	QuotaKey string `json:"quota_key"`
+	// Quota limit.
+	QuotaLimit int `json:"quota_limit"`
+	// Used quotas.
+	Used int `json:"used"`
+	// Unit of the quota value.
+	Unit string `json:"unit"`
+}

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -1093,6 +1093,10 @@ func NewERServiceV3(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts)
 	return sc, nil
 }
 
+func NewCCServiceV3(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	return initClientOpts(client, eo, "cc")
+}
+
 func NewEVPNServiceV3(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
 	sc, err := initCommonServiceClient(client, eo, "vpn", "v5")
 	if err != nil {


### PR DESCRIPTION
## What this does
Implements the OpenTelekomCloud `Cloud Connect (CC) v3` service SDK, covering all six API groups from the cloud-connect API reference.

### Acceptance tests
```
=== RUN   TestCentralNetworkLifeCycle
--- PASS: TestCentralNetworkLifeCycle (9.68s)
=== RUN   TestCentralNetworkList
--- PASS: TestCentralNetworkList (0.97s)
=== RUN   TestCentralNetworkQuotaList
--- PASS: TestCentralNetworkQuotaList (0.87s)
=== RUN   TestCentralNetworkCapabilityList
--- PASS: TestCentralNetworkCapabilityList (1.24s)
PASS

Process finished with the exit code 0

=== RUN   TestGlobalConnectionBandwidthLifeCycle
--- PASS: TestGlobalConnectionBandwidthLifeCycle (1.75s)
=== RUN   TestGlobalConnectionBandwidthList
--- PASS: TestGlobalConnectionBandwidthList (0.90s)
=== RUN   TestGlobalConnectionBandwidthConfigs
--- PASS: TestGlobalConnectionBandwidthConfigs (1.04s)
=== RUN   TestGlobalConnectionBandwidthSites
--- PASS: TestGlobalConnectionBandwidthSites (0.85s)
=== RUN   TestGlobalConnectionBandwidthSupportBindings
--- PASS: TestGlobalConnectionBandwidthSupportBindings (0.88s)
PASS

Process finished with the exit code 0

=== RUN   TestCentralNetworkPolicyLifeCycle
--- PASS: TestCentralNetworkPolicyLifeCycle (53.70s)
PASS

Process finished with the exit code 0
```