### PR TITLE
[Fix] DNS: Build next page URL from marker when API omits the "next" link

### DIFF
--- a/openstack/dns/v2/recordsets/results.go
+++ b/openstack/dns/v2/recordsets/results.go
@@ -55,6 +55,24 @@ func (r RecordSetPage) IsEmpty() (bool, error) {
 	return len(s) == 0, err
 }
 
+// NextPageURL returns the URL of the next page. The DNS API omits the
+// "next" link on marker-based pages, so when it is absent the URL is built
+// manually from the last recordset ID.
+func (r RecordSetPage) NextPageURL() (string, error) {
+	next, err := r.LinkedPageBase.NextPageURL()
+	if err != nil || next != "" {
+		return next, err
+	}
+	s, err := ExtractRecordSets(r)
+	if err != nil {
+		return "", err
+	}
+	if len(s) == 0 {
+		return "", nil
+	}
+	return r.WrapNextPageURL(s[len(s)-1].ID)
+}
+
 // ExtractRecordSets extracts a slice of RecordSets from a List result.
 func ExtractRecordSets(r pagination.Page) ([]RecordSet, error) {
 	var s struct {

--- a/openstack/dns/v2/recordsets/testing/pagination_test.go
+++ b/openstack/dns/v2/recordsets/testing/pagination_test.go
@@ -1,0 +1,74 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dns/v2/recordsets"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/gophertelekomcloud/testhelper/client"
+)
+
+func TestListByZoneMarkerPagination(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	var requests int
+	th.Mux.HandleFunc("/zones/zone-id/recordsets", func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		th.TestMethod(t, r, "GET")
+		th.CheckEquals(t, "2", r.URL.Query().Get("limit"))
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("marker") {
+		case "": // first page: the API includes a "next" link
+			_, _ = fmt.Fprintf(w, `
+				{
+					"recordsets": [{"id": "r1"}, {"id": "r2"}],
+					"links": {
+						"self": "%[1]szones/zone-id/recordsets?limit=2",
+						"next": "%[1]szones/zone-id/recordsets?limit=2&marker=r2"
+					}
+				}
+			`, th.Endpoint())
+		case "r2": // marker pages: only a "self" link, no "next" (issue #952)
+			_, _ = fmt.Fprintf(w, `
+				{
+					"recordsets": [{"id": "r3"}, {"id": "r4"}],
+					"links": {"self": "%szones/zone-id/recordsets?limit=2&marker=r2"}
+				}
+			`, th.Endpoint())
+		case "r4":
+			_, _ = fmt.Fprintf(w, `
+				{
+					"recordsets": [{"id": "r5"}],
+					"links": {"self": "%szones/zone-id/recordsets?limit=2&marker=r4"}
+				}
+			`, th.Endpoint())
+		case "r5": // past the end: empty page terminates the iteration
+			_, _ = fmt.Fprint(w, `{"recordsets": [], "links": {}}`)
+		default:
+			t.Errorf("unexpected marker %q", r.URL.Query().Get("marker"))
+		}
+	})
+
+	var ids []string
+	pages := 0
+	err := recordsets.ListByZone(client.ServiceClient(), "zone-id", recordsets.ListOpts{Limit: 2}).
+		EachPage(func(page pagination.Page) (bool, error) {
+			pages++
+			s, err := recordsets.ExtractRecordSets(page)
+			th.AssertNoErr(t, err)
+			for _, rs := range s {
+				ids = append(ids, rs.ID)
+			}
+			return true, nil
+		})
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, []string{"r1", "r2", "r3", "r4", "r5"}, ids)
+	th.CheckEquals(t, 3, pages)
+	th.CheckEquals(t, 4, requests)
+}

--- a/openstack/dns/v2/zones/results.go
+++ b/openstack/dns/v2/zones/results.go
@@ -52,6 +52,24 @@ func (r ZonePage) IsEmpty() (bool, error) {
 	return len(s) == 0, err
 }
 
+// NextPageURL returns the URL of the next page. The DNS API omits the
+// "next" link on marker-based pages, so when it is absent the URL is built
+// manually from the last zone ID.
+func (r ZonePage) NextPageURL() (string, error) {
+	next, err := r.LinkedPageBase.NextPageURL()
+	if err != nil || next != "" {
+		return next, err
+	}
+	s, err := ExtractZones(r)
+	if err != nil {
+		return "", err
+	}
+	if len(s) == 0 {
+		return "", nil
+	}
+	return r.WrapNextPageURL(s[len(s)-1].ID)
+}
+
 // ExtractZones extracts a slice of Zones from a List result.
 func ExtractZones(r pagination.Page) ([]Zone, error) {
 	var s struct {

--- a/openstack/dns/v2/zones/testing/pagination_test.go
+++ b/openstack/dns/v2/zones/testing/pagination_test.go
@@ -1,0 +1,67 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/dns/v2/zones"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/gophertelekomcloud/testhelper/client"
+)
+
+func TestListMarkerPagination(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	var requests int
+	th.Mux.HandleFunc("/zones", func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		th.TestMethod(t, r, "GET")
+		th.CheckEquals(t, "2", r.URL.Query().Get("limit"))
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("marker") {
+		case "": // first page: the API includes a "next" link
+			_, _ = fmt.Fprintf(w, `
+				{
+					"zones": [{"id": "z1"}, {"id": "z2"}],
+					"links": {
+						"self": "%[1]szones?limit=2",
+						"next": "%[1]szones?limit=2&marker=z2"
+					}
+				}
+			`, th.Endpoint())
+		case "z2": // marker pages: only a "self" link, no "next"
+			_, _ = fmt.Fprintf(w, `
+				{
+					"zones": [{"id": "z3"}],
+					"links": {"self": "%szones?limit=2&marker=z2"}
+				}
+			`, th.Endpoint())
+		case "z3": // past the end: empty page terminates the iteration
+			_, _ = fmt.Fprint(w, `{"zones": [], "links": {}}`)
+		default:
+			t.Errorf("unexpected marker %q", r.URL.Query().Get("marker"))
+		}
+	})
+
+	var ids []string
+	pages := 0
+	err := zones.List(client.ServiceClient(), zones.ListOpts{Limit: 2}).
+		EachPage(func(page pagination.Page) (bool, error) {
+			pages++
+			s, err := zones.ExtractZones(page)
+			th.AssertNoErr(t, err)
+			for _, z := range s {
+				ids = append(ids, z.ID)
+			}
+			return true, nil
+		})
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, []string{"z1", "z2", "z3"}, ids)
+	th.CheckEquals(t, 2, pages)
+	th.CheckEquals(t, 3, requests)
+}


### PR DESCRIPTION
### What this PR does / why we need it
Fixes #952

### Acceptance tests
```
=== RUN   TestZonesList
--- PASS: TestZonesList (2.39s)
=== RUN   TestZonesCRUD
    zones_test.go:33: Attempting to create DNS public zone
    zones_test.go:42: Created DNS public zone: 2c9c2de79d7175d8019f2733068a524c
    tools.go:75: {
          "hostname": "ns1.open-telekom-cloud.com.",
          "priority": 1
        }
    tools.go:75: {
          "hostname": "ns2.open-telekom-cloud.com.",
          "priority": 2
        }
    zones_test.go:59: Attempting to update DNS public zone: 2c9c2de79d7175d8019f2733068a524c
    zones_test.go:66: Updated DNS public zone
    zones_test.go:52: Attempting to delete DNS public zone: 2c9c2de79d7175d8019f2733068a524c
    zones_test.go:55: Deleted DNS public zone: 2c9c2de79d7175d8019f2733068a524c
--- PASS: TestZonesCRUD (1.39s)
PASS

Process finished with the exit code 0
```
