### PR TITLE
[Feat] CTS: Add is_support_validation to cts tracker v3

### DIFF
--- a/acceptance/openstack/cts/v3/trackers_test.go
+++ b/acceptance/openstack/cts/v3/trackers_test.go
@@ -25,9 +25,10 @@ func TestTrackersLifecycle(t *testing.T) {
 
 	t.Logf("Attempting to create CTSv3 Tracker")
 	ctsTracker, err := tracker.Create(client, tracker.CreateOpts{
-		TrackerType:  "system",
-		TrackerName:  "system",
-		IsLtsEnabled: true,
+		TrackerType:       "system",
+		TrackerName:       "system",
+		IsLtsEnabled:      true,
+		IsSupportValidate: pointerto.Bool(true),
 		ObsInfo: tracker.ObsInfo{
 			BucketName:      bucketName,
 			FilePrefixName:  "test-prefix",
@@ -50,14 +51,16 @@ func TestTrackersLifecycle(t *testing.T) {
 	th.AssertEquals(t, false, *ctsTracker.ObsInfo.IsObsCreated)
 	th.AssertEquals(t, bucketName, ctsTracker.ObsInfo.BucketName)
 	th.AssertEquals(t, "json", ctsTracker.ObsInfo.CompressType)
+	th.AssertDeepEquals(t, true, ctsTracker.IsSupportValidate)
 
 	t.Logf("Attempting to update CTSv3 Tracker: %s", ctsTracker.TrackerName)
 	ltsEnable := false
 	_, err = tracker.Update(client, tracker.UpdateOpts{
-		TrackerName:  "system",
-		TrackerType:  "system",
-		Status:       "enabled",
-		IsLtsEnabled: &ltsEnable,
+		TrackerName:       "system",
+		TrackerType:       "system",
+		Status:            "enabled",
+		IsLtsEnabled:      &ltsEnable,
+		IsSupportValidate: pointerto.Bool(false),
 		ObsInfo: tracker.ObsInfo{
 			FilePrefixName: "test-2-",
 			CompressType:   "gzip",
@@ -75,6 +78,7 @@ func TestTrackersLifecycle(t *testing.T) {
 	// if tracker is disabled LTS status can't be changed
 	th.AssertEquals(t, trackerGet.Lts.IsLtsEnabled, false)
 	th.AssertEquals(t, trackerGet.ObsInfo.FilePrefixName, "test-2-")
+	th.AssertEquals(t, false, trackerGet.IsSupportValidate)
 	// update of `compress_type` doesn't work
 	// th.AssertEquals(t, "gzip", ctsTracker.ObsInfo.CompressType)
 }

--- a/openstack/cts/v3/tracker/Create.go
+++ b/openstack/cts/v3/tracker/Create.go
@@ -1,7 +1,7 @@
 package tracker
 
 import (
-	"github.com/opentelekomcloud/gophertelekomcloud"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 )
@@ -15,6 +15,10 @@ type CreateOpts struct {
 	ObsInfo ObsInfo `json:"obs_info,omitempty"`
 	// Indicates whether to enable trace analysis.
 	IsLtsEnabled bool `json:"is_lts_enabled,omitempty"`
+	// Whether trace file verification is enabled for trace transfer.
+	// When this function is enabled, integrity verification will be performed to check
+	// whether trace files in OBS buckets have been tampered with.
+	IsSupportValidate *bool `json:"is_support_validate,omitempty"`
 }
 
 type ObsInfo struct {
@@ -70,6 +74,8 @@ type Tracker struct {
 	Detail string `json:"detail"`
 	// Tracker type
 	ObsInfo ObsInfo `json:"obs_info"`
+	// Whether to enable trace file verification.
+	IsSupportValidate bool `json:"is_support_validate,omitempty"`
 }
 
 type Lts struct {

--- a/openstack/cts/v3/tracker/Update.go
+++ b/openstack/cts/v3/tracker/Update.go
@@ -1,7 +1,7 @@
 package tracker
 
 import (
-	"github.com/opentelekomcloud/gophertelekomcloud"
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 )
@@ -18,6 +18,10 @@ type UpdateOpts struct {
 	// Status of a tracker. The value can be enabled or disabled.
 	// If you change the value to disabled, the tracker stops recording traces.
 	Status string `json:"status,omitempty"`
+	// Whether trace file verification is enabled for trace transfer.
+	// When this function is enabled, integrity verification will be performed to check
+	// whether trace files in OBS buckets have been tampered with.
+	IsSupportValidate *bool `json:"is_support_validate,omitempty"`
 }
 
 func Update(client *golangsdk.ServiceClient, opts UpdateOpts) (*Tracker, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Adds new field, `is_support_validate` to CTS v3 tracker

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->
https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/issues/3505

### Tests
```
=== RUN   TestTrackersLifecycle
    trackers_test.go:22: Attempting to create CTSv3 Tracker
    trackers_test.go:44: Created CTSv3 Tracker: system
    trackers_test.go:52: Attempting to update CTSv3 Tracker: system
    trackers_test.go:66: Updated CTSv3 Tracker: system
    trackers_test.go:37: Attempting to delete CTSv3 Tracker: system
    trackers_test.go:40: Deleted CTSv3 Tracker: system
--- PASS: TestTrackersLifecycle (2.81s)
PASS
```