### PR TITLE
[Fix] stop subnet pagination on short page

### DIFF
--- a/acceptance/openstack/vpc/v1/subnet_test.go
+++ b/acceptance/openstack/vpc/v1/subnet_test.go
@@ -81,13 +81,32 @@ func waitForSubnetDeleted(client *golangsdk.ServiceClient, id string, secs int) 
 	})
 }
 
+func deleteTestVPC(t *testing.T, client *golangsdk.ServiceClient, id string) {
+	t.Helper()
+
+	err := golangsdk.WaitFor(600, func() (bool, error) {
+		err := vpcs.Delete(client, id)
+		if err == nil {
+			return true, nil
+		}
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			return true, nil
+		}
+		if _, ok := err.(golangsdk.ErrDefault409); ok {
+			return false, nil
+		}
+		return false, err
+	})
+	th.AssertNoErr(t, err)
+}
+
 func TestSubnetList(t *testing.T) {
 	client, err := clients.NewVPCV1Client()
 	th.AssertNoErr(t, err)
 
 	vpc := createSubnetVPC(t, client)
 	t.Cleanup(func() {
-		th.AssertNoErr(t, vpcs.Delete(client, vpc.ID))
+		deleteTestVPC(t, client, vpc.ID)
 	})
 
 	subnet := createTestSubnet(t, client, vpc.ID)
@@ -108,7 +127,7 @@ func TestSubnetLifecycle(t *testing.T) {
 
 	vpc := createSubnetVPC(t, client)
 	t.Cleanup(func() {
-		th.AssertNoErr(t, vpcs.Delete(client, vpc.ID))
+		deleteTestVPC(t, client, vpc.ID)
 	})
 
 	subnet := createTestSubnet(t, client, vpc.ID)

--- a/openstack/vpc/v1/subnets/List.go
+++ b/openstack/vpc/v1/subnets/List.go
@@ -2,11 +2,15 @@ package subnets
 
 import (
 	"bytes"
+	"fmt"
+	"strconv"
 
 	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
 	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
 	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
 )
+
+const defaultPageLimit = 2000
 
 type ListOpts struct {
 	Marker string `q:"marker,omitempty"`
@@ -43,6 +47,16 @@ func (p SubnetPage) NewNextPageURL() (string, error) {
 	subnets, err := ExtractSubnets(p)
 	if err != nil || len(subnets) == 0 {
 		return "", err
+	}
+	limit := defaultPageLimit
+	if value := p.URL.Query().Get("limit"); value != "" {
+		limit, err = strconv.Atoi(value)
+		if err != nil {
+			return "", fmt.Errorf("invalid subnet page limit %q: %w", value, err)
+		}
+	}
+	if limit > 0 && len(subnets) < limit {
+		return "", nil
 	}
 	next := p.URL
 	query := next.Query()

--- a/openstack/vpc/v1/subnets/List_test.go
+++ b/openstack/vpc/v1/subnets/List_test.go
@@ -14,7 +14,9 @@ func TestListAllOptionsAndPagination(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
+	requestCount := 0
 	th.Mux.HandleFunc("/project-id/subnets", func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
 		th.TestMethod(t, r, http.MethodGet)
 		expected := map[string]string{
 			"limit":  "2",
@@ -40,8 +42,6 @@ func TestListAllOptionsAndPagination(t *testing.T) {
 				`{"subnets":[%s]}`,
 				strings.ReplaceAll(subnetJSON, `"id": "subnet-id"`, `"id": "subnet-3"`),
 			)
-		case "subnet-3":
-			_, _ = w.Write([]byte(`{"subnets":[]}`))
 		default:
 			t.Fatalf("unexpected marker %q", r.URL.Query().Get("marker"))
 		}
@@ -57,6 +57,7 @@ func TestListAllOptionsAndPagination(t *testing.T) {
 	th.AssertEquals(t, "subnet-1", actual[0].ID)
 	th.AssertEquals(t, "subnet-3", actual[2].ID)
 	th.AssertEquals(t, "192.168.20.0/24", actual[0].CIDR)
+	th.AssertEquals(t, 3, requestCount)
 }
 
 func TestListZeroLimit(t *testing.T) {
@@ -80,15 +81,15 @@ func TestListNoOptions(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
+	requestCount := 0
 	th.Mux.HandleFunc("/project-id/subnets", func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
 		switch r.URL.Query().Get("marker") {
 		case "":
 			if actual := r.URL.RawQuery; actual != "" {
 				t.Fatalf("unexpected query %q", actual)
 			}
 			_, _ = w.Write([]byte(`{"subnets":[` + subnetJSON + `]}`))
-		case "subnet-id":
-			_, _ = w.Write([]byte(`{"subnets":[]}`))
 		default:
 			t.Fatalf("unexpected marker %q", r.URL.Query().Get("marker"))
 		}
@@ -99,6 +100,7 @@ func TestListNoOptions(t *testing.T) {
 	th.AssertEquals(t, 1, len(actual))
 	th.AssertEquals(t, "subnet-id", actual[0].ID)
 	th.AssertEquals(t, "vpc-id", actual[0].VpcID)
+	th.AssertEquals(t, 2, requestCount)
 }
 
 func TestListInvalidResponse(t *testing.T) {


### PR DESCRIPTION
Preserve VPC filtering for enterprise-project authorization while avoiding an unnecessary empty sentinel request.

<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
