### PR TITLE
[Fix] wafd cc rule omit contitions and url if empty

### DIFF
--- a/acceptance/openstack/waf-premium/v1/rule_test.go
+++ b/acceptance/openstack/waf-premium/v1/rule_test.go
@@ -176,6 +176,34 @@ func TestWafPremiumCcRuleWorkflow(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, getCc.Url, "/path1")
 	th.AssertEquals(t, getCc.Action.Category, "log")
+
+	advancedCcOpts := rules.CreateCcOpts{
+		Mode: pointerto.Int(1),
+		Conditions: []rules.CcConditionsObject{{
+			Category:       "url",
+			LogicOperation: "contain",
+			Contents:       []string{"/url"},
+		}},
+		Description: "advanced log rule",
+		Action: &rules.CcActionObject{
+			Category: "log",
+		},
+		TagType:     "ip",
+		LimitNum:    10,
+		LimitPeriod: 60,
+	}
+	t.Logf("Attempting to Create WAF Premium advanced cc rule with log action")
+	advancedCc, err := rules.CreateCc(client, policy.ID, advancedCcOpts)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, advancedCc.Mode, 1)
+	th.AssertEquals(t, advancedCc.Action.Category, "log")
+	th.AssertEquals(t, advancedCc.Conditions[0].Category, "url")
+
+	t.Cleanup(func() {
+		t.Logf("Attempting to delete WAF Premium advanced cc rule: %s", advancedCc.ID)
+		th.AssertNoErr(t, rules.DeleteCcRule(client, policy.ID, advancedCc.ID))
+		t.Logf("Deleted WAF Premium advanced cc rule: %s", advancedCc.ID)
+	})
 }
 
 func TestWafPremiumCustomRuleWorkflow(t *testing.T) {

--- a/openstack/waf-premium/v1/rules/CreateCc.go
+++ b/openstack/waf-premium/v1/rules/CreateCc.go
@@ -14,10 +14,10 @@ type CreateCcOpts struct {
 	Mode *int `json:"mode" required:"true"`
 	// Path to be protected in the CC attack protection rule.
 	// This parameter is mandatory when the CC attack protection rule is in standard mode (i.e. the value of mode is 0).
-	Url string `json:"url" required:"true"`
+	Url string `json:"url,omitempty"`
 	// Rate limit conditions of the CC protection rule.
 	// This parameter is mandatory when the CC protection rule is in advanced mode (i.e. the value of mode is 1).
-	Conditions []CcConditionsObject `json:"conditions"`
+	Conditions []CcConditionsObject `json:"conditions,omitempty"`
 	// Protection action to take if the number of requests reaches the upper limit.
 	Action *CcActionObject `json:"action" required:"true"`
 	// Rate limit mode.
@@ -76,11 +76,11 @@ type CcConditionsObject struct {
 	// Reference table ID. It can be obtained by calling the API Querying the Reference Table List.
 	// This parameter is mandatory when the suffix of logic_operation is any or all.
 	// The reference table type must be the same as the category type.
-	ValueListId string `json:"value_list_id"`
+	ValueListId string `json:"value_list_id,omitempty"`
 	// Subfield. When category is set to params, cookie, or header,
 	// set this parameter based on site requirements.
 	// This parameter is mandatory.
-	Index string `json:"index"`
+	Index *string `json:"index"`
 }
 
 type CcActionObject struct {
@@ -102,7 +102,7 @@ type CcActionObject struct {
 	// you need to set the returned block page.
 	// If you want to use the default block page, this parameter can be excluded.
 	// If you want to use a custom block page, set this parameter.
-	Detail *CcDetailObject `json:"detail"`
+	Detail *CcDetailObject `json:"detail,omitempty"`
 }
 
 type CcDetailObject struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
For mode=1 need to skip several attributes and not put then in body
### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
=== RUN   TestWafPremiumCcRuleWorkflow
    rule_test.go:141: Attempting to Create WAF Premium cc rule
    rule_test.go:153: Attempting to List WAF Premium cc rule
    rule_test.go:160: Attempting to Update WAF Premium cc rule: c233365b54fa46f1acdfdeaa391dfd35
    rule_test.go:174: Attempting to Get WAF Premium cc rule: c233365b54fa46f1acdfdeaa391dfd35
    rule_test.go:196: Attempting to Create WAF Premium advanced cc rule with log action
    rule_test.go:204: Attempting to delete WAF Premium advanced cc rule: 6929ed52fd8145e8add264ebae23794d
    rule_test.go:206: Deleted WAF Premium advanced cc rule: 6929ed52fd8145e8add264ebae23794d
    rule_test.go:148: Attempting to delete WAF Premium cc rule: c233365b54fa46f1acdfdeaa391dfd35
    rule_test.go:150: Deleted WAF Premium cc rule: c233365b54fa46f1acdfdeaa391dfd35
    rule_test.go:125: Attempting to delete WAF Premium policy: 6903945abc28421c8fc48a12d710f1d2
    rule_test.go:127: Deleted WAF Premium policy: 6903945abc28421c8fc48a12d710f1d2
--- PASS: TestWafPremiumCcRuleWorkflow (264.31s)
PASS

Process finished with the exit code 0