### PR TITLE
[Feat.] Add VPC security group operations

### DIFF
--- a/acceptance/openstack/vpc/v1/security_group_test.go
+++ b/acceptance/openstack/vpc/v1/security_group_test.go
@@ -1,0 +1,86 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/securitygrouprules"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/securitygroups"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestSecurityGroupLifecycle(t *testing.T) {
+	client, err := clients.NewVPCV1Client()
+	th.AssertNoErr(t, err)
+
+	group, err := securitygroups.Create(client, securitygroups.CreateOpts{
+		Name:                tools.RandomString("security-group-acc-", 3),
+		EnterpriseProjectID: "0",
+	})
+	th.AssertNoErr(t, err)
+	groupID := group.ID
+	t.Cleanup(func() {
+		if groupID != "" {
+			th.AssertNoErr(t, securitygroups.Delete(client, groupID))
+		}
+	})
+
+	actualGroup, err := securitygroups.Get(client, groupID)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, groupID, actualGroup.ID)
+
+	groups, err := securitygroups.List(client, securitygroups.ListOpts{EnterpriseProjectID: "0"})
+	th.AssertNoErr(t, err)
+	groupFound := false
+	for _, candidate := range groups {
+		if candidate.ID == groupID {
+			groupFound = true
+			break
+		}
+	}
+	th.AssertEquals(t, true, groupFound)
+
+	rule, err := securitygrouprules.Create(client, securitygrouprules.CreateOpts{
+		SecurityGroupID: groupID,
+		Description:     "acceptance rule",
+		Direction:       "ingress",
+		EtherType:       "IPv4",
+		Protocol:        "tcp",
+		PortRangeMin:    pointerto.Int(8080),
+		PortRangeMax:    pointerto.Int(8080),
+		RemoteIPPrefix:  "192.0.2.0/24",
+	})
+	th.AssertNoErr(t, err)
+	ruleID := rule.ID
+	t.Cleanup(func() {
+		if ruleID != "" {
+			th.AssertNoErr(t, securitygrouprules.Delete(client, ruleID))
+		}
+	})
+
+	actualRule, err := securitygrouprules.Get(client, ruleID)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, ruleID, actualRule.ID)
+	th.AssertEquals(t, groupID, actualRule.SecurityGroupID)
+
+	rules, err := securitygrouprules.List(client, securitygrouprules.ListOpts{
+		SecurityGroupID: groupID,
+		RemoteIPPrefix:  "192.0.2.0/24",
+	})
+	th.AssertNoErr(t, err)
+	ruleFound := false
+	for _, candidate := range rules {
+		if candidate.ID == ruleID {
+			ruleFound = true
+			break
+		}
+	}
+	th.AssertEquals(t, true, ruleFound)
+
+	th.AssertNoErr(t, securitygrouprules.Delete(client, ruleID))
+	ruleID = ""
+	th.AssertNoErr(t, securitygroups.Delete(client, groupID))
+	groupID = ""
+}

--- a/acceptance/openstack/vpc/v2/security_group_test.go
+++ b/acceptance/openstack/vpc/v2/security_group_test.go
@@ -1,0 +1,124 @@
+package v2
+
+import (
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/networking/v2/ports"
+	v1groups "github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/securitygroups"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/subnets"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/vpcs"
+	v2groups "github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v2/securitygroups"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestSecurityGroupUpdatePorts(t *testing.T) {
+	v1Client, err := clients.NewVPCV1Client()
+	th.AssertNoErr(t, err)
+	v2Client, err := clients.NewVPCV2Client()
+	th.AssertNoErr(t, err)
+	networkClient, err := clients.NewNetworkV2Client()
+	th.AssertNoErr(t, err)
+
+	group, err := v1groups.Create(v1Client, v1groups.CreateOpts{
+		Name: tools.RandomString("security-group-ports-acc-", 3),
+	})
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		th.AssertNoErr(t, v1groups.Delete(v1Client, group.ID))
+	})
+
+	vpc := createSecurityGroupVPC(t, v1Client)
+	t.Cleanup(func() {
+		deleteSecurityGroupVPC(t, v1Client, vpc.ID)
+	})
+	subnet := createSecurityGroupSubnet(t, v1Client, vpc.ID)
+	t.Cleanup(func() {
+		deleteSecurityGroupSubnet(t, v1Client, subnet.VpcID, subnet.ID)
+	})
+
+	port, err := ports.Create(networkClient, ports.CreateOpts{
+		NetworkID: subnet.NetworkID,
+		Name:      tools.RandomString("security-group-port-acc-", 3),
+	}).Extract()
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		th.AssertNoErr(t, ports.Delete(networkClient, port.ID).ExtractErr())
+	})
+
+	failures, err := v2groups.UpdatePorts(v2Client, group.ID, v2groups.UpdatePortsOpts{
+		Ports:  []v2groups.Port{{ID: port.ID}},
+		Action: "add",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 0, len(failures))
+
+	failures, err = v2groups.UpdatePorts(v2Client, group.ID, v2groups.UpdatePortsOpts{
+		Ports:  []v2groups.Port{{ID: port.ID}},
+		Action: "remove",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 0, len(failures))
+}
+
+func createSecurityGroupVPC(t *testing.T, client *golangsdk.ServiceClient) *vpcs.Vpc {
+	t.Helper()
+	vpc, err := vpcs.Create(client, vpcs.CreateOpts{
+		Name: tools.RandomString("security-group-vpc-acc-", 3),
+		CIDR: "192.168.0.0/16",
+	})
+	th.AssertNoErr(t, err)
+	return vpc
+}
+
+func createSecurityGroupSubnet(t *testing.T, client *golangsdk.ServiceClient, vpcID string) *subnets.Subnet {
+	t.Helper()
+	subnet, err := subnets.Create(client, subnets.CreateOpts{
+		Name:       tools.RandomString("security-group-subnet-acc-", 3),
+		CIDR:       "192.168.30.0/24",
+		GatewayIP:  "192.168.30.1",
+		EnableDHCP: pointerto.Bool(true),
+		VpcID:      vpcID,
+	})
+	th.AssertNoErr(t, err)
+	th.AssertNoErr(t, golangsdk.WaitFor(600, func() (bool, error) {
+		current, err := subnets.Get(client, subnet.ID)
+		if err != nil {
+			return false, err
+		}
+		return current.Status == "ACTIVE", nil
+	}))
+	return subnet
+}
+
+func deleteSecurityGroupSubnet(t *testing.T, client *golangsdk.ServiceClient, vpcID, subnetID string) {
+	t.Helper()
+	th.AssertNoErr(t, subnets.Delete(client, vpcID, subnetID))
+	th.AssertNoErr(t, golangsdk.WaitFor(600, func() (bool, error) {
+		_, err := subnets.Get(client, subnetID)
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			return true, nil
+		}
+		return false, err
+	}))
+}
+
+func deleteSecurityGroupVPC(t *testing.T, client *golangsdk.ServiceClient, vpcID string) {
+	t.Helper()
+	th.AssertNoErr(t, golangsdk.WaitFor(600, func() (bool, error) {
+		err := vpcs.Delete(client, vpcID)
+		if err == nil {
+			return true, nil
+		}
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			return true, nil
+		}
+		if _, ok := err.(golangsdk.ErrDefault409); ok {
+			return false, nil
+		}
+		return false, err
+	}))
+}

--- a/openstack/vpc/v1/securitygrouprules/Create.go
+++ b/openstack/vpc/v1/securitygrouprules/Create.go
@@ -1,0 +1,40 @@
+package securitygrouprules
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateOpts struct {
+	SecurityGroupID      string `json:"security_group_id" required:"true"`
+	Description          string `json:"description,omitempty"`
+	Direction            string `json:"direction" required:"true"`
+	EtherType            string `json:"ethertype,omitempty"`
+	Protocol             string `json:"protocol,omitempty"`
+	PortRangeMin         *int   `json:"port_range_min,omitempty"`
+	PortRangeMax         *int   `json:"port_range_max,omitempty"`
+	RemoteIPPrefix       string `json:"remote_ip_prefix,omitempty"`
+	RemoteGroupID        string `json:"remote_group_id,omitempty"`
+	RemoteAddressGroupID string `json:"remote_address_group_id,omitempty"`
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*SecurityGroupRule, error) {
+	b, err := build.RequestBody(opts, "security_group_rule")
+	if err != nil {
+		return nil, err
+	}
+	raw, err := client.Post(client.ServiceURL(client.ProjectID, "security-group-rules"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+	var res struct {
+		SecurityGroupRule SecurityGroupRule `json:"security_group_rule"`
+	}
+	if err = extract.Into(raw.Body, &res); err != nil {
+		return nil, err
+	}
+	return &res.SecurityGroupRule, nil
+}

--- a/openstack/vpc/v1/securitygrouprules/Create.go
+++ b/openstack/vpc/v1/securitygrouprules/Create.go
@@ -25,7 +25,7 @@ func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*SecurityGroupRul
 		return nil, err
 	}
 	raw, err := client.Post(client.ServiceURL(client.ProjectID, "security-group-rules"), b, nil, &golangsdk.RequestOpts{
-		OkCodes: []int{200},
+		OkCodes: []int{200, 201},
 	})
 	if err != nil {
 		return nil, err

--- a/openstack/vpc/v1/securitygrouprules/Create_test.go
+++ b/openstack/vpc/v1/securitygrouprules/Create_test.go
@@ -1,0 +1,37 @@
+package securitygrouprules_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/securitygrouprules"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/project-id/security-group-rules", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodPost)
+		th.TestJSONRequest(t, r, `{"security_group_rule":{"security_group_id":"group-id","description":"allow web","direction":"ingress","ethertype":"IPv4","protocol":"tcp","port_range_min":0,"port_range_max":80,"remote_ip_prefix":"10.0.0.0/24"}}`)
+		_, _ = w.Write([]byte(`{"security_group_rule":` + ruleJSON + `}`))
+	})
+	actual, err := securitygrouprules.Create(serviceClient(), securitygrouprules.CreateOpts{
+		SecurityGroupID: "group-id", Description: "allow web", Direction: "ingress",
+		EtherType: "IPv4", Protocol: "tcp", PortRangeMin: pointerto.Int(0),
+		PortRangeMax: pointerto.Int(80), RemoteIPPrefix: "10.0.0.0/24",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "rule-id", actual.ID)
+	th.AssertEquals(t, 80, *actual.PortRangeMin)
+}
+
+func TestCreateMissingRequiredOpts(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	actual, err := securitygrouprules.Create(serviceClient(), securitygrouprules.CreateOpts{})
+	if err == nil || actual != nil {
+		t.Fatalf("expected nil response and validation error, got %#v, %v", actual, err)
+	}
+}

--- a/openstack/vpc/v1/securitygrouprules/Delete.go
+++ b/openstack/vpc/v1/securitygrouprules/Delete.go
@@ -1,0 +1,12 @@
+package securitygrouprules
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+func Delete(client *golangsdk.ServiceClient, id string) error {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints(client.ProjectID, "security-group-rules", id).Build()
+	if err != nil {
+		return err
+	}
+	_, err = client.Delete(client.ServiceURL(url.String()), nil)
+	return err
+}

--- a/openstack/vpc/v1/securitygrouprules/Delete_test.go
+++ b/openstack/vpc/v1/securitygrouprules/Delete_test.go
@@ -1,0 +1,27 @@
+package securitygrouprules_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/securitygrouprules"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/project-id/security-group-rules/rule-id", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodDelete)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	th.AssertNoErr(t, securitygrouprules.Delete(serviceClient(), "rule-id"))
+}
+
+func TestDeleteInvalidID(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	if err := securitygrouprules.Delete(serviceClient(), "../security-groups/group-id"); err == nil {
+		t.Fatal("expected invalid ID error")
+	}
+}

--- a/openstack/vpc/v1/securitygrouprules/Get.go
+++ b/openstack/vpc/v1/securitygrouprules/Get.go
@@ -1,0 +1,24 @@
+package securitygrouprules
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Get(client *golangsdk.ServiceClient, id string) (*SecurityGroupRule, error) {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints(client.ProjectID, "security-group-rules", id).Build()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	var res struct {
+		SecurityGroupRule SecurityGroupRule `json:"security_group_rule"`
+	}
+	if err = extract.Into(raw.Body, &res); err != nil {
+		return nil, err
+	}
+	return &res.SecurityGroupRule, nil
+}

--- a/openstack/vpc/v1/securitygrouprules/Get_test.go
+++ b/openstack/vpc/v1/securitygrouprules/Get_test.go
@@ -1,0 +1,31 @@
+package securitygrouprules_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/securitygrouprules"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/project-id/security-group-rules/rule-id", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodGet)
+		_, _ = w.Write([]byte(`{"security_group_rule":` + ruleJSON + `}`))
+	})
+	actual, err := securitygrouprules.Get(serviceClient(), "rule-id")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "rule-id", actual.ID)
+	th.AssertEquals(t, 80, *actual.PortRangeMax)
+}
+
+func TestGetInvalidID(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	actual, err := securitygrouprules.Get(serviceClient(), "../security-groups/group-id")
+	if err == nil || actual != nil {
+		t.Fatalf("expected nil response and invalid ID error, got %#v, %v", actual, err)
+	}
+}

--- a/openstack/vpc/v1/securitygrouprules/List.go
+++ b/openstack/vpc/v1/securitygrouprules/List.go
@@ -1,0 +1,80 @@
+package securitygrouprules
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+)
+
+const defaultPageLimit = 2000
+
+type ListOpts struct {
+	Marker          string `q:"marker,omitempty"`
+	Limit           *int   `q:"limit,omitempty"`
+	SecurityGroupID string `q:"security_group_id,omitempty"`
+	RemoteIPPrefix  string `q:"remote_ip_prefix,omitempty"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]SecurityGroupRule, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints(client.ProjectID, "security-group-rules").
+		WithQueryParams(&opts).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+	pages, err := pagination.Pager{
+		Client:     client,
+		InitialURL: client.ServiceURL(url.String()),
+		CreatePage: func(r pagination.NewPageResult) pagination.NewPage {
+			return SecurityGroupRulePage{NewPageResult: r}
+		},
+	}.NewAllPages()
+	if err != nil {
+		return nil, err
+	}
+	return ExtractSecurityGroupRules(pages)
+}
+
+type SecurityGroupRulePage struct {
+	pagination.NewPageResult
+}
+
+func (p SecurityGroupRulePage) NewNextPageURL() (string, error) {
+	rules, err := ExtractSecurityGroupRules(p)
+	if err != nil || len(rules) == 0 {
+		return "", err
+	}
+	limit := defaultPageLimit
+	if value := p.URL.Query().Get("limit"); value != "" {
+		limit, err = strconv.Atoi(value)
+		if err != nil {
+			return "", fmt.Errorf("invalid security group rule page limit %q: %w", value, err)
+		}
+	}
+	if limit > 0 && len(rules) < limit {
+		return "", nil
+	}
+	next := p.URL
+	query := next.Query()
+	query.Set("marker", rules[len(rules)-1].ID)
+	next.RawQuery = query.Encode()
+	return next.String(), nil
+}
+
+func (p SecurityGroupRulePage) NewIsEmpty() (bool, error) {
+	rules, err := ExtractSecurityGroupRules(p)
+	return len(rules) == 0, err
+}
+
+func ExtractSecurityGroupRules(page pagination.NewPage) ([]SecurityGroupRule, error) {
+	var res struct {
+		SecurityGroupRules []SecurityGroupRule `json:"security_group_rules"`
+	}
+	err := extract.Into(bytes.NewReader(page.(SecurityGroupRulePage).Body), &res)
+	return res.SecurityGroupRules, err
+}

--- a/openstack/vpc/v1/securitygrouprules/List_test.go
+++ b/openstack/vpc/v1/securitygrouprules/List_test.go
@@ -1,0 +1,56 @@
+package securitygrouprules_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/securitygrouprules"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestListAllOptionsAndPagination(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	requests := 0
+	th.Mux.HandleFunc("/project-id/security-group-rules", func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		th.AssertEquals(t, "2", r.URL.Query().Get("limit"))
+		th.AssertEquals(t, "group-id", r.URL.Query().Get("security_group_id"))
+		th.AssertEquals(t, "10.0.0.0/24", r.URL.Query().Get("remote_ip_prefix"))
+		switch r.URL.Query().Get("marker") {
+		case "start":
+			_, _ = fmt.Fprintf(w, `{"security_group_rules":[%s,%s]}`,
+				strings.ReplaceAll(ruleJSON, `"rule-id"`, `"rule-1"`),
+				strings.ReplaceAll(ruleJSON, `"rule-id"`, `"rule-2"`))
+		case "rule-2":
+			_, _ = fmt.Fprintf(w, `{"security_group_rules":[%s]}`,
+				strings.ReplaceAll(ruleJSON, `"rule-id"`, `"rule-3"`))
+		case "rule-3":
+			_, _ = w.Write([]byte(`{"security_group_rules":[]}`))
+		default:
+			t.Fatalf("unexpected marker %q", r.URL.Query().Get("marker"))
+		}
+	})
+	limit := 2
+	actual, err := securitygrouprules.List(serviceClient(), securitygrouprules.ListOpts{
+		Marker: "start", Limit: &limit, SecurityGroupID: "group-id", RemoteIPPrefix: "10.0.0.0/24",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 3, len(actual))
+	th.AssertEquals(t, "rule-3", actual[2].ID)
+	th.AssertEquals(t, 3, requests)
+}
+
+func TestListInvalidResponse(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/project-id/security-group-rules", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"security_group_rules":`))
+	})
+	actual, err := securitygrouprules.List(serviceClient(), securitygrouprules.ListOpts{})
+	if err == nil || actual != nil {
+		t.Fatalf("expected nil response and extraction error, got %#v, %v", actual, err)
+	}
+}

--- a/openstack/vpc/v1/securitygrouprules/fixtures_test.go
+++ b/openstack/vpc/v1/securitygrouprules/fixtures_test.go
@@ -1,0 +1,27 @@
+package securitygrouprules_test
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/testhelper/client"
+)
+
+func serviceClient() *golangsdk.ServiceClient {
+	c := client.ServiceClient()
+	c.ProjectID = "project-id"
+	return c
+}
+
+const ruleJSON = `{
+	"id":"rule-id",
+	"description":"allow web",
+	"security_group_id":"group-id",
+	"direction":"ingress",
+	"ethertype":"IPv4",
+	"protocol":"tcp",
+	"port_range_min":80,
+	"port_range_max":80,
+	"remote_ip_prefix":"10.0.0.0/24",
+	"remote_group_id":null,
+	"remote_address_group_id":null,
+	"tenant_id":"project-id"
+}`

--- a/openstack/vpc/v1/securitygrouprules/types.go
+++ b/openstack/vpc/v1/securitygrouprules/types.go
@@ -1,0 +1,16 @@
+package securitygrouprules
+
+type SecurityGroupRule struct {
+	ID                   string `json:"id"`
+	Description          string `json:"description"`
+	SecurityGroupID      string `json:"security_group_id"`
+	Direction            string `json:"direction"`
+	EtherType            string `json:"ethertype"`
+	Protocol             string `json:"protocol"`
+	PortRangeMin         *int   `json:"port_range_min"`
+	PortRangeMax         *int   `json:"port_range_max"`
+	RemoteIPPrefix       string `json:"remote_ip_prefix"`
+	RemoteGroupID        string `json:"remote_group_id"`
+	RemoteAddressGroupID string `json:"remote_address_group_id"`
+	TenantID             string `json:"tenant_id"`
+}

--- a/openstack/vpc/v1/securitygroups/Create.go
+++ b/openstack/vpc/v1/securitygroups/Create.go
@@ -1,0 +1,33 @@
+package securitygroups
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateOpts struct {
+	Name                string `json:"name" required:"true"`
+	VpcID               string `json:"vpc_id,omitempty"`
+	EnterpriseProjectID string `json:"enterprise_project_id,omitempty"`
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*SecurityGroup, error) {
+	b, err := build.RequestBody(opts, "security_group")
+	if err != nil {
+		return nil, err
+	}
+	raw, err := client.Post(client.ServiceURL(client.ProjectID, "security-groups"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+	var res struct {
+		SecurityGroup SecurityGroup `json:"security_group"`
+	}
+	if err = extract.Into(raw.Body, &res); err != nil {
+		return nil, err
+	}
+	return &res.SecurityGroup, nil
+}

--- a/openstack/vpc/v1/securitygroups/Create_test.go
+++ b/openstack/vpc/v1/securitygroups/Create_test.go
@@ -1,0 +1,47 @@
+package securitygroups_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/securitygroups"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/project-id/security-groups", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodPost)
+		th.TestJSONRequest(t, r, `{"security_group":{"name":"sg-test","vpc_id":"vpc-id","enterprise_project_id":"0"}}`)
+		_, _ = w.Write([]byte(`{"security_group":` + groupJSON + `}`))
+	})
+	actual, err := securitygroups.Create(serviceClient(), securitygroups.CreateOpts{
+		Name: "sg-test", VpcID: "vpc-id", EnterpriseProjectID: "0",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "group-id", actual.ID)
+	th.AssertEquals(t, "default", actual.Description)
+	th.AssertEquals(t, 1, len(actual.SecurityGroupRules))
+}
+
+func TestCreateMissingRequiredOpts(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	actual, err := securitygroups.Create(serviceClient(), securitygroups.CreateOpts{})
+	if err == nil || actual != nil {
+		t.Fatalf("expected nil response and validation error, got %#v, %v", actual, err)
+	}
+}
+
+func TestCreateError(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/project-id/security-groups", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	})
+	actual, err := securitygroups.Create(serviceClient(), securitygroups.CreateOpts{Name: "sg-test"})
+	if err == nil || actual != nil {
+		t.Fatalf("expected nil response and request error, got %#v, %v", actual, err)
+	}
+}

--- a/openstack/vpc/v1/securitygroups/Delete.go
+++ b/openstack/vpc/v1/securitygroups/Delete.go
@@ -1,0 +1,12 @@
+package securitygroups
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+func Delete(client *golangsdk.ServiceClient, id string) error {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints(client.ProjectID, "security-groups", id).Build()
+	if err != nil {
+		return err
+	}
+	_, err = client.Delete(client.ServiceURL(url.String()), nil)
+	return err
+}

--- a/openstack/vpc/v1/securitygroups/Delete_test.go
+++ b/openstack/vpc/v1/securitygroups/Delete_test.go
@@ -1,0 +1,27 @@
+package securitygroups_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/securitygroups"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/project-id/security-groups/group-id", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodDelete)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	th.AssertNoErr(t, securitygroups.Delete(serviceClient(), "group-id"))
+}
+
+func TestDeleteInvalidID(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	if err := securitygroups.Delete(serviceClient(), "../vpcs/vpc-id"); err == nil {
+		t.Fatal("expected invalid ID error")
+	}
+}

--- a/openstack/vpc/v1/securitygroups/Get.go
+++ b/openstack/vpc/v1/securitygroups/Get.go
@@ -1,0 +1,24 @@
+package securitygroups
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Get(client *golangsdk.ServiceClient, id string) (*SecurityGroup, error) {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints(client.ProjectID, "security-groups", id).Build()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	var res struct {
+		SecurityGroup SecurityGroup `json:"security_group"`
+	}
+	if err = extract.Into(raw.Body, &res); err != nil {
+		return nil, err
+	}
+	return &res.SecurityGroup, nil
+}

--- a/openstack/vpc/v1/securitygroups/Get_test.go
+++ b/openstack/vpc/v1/securitygroups/Get_test.go
@@ -1,0 +1,44 @@
+package securitygroups_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/securitygroups"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/project-id/security-groups/group-id", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodGet)
+		_, _ = w.Write([]byte(`{"security_group":` + groupJSON + `}`))
+	})
+	actual, err := securitygroups.Get(serviceClient(), "group-id")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "group-id", actual.ID)
+	th.AssertEquals(t, "vpc-id", actual.VpcID)
+	th.AssertEquals(t, (*int)(nil), actual.SecurityGroupRules[0].PortRangeMin)
+}
+
+func TestGetInvalidID(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	actual, err := securitygroups.Get(serviceClient(), "../vpcs/vpc-id")
+	if err == nil || actual != nil {
+		t.Fatalf("expected nil response and invalid ID error, got %#v, %v", actual, err)
+	}
+}
+
+func TestGetInvalidResponse(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/project-id/security-groups/group-id", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"security_group":`))
+	})
+	actual, err := securitygroups.Get(serviceClient(), "group-id")
+	if err == nil || actual != nil {
+		t.Fatalf("expected nil response and extraction error, got %#v, %v", actual, err)
+	}
+}

--- a/openstack/vpc/v1/securitygroups/List.go
+++ b/openstack/vpc/v1/securitygroups/List.go
@@ -1,0 +1,80 @@
+package securitygroups
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+)
+
+const defaultPageLimit = 2000
+
+type ListOpts struct {
+	Marker              string `q:"marker,omitempty"`
+	Limit               *int   `q:"limit,omitempty"`
+	VpcID               string `q:"vpc_id,omitempty"`
+	EnterpriseProjectID string `q:"enterprise_project_id,omitempty"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]SecurityGroup, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints(client.ProjectID, "security-groups").
+		WithQueryParams(&opts).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+	pages, err := pagination.Pager{
+		Client:     client,
+		InitialURL: client.ServiceURL(url.String()),
+		CreatePage: func(r pagination.NewPageResult) pagination.NewPage {
+			return SecurityGroupPage{NewPageResult: r}
+		},
+	}.NewAllPages()
+	if err != nil {
+		return nil, err
+	}
+	return ExtractSecurityGroups(pages)
+}
+
+type SecurityGroupPage struct {
+	pagination.NewPageResult
+}
+
+func (p SecurityGroupPage) NewNextPageURL() (string, error) {
+	groups, err := ExtractSecurityGroups(p)
+	if err != nil || len(groups) == 0 {
+		return "", err
+	}
+	limit := defaultPageLimit
+	if value := p.URL.Query().Get("limit"); value != "" {
+		limit, err = strconv.Atoi(value)
+		if err != nil {
+			return "", fmt.Errorf("invalid security group page limit %q: %w", value, err)
+		}
+	}
+	if limit > 0 && len(groups) < limit {
+		return "", nil
+	}
+	next := p.URL
+	query := next.Query()
+	query.Set("marker", groups[len(groups)-1].ID)
+	next.RawQuery = query.Encode()
+	return next.String(), nil
+}
+
+func (p SecurityGroupPage) NewIsEmpty() (bool, error) {
+	groups, err := ExtractSecurityGroups(p)
+	return len(groups) == 0, err
+}
+
+func ExtractSecurityGroups(page pagination.NewPage) ([]SecurityGroup, error) {
+	var res struct {
+		SecurityGroups []SecurityGroup `json:"security_groups"`
+	}
+	err := extract.Into(bytes.NewReader(page.(SecurityGroupPage).Body), &res)
+	return res.SecurityGroups, err
+}

--- a/openstack/vpc/v1/securitygroups/List_test.go
+++ b/openstack/vpc/v1/securitygroups/List_test.go
@@ -1,0 +1,58 @@
+package securitygroups_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/securitygroups"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestListAllOptionsAndPagination(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	requests := 0
+	th.Mux.HandleFunc("/project-id/security-groups", func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		th.TestMethod(t, r, http.MethodGet)
+		th.AssertEquals(t, "2", r.URL.Query().Get("limit"))
+		th.AssertEquals(t, "vpc-id", r.URL.Query().Get("vpc_id"))
+		th.AssertEquals(t, "0", r.URL.Query().Get("enterprise_project_id"))
+		switch r.URL.Query().Get("marker") {
+		case "start":
+			_, _ = fmt.Fprintf(w, `{"security_groups":[%s,%s]}`,
+				strings.ReplaceAll(groupJSON, `"group-id"`, `"group-1"`),
+				strings.ReplaceAll(groupJSON, `"group-id"`, `"group-2"`))
+		case "group-2":
+			_, _ = fmt.Fprintf(w, `{"security_groups":[%s]}`,
+				strings.ReplaceAll(groupJSON, `"group-id"`, `"group-3"`))
+		case "group-3":
+			_, _ = w.Write([]byte(`{"security_groups":[]}`))
+		default:
+			t.Fatalf("unexpected marker %q", r.URL.Query().Get("marker"))
+		}
+	})
+	limit := 2
+	actual, err := securitygroups.List(serviceClient(), securitygroups.ListOpts{
+		Marker: "start", Limit: &limit, VpcID: "vpc-id", EnterpriseProjectID: "0",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 3, len(actual))
+	th.AssertEquals(t, "group-3", actual[2].ID)
+	th.AssertEquals(t, 3, requests)
+}
+
+func TestListNoOptionsAndInvalidResponse(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/project-id/security-groups", func(w http.ResponseWriter, r *http.Request) {
+		th.AssertEquals(t, "", r.URL.RawQuery)
+		_, _ = w.Write([]byte(`{"security_groups":`))
+	})
+	actual, err := securitygroups.List(serviceClient(), securitygroups.ListOpts{})
+	if err == nil || actual != nil {
+		t.Fatalf("expected nil response and extraction error, got %#v, %v", actual, err)
+	}
+}

--- a/openstack/vpc/v1/securitygroups/fixtures_test.go
+++ b/openstack/vpc/v1/securitygroups/fixtures_test.go
@@ -1,0 +1,34 @@
+package securitygroups_test
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/testhelper/client"
+)
+
+func serviceClient() *golangsdk.ServiceClient {
+	c := client.ServiceClient()
+	c.ProjectID = "project-id"
+	return c
+}
+
+const groupJSON = `{
+	"name":"sg-test",
+	"description":"default",
+	"id":"group-id",
+	"vpc_id":"vpc-id",
+	"enterprise_project_id":"0",
+	"security_group_rules":[{
+		"id":"rule-id",
+		"description":"",
+		"security_group_id":"group-id",
+		"direction":"egress",
+		"ethertype":"IPv4",
+		"protocol":null,
+		"port_range_min":null,
+		"port_range_max":null,
+		"remote_ip_prefix":null,
+		"remote_group_id":null,
+		"remote_address_group_id":null,
+		"tenant_id":"project-id"
+	}]
+}`

--- a/openstack/vpc/v1/securitygroups/types.go
+++ b/openstack/vpc/v1/securitygroups/types.go
@@ -1,0 +1,25 @@
+package securitygroups
+
+type SecurityGroup struct {
+	Name                string              `json:"name"`
+	Description         string              `json:"description"`
+	ID                  string              `json:"id"`
+	VpcID               string              `json:"vpc_id"`
+	SecurityGroupRules  []SecurityGroupRule `json:"security_group_rules"`
+	EnterpriseProjectID string              `json:"enterprise_project_id"`
+}
+
+type SecurityGroupRule struct {
+	ID                   string `json:"id"`
+	Description          string `json:"description"`
+	SecurityGroupID      string `json:"security_group_id"`
+	Direction            string `json:"direction"`
+	EtherType            string `json:"ethertype"`
+	Protocol             string `json:"protocol"`
+	PortRangeMin         *int   `json:"port_range_min"`
+	PortRangeMax         *int   `json:"port_range_max"`
+	RemoteIPPrefix       string `json:"remote_ip_prefix"`
+	RemoteGroupID        string `json:"remote_group_id"`
+	RemoteAddressGroupID string `json:"remote_address_group_id"`
+	TenantID             string `json:"tenant_id"`
+}

--- a/openstack/vpc/v2/securitygroups/UpdatePorts.go
+++ b/openstack/vpc/v2/securitygroups/UpdatePorts.go
@@ -1,0 +1,48 @@
+package securitygroups
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type UpdatePortsOpts struct {
+	Ports  []Port `json:"ports" required:"true"`
+	Action string `json:"action" required:"true"`
+}
+
+type Port struct {
+	ID string `json:"id" required:"true"`
+}
+
+type FailedPort struct {
+	ID        string `json:"id"`
+	ErrorCode string `json:"error_code"`
+	ErrorMsg  string `json:"error_msg"`
+}
+
+func UpdatePorts(client *golangsdk.ServiceClient, securityGroupID string, opts UpdatePortsOpts) ([]FailedPort, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints(client.ProjectID, "security-groups", securityGroupID, "instance", "action").
+		Build()
+	if err != nil {
+		return nil, err
+	}
+	b, err := build.RequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	raw, err := client.Post(client.ServiceURL(url.String()), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+	var res struct {
+		Fail []FailedPort `json:"fail"`
+	}
+	if err = extract.Into(raw.Body, &res); err != nil {
+		return nil, err
+	}
+	return res.Fail, nil
+}

--- a/openstack/vpc/v2/securitygroups/UpdatePorts_test.go
+++ b/openstack/vpc/v2/securitygroups/UpdatePorts_test.go
@@ -1,0 +1,57 @@
+package securitygroups_test
+
+import (
+	"net/http"
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v2/securitygroups"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/gophertelekomcloud/testhelper/client"
+)
+
+func serviceClient() *golangsdk.ServiceClient {
+	c := client.ServiceClient()
+	c.ProjectID = "project-id"
+	return c
+}
+
+func TestUpdatePorts(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/project-id/security-groups/group-id/instance/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodPost)
+		th.TestJSONRequest(t, r, `{"ports":[{"id":"port-1"},{"id":"port-2"}],"action":"add"}`)
+		_, _ = w.Write([]byte(`{"fail":[]}`))
+	})
+	actual, err := securitygroups.UpdatePorts(serviceClient(), "group-id", securitygroups.UpdatePortsOpts{
+		Ports: []securitygroups.Port{{ID: "port-1"}, {ID: "port-2"}}, Action: "add",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 0, len(actual))
+}
+
+func TestUpdatePortsFailureResponse(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/project-id/security-groups/group-id/instance/action", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"fail":[{"id":"port-1","error_code":"VPC.0608","error_msg":"not found"}]}`))
+	})
+	actual, err := securitygroups.UpdatePorts(serviceClient(), "group-id", securitygroups.UpdatePortsOpts{
+		Ports: []securitygroups.Port{{ID: "port-1"}}, Action: "remove",
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "port-1", actual[0].ID)
+	th.AssertEquals(t, "VPC.0608", actual[0].ErrorCode)
+}
+
+func TestUpdatePortsInvalidID(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	actual, err := securitygroups.UpdatePorts(serviceClient(), "../vpcs/vpc-id", securitygroups.UpdatePortsOpts{
+		Ports: []securitygroups.Port{{ID: "port-1"}}, Action: "add",
+	})
+	if err == nil || actual != nil {
+		t.Fatalf("expected nil response and invalid ID error, got %#v, %v", actual, err)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Implementation of https://docs.otc.t-systems.com/virtual-private-cloud/api-ref/vpc_apis_v1_v2/security_group/index.html API under VPC service

### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer

```
=== RUN   TestSecurityGroupUpdatePorts
--- PASS: TestSecurityGroupUpdatePorts (16.20s)
PASS

Process finished with the exit code 0

=== RUN   TestSecurityGroupLifecycle
--- PASS: TestSecurityGroupLifecycle (3.75s)
PASS

Process finished with the exit code 0
```