### PR TITLE
IMS: add eps options 

### DIFF
--- a/openstack/ims/v1/images/CreateDataImage.go
+++ b/openstack/ims/v1/images/CreateDataImage.go
@@ -38,6 +38,14 @@ type CreateDataImageOpts struct {
 	//
 	// Use either tags or image_tags.
 	ImageTags []tags.ResourceTag `json:"image_tags,omitempty"`
+	// Specifies the enterprise project that an image belongs to.
+	//
+	// If only enterprise project authorization is used, the enterprise_project_id parameter must be specified. Otherwise, an error may occur, indicating that you do not have the required permissions.
+	//
+	// If the value is 0 or left blank, the image belongs to the default enterprise project.
+	// If the value is a UUID, the image belongs to the enterprise project corresponding to the UUID.
+	// For more information about enterprise projects and how to obtain enterprise project IDs, see Enterprise Project Service User Guide.
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
 }
 
 // CreateDataImage This API is used to create a data disk image from a data disk image file uploaded to the OBS bucket. The API is an asynchronous one. If it is successfully called, the cloud service system receives the request. However, you need to use the asynchronous job query API to query the image creation status. For details, see Asynchronous Job Query.

--- a/openstack/ims/v1/images/CreateWholeImageFromCBRorCSBS.go
+++ b/openstack/ims/v1/images/CreateWholeImageFromCBRorCSBS.go
@@ -50,6 +50,14 @@ type CreateWholeImageFromCBRorCSBSOpts struct {
 	//
 	// If you do not specify this parameter, value CSBS is used by default.
 	WholeImageType string `json:"whole_image_type,omitempty"`
+	// Specifies the enterprise project that an image belongs to.
+	//
+	// If only enterprise project authorization is used, the enterprise_project_id parameter must be specified. Otherwise, an error may occur, indicating that you do not have the required permissions.
+	//
+	// If the value is 0 or left blank, an image belongs to the default enterprise project.
+	// If the value is a UUID, an image belongs to the enterprise project with this UUID.
+	// For more information about enterprise projects and how to obtain enterprise project IDs, see Enterprise Project Service User Guide.
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
 }
 
 func CreateWholeImageFromCBRorCSBS(client *golangsdk.ServiceClient, opts CreateWholeImageFromCBRorCSBSOpts) (*string, error) {

--- a/openstack/ims/v1/images/CreateWholeImageFromECS.go
+++ b/openstack/ims/v1/images/CreateWholeImageFromECS.go
@@ -39,6 +39,14 @@ type CreateWholeImageFromECSOpts struct {
 	//
 	// You can obtain the vault ID from the CBR console or section "Querying the Vault List" in Cloud Backup and Recovery API Reference.
 	VaultId string `json:"vault_id,omitempty"`
+	// Specifies the enterprise project that an image belongs to.
+	//
+	// If only enterprise project authorization is used, the enterprise_project_id parameter must be specified. Otherwise, an error may occur, indicating that you do not have the required permissions.
+	//
+	// If the value is 0 or left blank, an image belongs to the default enterprise project.
+	// If the value is a UUID, an image belongs to the enterprise project with this UUID.
+	// For more information about enterprise projects and how to obtain enterprise project IDs, see Enterprise Project Service User Guide.
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
 }
 
 func CreateWholeImageFromECS(client *golangsdk.ServiceClient, opts CreateWholeImageFromECSOpts) (*string, error) {

--- a/openstack/ims/v2/images/CreateImageFromDisk.go
+++ b/openstack/ims/v2/images/CreateImageFromDisk.go
@@ -50,6 +50,14 @@ type CreateImageFromDiskOpts struct {
 	//
 	// Use either tags or image_tags.
 	ImageTags []tags.ResourceTag `json:"image_tags,omitempty"`
+	// Specifies the enterprise project that an image belongs to.
+	//
+	// If only enterprise project authorization is used, the enterprise_project_id parameter must be specified. Otherwise, an error may occur, indicating that you do not have the required permissions.
+	//
+	// If the value is 0 or left blank, an image belongs to the default enterprise project.
+	// If the value is a UUID, an image belongs to the enterprise project with this UUID.
+	// For more information about enterprise projects and how to obtain enterprise project IDs, see Enterprise Project Service User Guide.
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
 }
 
 // CreateImageFromDisk Constraints (Creating a System Disk Image Using a Data Disk)

--- a/openstack/ims/v2/images/CreateImageFromECS.go
+++ b/openstack/ims/v2/images/CreateImageFromECS.go
@@ -39,6 +39,14 @@ type CreateImageFromECSOpts struct {
 	MaxRam int `json:"max_ram,omitempty"`
 	// Specifies the minimum memory of the image in the unit of MB. The default value is 0, indicating that the memory is not restricted.
 	MinRam int `json:"min_ram,omitempty"`
+	// Specifies the enterprise project that an image belongs to.
+	//
+	// If only enterprise project authorization is used, the enterprise_project_id parameter must be specified. Otherwise, an error may occur, indicating that you do not have the required permissions.
+	//
+	// If the value is 0 or left blank, an image belongs to the default enterprise project.
+	// If the value is a UUID, an image belongs to the enterprise project with this UUID.
+	// For more information about enterprise projects and how to obtain enterprise project IDs, see Enterprise Project Service User Guide.
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
 }
 
 type ECSDataImage struct {

--- a/openstack/ims/v2/images/CreateImageFromOBS.go
+++ b/openstack/ims/v2/images/CreateImageFromOBS.go
@@ -76,6 +76,14 @@ type CreateImageFromOBSOpts struct {
 	// ECS and FusionCompute: indicate an ECS image.
 	// BMS and Ironic: indicate a BMS image.the image type, the value can be ECS,BMS,FusionCompute, or Ironic
 	Type string `json:"type,omitempty"`
+	// Specifies the enterprise project that an image belongs to.
+	//
+	// If only enterprise project authorization is used, the enterprise_project_id parameter must be specified. Otherwise, an error may occur, indicating that you do not have the required permissions.
+	//
+	// If the value is 0 or left blank, an image belongs to the default enterprise project.
+	// If the value is a UUID, an image belongs to the enterprise project with this UUID.
+	// For more information about enterprise projects and how to obtain enterprise project IDs, see Enterprise Project Service User Guide.
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
 }
 
 type OBSDataImage struct {

--- a/openstack/ims/v2/images/ImportImageQuick.go
+++ b/openstack/ims/v2/images/ImportImageQuick.go
@@ -39,6 +39,14 @@ type ImportImageQuickOpts struct {
 	// The parameter value is ECS/BMS for system disk images. The default value is ECS.
 	// The parameter value is DataImage for data disk images.
 	Type string `json:"type,omitempty"`
+	// Specifies the enterprise project that an image belongs to.
+	//
+	// If only enterprise project authorization is used, the enterprise_project_id parameter must be specified. Otherwise, an error may occur, indicating that you do not have the required permissions.
+	//
+	// If the value is 0 or left blank, the image belongs to the default enterprise project.
+	// If the value is a UUID, the image belongs to the enterprise project corresponding to the UUID.
+	// For more information about enterprise projects and how to obtain enterprise project IDs, see Enterprise Project Service User Guide.
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
 }
 
 func ImportImageQuick(client *golangsdk.ServiceClient, opts ImportImageQuickOpts) (*string, error) {


### PR DESCRIPTION
### Acceptance tests
```
=== RUN   TestCreateImageFromECS
    create_image_from_ECS_test.go:17: long run test only for manual purpose
--- SKIP: TestCreateImageFromECS (0.00s)
=== RUN   TestCreateImageFromOBS
    create_image_obs_test.go:14: long run test only for manual purpose
--- SKIP: TestCreateImageFromOBS (0.00s)
=== RUN   TestCreateDataImage
--- PASS: TestCreateDataImage (147.50s)
=== RUN   TestCreateWholeImageFromCBR
    create_whole_image_from_ECS_test.go:18: long run test only for manual purpose
--- SKIP: TestCreateWholeImageFromCBR (0.00s)
=== RUN   TestCreateWholeImageFromECS
    common.go:150: Change image query filter, no results returned
--- SKIP: TestCreateWholeImageFromECS (1.83s)
=== RUN   TestImageServiceV2MemberLifecycle
    members_test.go:19: OS_PROJECT_ID_2 or OS_PRIVATE_IMAGE_ID env vars are missing but IMS member test requires it
--- SKIP: TestImageServiceV2MemberLifecycle (0.33s)
PASS
ok  	github.com/opentelekomcloud/gophertelekomcloud/acceptance/openstack/ims	(cached)

```