### PR TITLE
[Feat.] vpc quota and private ip endpoints

### DIFF
--- a/acceptance/openstack/vpc/v1/privateip_test.go
+++ b/acceptance/openstack/vpc/v1/privateip_test.go
@@ -1,0 +1,55 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/privateips"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestPrivateIPLifecycle(t *testing.T) {
+	client, err := clients.NewVPCV1Client()
+	th.AssertNoErr(t, err)
+
+	vpc := createSubnetVPC(t, client)
+	t.Cleanup(func() {
+		deleteTestVPC(t, client, vpc.ID)
+	})
+
+	subnet := createTestSubnet(t, client, vpc.ID)
+	t.Cleanup(func() {
+		deleteTestSubnet(t, client, subnet.VpcID, subnet.ID)
+	})
+
+	created, err := privateips.Create(client, privateips.CreateOpts{
+		PrivateIPs: []privateips.PrivateIPRequest{{SubnetID: subnet.NetworkID}},
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(created))
+	privateIPID := created[0].ID
+	t.Cleanup(func() {
+		if privateIPID != "" {
+			th.AssertNoErr(t, privateips.Delete(client, privateIPID))
+		}
+	})
+
+	actual, err := privateips.Get(client, privateIPID)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, privateIPID, actual.ID)
+	th.AssertEquals(t, subnet.NetworkID, actual.SubnetID)
+
+	list, err := privateips.List(client, subnet.NetworkID, privateips.ListOpts{})
+	th.AssertNoErr(t, err)
+	found := false
+	for _, privateIP := range list {
+		if privateIP.ID == privateIPID {
+			found = true
+			break
+		}
+	}
+	th.AssertEquals(t, true, found)
+
+	th.AssertNoErr(t, privateips.Delete(client, privateIPID))
+	privateIPID = ""
+}

--- a/acceptance/openstack/vpc/v1/quota_test.go
+++ b/acceptance/openstack/vpc/v1/quota_test.go
@@ -1,0 +1,21 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/quotas"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestQuotaList(t *testing.T) {
+	client, err := clients.NewVPCV1Client()
+	th.AssertNoErr(t, err)
+
+	resources, err := quotas.List(client, quotas.ListOpts{Type: "publicIp"})
+	th.AssertNoErr(t, err)
+	if len(resources) == 0 {
+		t.Fatal("expected at least one publicIp quota resource")
+	}
+	th.AssertEquals(t, "publicIp", resources[0].Type)
+}

--- a/openstack/vpc/v1/privateips/Create.go
+++ b/openstack/vpc/v1/privateips/Create.go
@@ -1,0 +1,36 @@
+package privateips
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateOpts struct {
+	PrivateIPs []PrivateIPRequest `json:"privateips" required:"true"`
+}
+
+type PrivateIPRequest struct {
+	SubnetID  string `json:"subnet_id" required:"true"`
+	IPAddress string `json:"ip_address,omitempty"`
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) ([]PrivateIP, error) {
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Post(client.ServiceURL(client.ProjectID, "privateips"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		PrivateIPs []PrivateIP `json:"privateips"`
+	}
+	err = extract.Into(raw.Body, &res)
+	return res.PrivateIPs, err
+}

--- a/openstack/vpc/v1/privateips/Create_test.go
+++ b/openstack/vpc/v1/privateips/Create_test.go
@@ -1,0 +1,101 @@
+package privateips_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/privateips"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/privateips", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodPost)
+		th.TestJSONRequest(t, r, `{
+			"privateips": [
+				{
+					"subnet_id": "network-id"
+				},
+				{
+					"subnet_id": "network-id",
+					"ip_address": "192.168.20.11"
+				}
+			]
+		}`)
+		_, _ = w.Write([]byte(`{"privateips":[` + privateIPJSON + `]}`))
+	})
+
+	actual, err := privateips.Create(serviceClient(), privateips.CreateOpts{
+		PrivateIPs: []privateips.PrivateIPRequest{
+			{SubnetID: "network-id"},
+			{SubnetID: "network-id", IPAddress: "192.168.20.11"},
+		},
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(actual))
+	th.AssertEquals(t, "private-ip-id", actual[0].ID)
+	th.AssertEquals(t, "DOWN", actual[0].Status)
+	th.AssertEquals(t, "network-id", actual[0].SubnetID)
+	th.AssertEquals(t, "project-id", actual[0].TenantID)
+	th.AssertEquals(t, "", actual[0].DeviceOwner)
+	th.AssertEquals(t, "192.168.20.10", actual[0].IPAddress)
+}
+
+func TestCreateMissingRequiredOpts(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/privateips", func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("no request expected for invalid options")
+	})
+
+	actual, err := privateips.Create(serviceClient(), privateips.CreateOpts{})
+	if err == nil {
+		t.Fatal("expected options validation error")
+	}
+	if actual != nil {
+		t.Fatalf("expected nil response, got %#v", actual)
+	}
+}
+
+func TestCreateInvalidResponse(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/privateips", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"privateips":`))
+	})
+
+	actual, err := privateips.Create(serviceClient(), privateips.CreateOpts{
+		PrivateIPs: []privateips.PrivateIPRequest{{SubnetID: "network-id"}},
+	})
+	if err == nil {
+		t.Fatal("expected response extraction error")
+	}
+	if actual != nil {
+		t.Fatalf("expected nil response, got %#v", actual)
+	}
+}
+
+func TestCreateError(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/privateips", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error_code":"VPC.0207","error_msg":"Invalid private IP parameter."}`))
+	})
+
+	actual, err := privateips.Create(serviceClient(), privateips.CreateOpts{
+		PrivateIPs: []privateips.PrivateIPRequest{{SubnetID: "network-id"}},
+	})
+	if err == nil {
+		t.Fatal("expected request error")
+	}
+	if actual != nil {
+		t.Fatalf("expected nil response, got %#v", actual)
+	}
+}

--- a/openstack/vpc/v1/privateips/Delete.go
+++ b/openstack/vpc/v1/privateips/Delete.go
@@ -1,0 +1,15 @@
+package privateips
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+func Delete(client *golangsdk.ServiceClient, id string) error {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints(client.ProjectID, "privateips", id).
+		Build()
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Delete(client.ServiceURL(url.String()), nil)
+	return err
+}

--- a/openstack/vpc/v1/privateips/Delete_test.go
+++ b/openstack/vpc/v1/privateips/Delete_test.go
@@ -1,0 +1,44 @@
+package privateips_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/privateips"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/privateips/private-ip-id", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodDelete)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	th.AssertNoErr(t, privateips.Delete(serviceClient(), "private-ip-id"))
+}
+
+func TestDeleteError(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/privateips/private-ip-id", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error_code":"VPC.0208","error_msg":"Private IP is in use."}`))
+	})
+
+	if err := privateips.Delete(serviceClient(), "private-ip-id"); err == nil {
+		t.Fatal("expected request error")
+	}
+}
+
+func TestDeleteInvalidID(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	if err := privateips.Delete(serviceClient(), "../vpcs/vpc-id"); err == nil {
+		t.Fatal("expected invalid ID error")
+	}
+}

--- a/openstack/vpc/v1/privateips/Get.go
+++ b/openstack/vpc/v1/privateips/Get.go
@@ -1,0 +1,29 @@
+package privateips
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Get(client *golangsdk.ServiceClient, id string) (*PrivateIP, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints(client.ProjectID, "privateips", id).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		PrivateIP PrivateIP `json:"privateip"`
+	}
+	err = extract.Into(raw.Body, &res)
+	if err != nil {
+		return nil, err
+	}
+	return &res.PrivateIP, err
+}

--- a/openstack/vpc/v1/privateips/Get_test.go
+++ b/openstack/vpc/v1/privateips/Get_test.go
@@ -1,0 +1,92 @@
+package privateips_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/privateips"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/privateips/private-ip-id", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodGet)
+		_, _ = w.Write([]byte(`{"privateip":` + privateIPJSON + `}`))
+	})
+
+	actual, err := privateips.Get(serviceClient(), "private-ip-id")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "private-ip-id", actual.ID)
+	th.AssertEquals(t, "DOWN", actual.Status)
+	th.AssertEquals(t, "network-id", actual.SubnetID)
+	th.AssertEquals(t, "project-id", actual.TenantID)
+	th.AssertEquals(t, "", actual.DeviceOwner)
+	th.AssertEquals(t, "192.168.20.10", actual.IPAddress)
+}
+
+func TestGetZeroValues(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/privateips/private-ip-id", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"privateip":{"id":"private-ip-id"}}`))
+	})
+
+	actual, err := privateips.Get(serviceClient(), "private-ip-id")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "private-ip-id", actual.ID)
+	th.AssertEquals(t, "", actual.Status)
+	th.AssertEquals(t, "", actual.DeviceOwner)
+	th.AssertEquals(t, "", actual.IPAddress)
+}
+
+func TestGetInvalidResponse(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/privateips/private-ip-id", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"privateip":`))
+	})
+
+	actual, err := privateips.Get(serviceClient(), "private-ip-id")
+	if err == nil {
+		t.Fatal("expected response extraction error")
+	}
+	if actual != nil {
+		t.Fatalf("expected nil response, got %#v", actual)
+	}
+}
+
+func TestGetError(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/privateips/private-ip-id", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error_code":"VPC.0206","error_msg":"Private IP does not exist."}`))
+	})
+
+	actual, err := privateips.Get(serviceClient(), "private-ip-id")
+	if err == nil {
+		t.Fatal("expected request error")
+	}
+	if actual != nil {
+		t.Fatalf("expected nil response, got %#v", actual)
+	}
+}
+
+func TestGetInvalidID(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	actual, err := privateips.Get(serviceClient(), "../vpcs/vpc-id")
+	if err == nil {
+		t.Fatal("expected invalid ID error")
+	}
+	if actual != nil {
+		t.Fatalf("expected nil response, got %#v", actual)
+	}
+}

--- a/openstack/vpc/v1/privateips/List.go
+++ b/openstack/vpc/v1/privateips/List.go
@@ -1,0 +1,81 @@
+package privateips
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+)
+
+const defaultPageLimit = 2000
+
+type ListOpts struct {
+	Marker string `q:"marker,omitempty"`
+	Limit  *int   `q:"limit,omitempty"`
+}
+
+func List(client *golangsdk.ServiceClient, subnetID string, opts ListOpts) ([]PrivateIP, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints(client.ProjectID, "subnets", subnetID, "privateips").
+		WithQueryParams(&opts).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	pages, err := pagination.Pager{
+		Client:     client,
+		InitialURL: client.ServiceURL(url.String()),
+		CreatePage: func(r pagination.NewPageResult) pagination.NewPage {
+			return PrivateIPPage{NewPageResult: r}
+		},
+	}.NewAllPages()
+	if err != nil {
+		return nil, err
+	}
+	return ExtractPrivateIPs(pages)
+}
+
+type PrivateIPPage struct {
+	pagination.NewPageResult
+}
+
+func (p PrivateIPPage) NewNextPageURL() (string, error) {
+	privateIPs, err := ExtractPrivateIPs(p)
+	if err != nil || len(privateIPs) == 0 {
+		return "", err
+	}
+
+	limit := defaultPageLimit
+	if value := p.URL.Query().Get("limit"); value != "" {
+		limit, err = strconv.Atoi(value)
+		if err != nil {
+			return "", fmt.Errorf("invalid private IP page limit %q: %w", value, err)
+		}
+	}
+	if limit > 0 && len(privateIPs) < limit {
+		return "", nil
+	}
+
+	next := p.URL
+	query := next.Query()
+	query.Set("marker", privateIPs[len(privateIPs)-1].ID)
+	next.RawQuery = query.Encode()
+	return next.String(), nil
+}
+
+func (p PrivateIPPage) NewIsEmpty() (bool, error) {
+	privateIPs, err := ExtractPrivateIPs(p)
+	return len(privateIPs) == 0, err
+}
+
+func ExtractPrivateIPs(page pagination.NewPage) ([]PrivateIP, error) {
+	var res struct {
+		PrivateIPs []PrivateIP `json:"privateips"`
+	}
+	err := extract.Into(bytes.NewReader(page.(PrivateIPPage).Body), &res)
+	return res.PrivateIPs, err
+}

--- a/openstack/vpc/v1/privateips/List_test.go
+++ b/openstack/vpc/v1/privateips/List_test.go
@@ -1,0 +1,125 @@
+package privateips_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/privateips"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestListAllOptionsAndPagination(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	requestCount := 0
+	th.Mux.HandleFunc("/project-id/subnets/network-id/privateips", func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		th.TestMethod(t, r, http.MethodGet)
+		if actual := r.URL.Query().Get("limit"); actual != "2" {
+			t.Fatalf("unexpected limit %q", actual)
+		}
+
+		switch r.URL.Query().Get("marker") {
+		case "start-id":
+			_, _ = fmt.Fprintf(
+				w,
+				`{"privateips":[%s,%s]}`,
+				strings.ReplaceAll(privateIPJSON, `"private-ip-id"`, `"private-ip-1"`),
+				strings.ReplaceAll(privateIPJSON, `"private-ip-id"`, `"private-ip-2"`),
+			)
+		case "private-ip-2":
+			_, _ = fmt.Fprintf(
+				w,
+				`{"privateips":[%s]}`,
+				strings.ReplaceAll(privateIPJSON, `"private-ip-id"`, `"private-ip-3"`),
+			)
+		case "private-ip-3":
+			_, _ = w.Write([]byte(`{"privateips":[]}`))
+		default:
+			t.Fatalf("unexpected marker %q", r.URL.Query().Get("marker"))
+		}
+	})
+
+	limit := 2
+	actual, err := privateips.List(serviceClient(), "network-id", privateips.ListOpts{
+		Marker: "start-id",
+		Limit:  &limit,
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 3, len(actual))
+	th.AssertEquals(t, "private-ip-1", actual[0].ID)
+	th.AssertEquals(t, "private-ip-3", actual[2].ID)
+	th.AssertEquals(t, "192.168.20.10", actual[0].IPAddress)
+	th.AssertEquals(t, 3, requestCount)
+}
+
+func TestListZeroLimit(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/subnets/network-id/privateips", func(w http.ResponseWriter, r *http.Request) {
+		if actual := r.URL.Query().Get("limit"); actual != "0" {
+			t.Fatalf("unexpected limit %q", actual)
+		}
+		_, _ = w.Write([]byte(`{"privateips":[]}`))
+	})
+
+	limit := 0
+	actual, err := privateips.List(serviceClient(), "network-id", privateips.ListOpts{Limit: &limit})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 0, len(actual))
+}
+
+func TestListNoOptions(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/subnets/network-id/privateips", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery != "" {
+			t.Fatalf("unexpected query %q", r.URL.RawQuery)
+		}
+		_, _ = w.Write([]byte(`{"privateips":[]}`))
+	})
+
+	actual, err := privateips.List(serviceClient(), "network-id", privateips.ListOpts{})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 0, len(actual))
+}
+
+func TestListInvalidResponse(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/subnets/network-id/privateips", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"privateips":`))
+	})
+
+	actual, err := privateips.List(serviceClient(), "network-id", privateips.ListOpts{})
+	if err == nil {
+		t.Fatal("expected response extraction error")
+	}
+	if actual != nil {
+		t.Fatalf("expected nil response, got %#v", actual)
+	}
+}
+
+func TestListError(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/subnets/network-id/privateips", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error_code":"VPC.0207","error_msg":"Invalid private IP parameter."}`))
+	})
+
+	actual, err := privateips.List(serviceClient(), "network-id", privateips.ListOpts{})
+	if err == nil {
+		t.Fatal("expected request error")
+	}
+	if actual != nil {
+		t.Fatalf("expected nil response, got %#v", actual)
+	}
+}

--- a/openstack/vpc/v1/privateips/fixtures_test.go
+++ b/openstack/vpc/v1/privateips/fixtures_test.go
@@ -1,0 +1,21 @@
+package privateips_test
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/testhelper/client"
+)
+
+func serviceClient() *golangsdk.ServiceClient {
+	c := client.ServiceClient()
+	c.ProjectID = "project-id"
+	return c
+}
+
+const privateIPJSON = `{
+	"status": "DOWN",
+	"id": "private-ip-id",
+	"subnet_id": "network-id",
+	"tenant_id": "project-id",
+	"device_owner": "",
+	"ip_address": "192.168.20.10"
+}`

--- a/openstack/vpc/v1/privateips/types.go
+++ b/openstack/vpc/v1/privateips/types.go
@@ -1,0 +1,10 @@
+package privateips
+
+type PrivateIP struct {
+	Status      string `json:"status"`
+	ID          string `json:"id"`
+	SubnetID    string `json:"subnet_id"`
+	TenantID    string `json:"tenant_id"`
+	DeviceOwner string `json:"device_owner"`
+	IPAddress   string `json:"ip_address"`
+}

--- a/openstack/vpc/v1/quotas/List.go
+++ b/openstack/vpc/v1/quotas/List.go
@@ -1,0 +1,40 @@
+package quotas
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type ListOpts struct {
+	Type string `q:"type,omitempty"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]Quota, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints(client.ProjectID, "quotas").
+		WithQueryParams(&opts).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var res struct {
+		Quotas struct {
+			Resources []Quota `json:"resources"`
+		} `json:"quotas"`
+	}
+	err = extract.Into(raw.Body, &res)
+	return res.Quotas.Resources, err
+}
+
+type Quota struct {
+	Type  string `json:"type"`
+	Used  int    `json:"used"`
+	Quota int    `json:"quota"`
+	Min   int    `json:"min"`
+}

--- a/openstack/vpc/v1/quotas/List_test.go
+++ b/openstack/vpc/v1/quotas/List_test.go
@@ -1,0 +1,80 @@
+package quotas_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/quotas"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/quotas", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodGet)
+		th.AssertEquals(t, "publicIp", r.URL.Query().Get("type"))
+		_, _ = w.Write([]byte(quotasJSON))
+	})
+
+	actual, err := quotas.List(serviceClient(), quotas.ListOpts{Type: "publicIp"})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 2, len(actual))
+	th.AssertEquals(t, "publicIp", actual[0].Type)
+	th.AssertEquals(t, 2, actual[0].Used)
+	th.AssertEquals(t, 10, actual[0].Quota)
+	th.AssertEquals(t, 0, actual[0].Min)
+	th.AssertEquals(t, -1, actual[1].Quota)
+}
+
+func TestListNoOptions(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/quotas", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery != "" {
+			t.Fatalf("unexpected query %q", r.URL.RawQuery)
+		}
+		_, _ = w.Write([]byte(`{"quotas":{"resources":[]}}`))
+	})
+
+	actual, err := quotas.List(serviceClient(), quotas.ListOpts{})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 0, len(actual))
+}
+
+func TestListInvalidResponse(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/quotas", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"quotas":`))
+	})
+
+	actual, err := quotas.List(serviceClient(), quotas.ListOpts{})
+	if err == nil {
+		t.Fatal("expected response extraction error")
+	}
+	if actual != nil {
+		t.Fatalf("expected nil response, got %#v", actual)
+	}
+}
+
+func TestListError(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/project-id/quotas", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error_code":"VPC.0002","error_msg":"Invalid parameter."}`))
+	})
+
+	actual, err := quotas.List(serviceClient(), quotas.ListOpts{})
+	if err == nil {
+		t.Fatal("expected request error")
+	}
+	if actual != nil {
+		t.Fatalf("expected nil response, got %#v", actual)
+	}
+}

--- a/openstack/vpc/v1/quotas/fixtures_test.go
+++ b/openstack/vpc/v1/quotas/fixtures_test.go
@@ -1,0 +1,31 @@
+package quotas_test
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/testhelper/client"
+)
+
+func serviceClient() *golangsdk.ServiceClient {
+	c := client.ServiceClient()
+	c.ProjectID = "project-id"
+	return c
+}
+
+const quotasJSON = `{
+	"quotas": {
+		"resources": [
+			{
+				"type": "publicIp",
+				"used": 2,
+				"quota": 10,
+				"min": 0
+			},
+			{
+				"type": "vpc",
+				"used": 0,
+				"quota": -1,
+				"min": 0
+			}
+		]
+	}
+}`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Implements: https://docs.otc.t-systems.com/virtual-private-cloud/api-ref/vpc_apis_v1_v2/private_ip_address/index.html and https://docs.otc.t-systems.com/virtual-private-cloud/api-ref/vpc_apis_v1_v2/quota/index.html
### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
```
=== RUN   TestPrivateIPLifecycle
    privateip_test.go:15: Created VPC: 12739de4-dffb-4fbe-946b-2753b721b10a
    privateip_test.go:20: Waiting for subnet 9aa7f4f3-f4fa-4bbc-894c-a56b237e4e45 to become active
    privateip_test.go:20: Created subnet: 9aa7f4f3-f4fa-4bbc-894c-a56b237e4e45
    privateip_test.go:22: Waiting for subnet 9aa7f4f3-f4fa-4bbc-894c-a56b237e4e45 to be deleted
    privateip_test.go:22: Deleted subnet: 9aa7f4f3-f4fa-4bbc-894c-a56b237e4e45
--- PASS: TestPrivateIPLifecycle (12.88s)
PASS

Process finished with the exit code 0

=== RUN   TestQuotaList
--- PASS: TestQuotaList (0.59s)
PASS

Process finished with the exit code 0
```