### PR TITLE
[Feat] CCE: Add AgencyName to cluster Spec and UpdateSpec

### DIFF
--- a/openstack/cce/v3/clusters/Update.go
+++ b/openstack/cce/v3/clusters/Update.go
@@ -14,6 +14,8 @@ type UpdateOpts struct {
 type UpdateSpec struct {
 	// Cluster description
 	Description string `json:"description,omitempty"`
+	// Custom IAM agency name for the cluster
+	AgencyName string `json:"agencyName,omitempty"`
 }
 
 // Update allows clusters to update description.

--- a/openstack/cce/v3/clusters/common.go
+++ b/openstack/cce/v3/clusters/common.go
@@ -41,6 +41,8 @@ type Spec struct {
 	Version string `json:"version,omitempty"`
 	// Cluster description
 	Description string `json:"description,omitempty"`
+	// Custom IAM agency name for the cluster
+	AgencyName string `json:"agencyName,omitempty"`
 	// Whether the cluster supports IPv6 addresses. This field is supported in clusters of v1.25 and later versions.
 	Ipv6Enable bool `json:"ipv6enable,omitempty"`
 	// Node network parameters

--- a/openstack/cce/v3/clusters/testing/fixtures.go
+++ b/openstack/cce/v3/clusters/testing/fixtures.go
@@ -16,6 +16,7 @@ const Output = `
         "type": "VirtualMachine",
         "flavor": "cce.s1.small",
         "version": "v1.7.3-r10",
+        "agencyName": "test-agency",
         "hostNetwork": {
             "vpc": "3305eb40-2707-4940-921c-9f335f84a2ca",
             "subnet": "00e41db7-e56b-4946-bf91-27bb9effd664"
@@ -48,6 +49,7 @@ const OutputOTC = `
         "type": "VirtualMachine",
         "flavor": "cce.s1.small",
         "version": "v1.7.3-r10",
+        "agencyName": "test-agency",
         "hostNetwork": {
             "vpc": "3305eb40-2707-4940-921c-9f335f84a2ca",
             "subnet": "00e41db7-e56b-4946-bf91-27bb9effd664"
@@ -76,9 +78,10 @@ var Expected = &clusters.Clusters{
 		Id:   "daa97872-59d7-11e8-a787-0255ac101f54",
 	},
 	Spec: clusters.Spec{
-		Type:    "VirtualMachine",
-		Flavor:  "cce.s1.small",
-		Version: "v1.7.3-r10",
+		Type:       "VirtualMachine",
+		Flavor:     "cce.s1.small",
+		Version:    "v1.7.3-r10",
+		AgencyName: "test-agency",
 		HostNetwork: clusters.HostNetworkSpec{
 			VpcId:    "3305eb40-2707-4940-921c-9f335f84a2ca",
 			SubnetId: "00e41db7-e56b-4946-bf91-27bb9effd664",
@@ -104,9 +107,10 @@ var ExpectedOTC = &clusters.Clusters{
 		Id:   "daa97872-59d7-11e8-a787-0255ac101f54",
 	},
 	Spec: clusters.Spec{
-		Type:    "VirtualMachine",
-		Flavor:  "cce.s1.small",
-		Version: "v1.7.3-r10",
+		Type:       "VirtualMachine",
+		Flavor:     "cce.s1.small",
+		Version:    "v1.7.3-r10",
+		AgencyName: "test-agency",
 		HostNetwork: clusters.HostNetworkSpec{
 			VpcId:    "3305eb40-2707-4940-921c-9f335f84a2ca",
 			SubnetId: "00e41db7-e56b-4946-bf91-27bb9effd664",
@@ -139,6 +143,7 @@ const ListOutput = `
                 "type": "VirtualMachine",
                 "flavor": "cce.s1.small",
                 "version": "v1.7.3-r10",
+                "agencyName": "test-agency",
                 "hostNetwork": {
                     "vpc": "3305eb40-2707-4940-921c-9f335f84a2ca",
                     "subnet": "00e41db7-e56b-4946-bf91-27bb9effd664"
@@ -176,6 +181,7 @@ const ListOutputOTC = `
                 "type": "VirtualMachine",
                 "flavor": "cce.s1.small",
                 "version": "v1.7.3-r10",
+                "agencyName": "test-agency",
                 "hostNetwork": {
                     "vpc": "3305eb40-2707-4940-921c-9f335f84a2ca",
                     "subnet": "00e41db7-e56b-4946-bf91-27bb9effd664"
@@ -205,6 +211,7 @@ var ListExpected = []clusters.Clusters{
 		Metadata:   clusters.MetaData{Name: "test123", Id: "daa97872-59d7-11e8-a787-0255ac101f54"},
 		Spec: clusters.Spec{Type: "VirtualMachine",
 			Flavor:           "cce.s1.small",
+			AgencyName:       "test-agency",
 			HostNetwork:      clusters.HostNetworkSpec{VpcId: "3305eb40-2707-4940-921c-9f335f84a2ca", SubnetId: "00e41db7-e56b-4946-bf91-27bb9effd664"},
 			ContainerNetwork: clusters.ContainerNetworkSpec{Mode: "overlay_l2"},
 			BillingMode:      0,
@@ -221,6 +228,7 @@ var ListExpectedOTC = []clusters.Clusters{
 		Metadata:   clusters.MetaData{Name: "test123", Id: "daa97872-59d7-11e8-a787-0255ac101f54"},
 		Spec: clusters.Spec{Type: "VirtualMachine",
 			Flavor:           "cce.s1.small",
+			AgencyName:       "test-agency",
 			HostNetwork:      clusters.HostNetworkSpec{VpcId: "3305eb40-2707-4940-921c-9f335f84a2ca", SubnetId: "00e41db7-e56b-4946-bf91-27bb9effd664"},
 			ContainerNetwork: clusters.ContainerNetworkSpec{Mode: "overlay_l2"},
 			BillingMode:      0,

--- a/openstack/cce/v3/clusters/testing/requests_test.go
+++ b/openstack/cce/v3/clusters/testing/requests_test.go
@@ -123,6 +123,7 @@ func TestCreateV3Cluster(t *testing.T) {
         "type": "VirtualMachine",
         "flavor": "cce.s1.small",
         "version": "v1.7.3-r10",
+        "agencyName": "test-agency",
          "hostNetwork": {
             "vpc": "3305eb40-2707-4940-921c-9f335f84a2ca",
             "subnet": "00e41db7-e56b-4946-bf91-27bb9effd664"
@@ -147,8 +148,9 @@ func TestCreateV3Cluster(t *testing.T) {
 		ApiVersion: "v3",
 		Metadata:   clusters.CreateMetaData{Name: "test-cluster"},
 		Spec: clusters.Spec{Type: "VirtualMachine",
-			Flavor:  "cce.s1.small",
-			Version: "v1.7.3-r10",
+			Flavor:     "cce.s1.small",
+			Version:    "v1.7.3-r10",
+			AgencyName: "test-agency",
 			HostNetwork: clusters.HostNetworkSpec{
 				VpcId:    "3305eb40-2707-4940-921c-9f335f84a2ca",
 				SubnetId: "00e41db7-e56b-4946-bf91-27bb9effd664"},
@@ -250,7 +252,8 @@ func TestUpdateV3Cluster(t *testing.T) {
 		th.TestJSONRequest(t, r, `
 {
     "spec": {
-        "description": "new description"
+        "description": "new description",
+        "agencyName": "new-test-agency"
     }
 }
 			`)
@@ -260,7 +263,10 @@ func TestUpdateV3Cluster(t *testing.T) {
 
 		_, _ = fmt.Fprint(w, Output)
 	})
-	options := clusters.UpdateOpts{Spec: clusters.UpdateSpec{Description: "new description"}}
+	options := clusters.UpdateOpts{Spec: clusters.UpdateSpec{
+		Description: "new description",
+		AgencyName:  "new-test-agency",
+	}}
 	actual, err := clusters.Update(fake.ServiceClient(), "daa97872-59d7-11e8-a787-0255ac101f54", options)
 	th.AssertNoErr(t, err)
 	expected := Expected


### PR DESCRIPTION
## Summary

- Add `AgencyName string` (JSON: `agencyName`) to `Spec` in `common.go`
- Add `AgencyName string` (JSON: `agencyName`) to `UpdateSpec` in `Update.go`
- Enables Terraform provider to support custom cluster-level IAM agencies (CCE Standard v1.27+)

## Test plan

- [x] Verify `go build ./...` passes
- [x] Verify `go vet ./...` passes
- [x] Terraform provider integration: create/update/read cluster with `agency_name` set

Closes #970 