### PR TITLE
[Fix] RDS: API to apply for private domain returns 200 instead of 202

### DIFF
--- a/acceptance/openstack/rds/v3/rds_test.go
+++ b/acceptance/openstack/rds/v3/rds_test.go
@@ -593,27 +593,41 @@ func TestRdsUpgradeVersion(t *testing.T) {
 
 func TestRdsPrivateDomainName(t *testing.T) {
 	if os.Getenv("RUN_RDS_LIFECYCLE") == "" {
-		t.Skip("too slow to run in zuul")
-	}
-	rdsId := os.Getenv("OS_RDS_ID")
-	if rdsId == "" {
-		t.Skip("OS_RDS_ID env var required for the test is missing")
+		t.Skip("new RDS have latest minor versions")
 	}
 
 	client, err := clients.NewRdsV3()
 	th.AssertNoErr(t, err)
 
-	dnsName := tools.RandomString("testaccdomain", 4)
-	modifyOpts := instances.ModifyPrivateDomainNameOpts{
-		InstanceId: rdsId,
-		DnsName:    dnsName,
-	}
-	modifyResp, err := instances.ModifyPrivateDomainName(client, modifyOpts)
+	cc, err := clients.CloudAndClient()
 	th.AssertNoErr(t, err)
 
-	_ = instances.WaitForJobCompleted(client, 600, *modifyResp)
+	t.Log("Creating instance")
 
-	domain, err := instances.GetPrivateDomainName(client, rdsId, instances.GetPrivateDomainNameParams{
+	// Create MySql RDSv3 instance
+	rds := CreateMySqlRDS(t, client, cc.RegionName)
+	t.Cleanup(func() { DeleteRDS(t, client, rds.Id) })
+	th.AssertEquals(t, "mysql", strings.ToLower(rds.Datastore.Type))
+
+	// Apply can only be tested on MySQL database
+	applyJobId, err := instances.ApplyForPrivateDomain(client, instances.ApplyForPrivateDomainOpts{
+		InstanceId: rds.Id,
+		DnsType:    "private",
+	})
+	th.AssertNoErr(t, err)
+	_ = instances.WaitForJobCompleted(client, 600, *applyJobId)
+
+	dnsName := tools.RandomString("testaccdomain", 4)
+	modifyOpts := instances.ModifyPrivateDomainNameOpts{
+		InstanceId: rds.Id,
+		DnsName:    dnsName,
+	}
+	modifyJobId, err := instances.ModifyPrivateDomainName(client, modifyOpts)
+	th.AssertNoErr(t, err)
+
+	_ = instances.WaitForJobCompleted(client, 600, *modifyJobId)
+
+	domain, err := instances.GetPrivateDomainName(client, rds.Id, instances.GetPrivateDomainNameParams{
 		DnsType: "private",
 	})
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/rds/v3/rds_test.go
+++ b/acceptance/openstack/rds/v3/rds_test.go
@@ -593,7 +593,7 @@ func TestRdsUpgradeVersion(t *testing.T) {
 
 func TestRdsPrivateDomainName(t *testing.T) {
 	if os.Getenv("RUN_RDS_LIFECYCLE") == "" {
-		t.Skip("new RDS have latest minor versions")
+		t.Skip("Too slow for CI")
 	}
 
 	client, err := clients.NewRdsV3()

--- a/openstack/rds/v3/instances/PrivateDomainNameApply.go
+++ b/openstack/rds/v3/instances/PrivateDomainNameApply.go
@@ -20,7 +20,7 @@ func ApplyForPrivateDomain(client *golangsdk.ServiceClient, opts ApplyForPrivate
 
 	// POST /v3/{project_id}/instances/{instance_id}/create-dns
 	raw, err := client.Post(client.ServiceURL("instances", opts.InstanceId, "create-dns"), b, nil, &golangsdk.RequestOpts{
-		OkCodes: []int{202},
+		OkCodes: []int{200, 202},
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
- Fix expected return code.
- ApplyForPrivateDomain is required for MySQL databases. So, test needs to be modified.

### What this PR does / why we need it

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->
Issue #979 

### Tests
```
=== RUN   TestRdsPrivateDomainName
    rds_test.go:605: Creating instance
    helpers.go:67: Attempting to create RDSv3
    helpers.go:108: Created RDSv3: 1e0bc00e1a294b86a0973915fa032c2fin01
    helpers.go:114: Attempting to delete RDSv3: 1e0bc00e1a294b86a0973915fa032c2fin01
    helpers.go:125: RDSv3 instance deleted: 1e0bc00e1a294b86a0973915fa032c2fin01
--- PASS: TestRdsPrivateDomainName (344.14s)
PASS
```
