### PR TITLE
[Fix] CCE: Temporarily remove conditions parameter from cluster status

### DIFF
--- a/openstack/cce/v3/clusters/common.go
+++ b/openstack/cce/v3/clusters/common.go
@@ -94,8 +94,6 @@ type Status struct {
 	JobID string `json:"jobID"`
 	// Reasons for the cluster to become current
 	Reason string `json:"reason"`
-	// The status of each component in the cluster
-	Conditions Conditions `json:"conditions"`
 	// Kube-apiserver access address in the cluster
 	Endpoints []Endpoints `json:"-"`
 }
@@ -138,15 +136,6 @@ type AuthenticationSpec struct {
 	// Authentication mode: rbac , x509 or authenticating_proxy
 	Mode                string            `json:"mode" required:"true"`
 	AuthenticatingProxy map[string]string `json:"authenticatingProxy" required:"true"`
-}
-
-type Conditions struct {
-	// The type of component
-	Type string `json:"type"`
-	// The state of the component
-	Status string `json:"status"`
-	// The reason that the component becomes current
-	Reason string `json:"reason"`
 }
 
 type Endpoints struct {


### PR DESCRIPTION
### What this PR does / why we need it

The parameter `status.conditions` is no longer in the t cloud public api docs but an array is returned instead. Removing this parameter entirely until clarified.

### Which issue this PR fixes
T cloud pub issue [#3450](https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3450)
Gophertelekomcloud Issue #956 

### Acceptance

```
=== RUN   TestCluster
--- PASS: TestCluster (359.59s)
PASS
```
