### PR TITLE
[Feat.] Add VPC peering support

### DIFF
--- a/acceptance/openstack/vpc/v2/peering_test.go
+++ b/acceptance/openstack/vpc/v2/peering_test.go
@@ -1,0 +1,99 @@
+package v2
+
+import (
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/clients"
+	"github.com/opentelekomcloud/gophertelekomcloud/acceptance/tools"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v1/vpcs"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v2/peerings"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestPeeringDeleteNotFound(t *testing.T) {
+	client, err := clients.NewVPCV2Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = peerings.Delete(client, "00000000-0000-0000-0000-000000000000"); err == nil {
+		t.Fatal("expected deleting a synthetic peering ID to fail")
+	}
+}
+
+func TestPeeringAcceptNotFound(t *testing.T) {
+	client, err := clients.NewVPCV2Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = peerings.Accept(client, "00000000-0000-0000-0000-000000000000"); err == nil {
+		t.Fatal("expected accepting a synthetic peering ID to fail")
+	}
+}
+
+func TestPeeringRejectNotFound(t *testing.T) {
+	client, err := clients.NewVPCV2Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = peerings.Reject(client, "00000000-0000-0000-0000-000000000000"); err == nil {
+		t.Fatal("expected rejecting a synthetic peering ID to fail")
+	}
+}
+
+func TestPeeringLifecycle(t *testing.T) {
+	v1Client, err := clients.NewVPCV1Client()
+	th.AssertNoErr(t, err)
+	v2Client, err := clients.NewVPCV2Client()
+	th.AssertNoErr(t, err)
+
+	requestVpc := createPeeringVPC(t, v1Client, "192.168.100.0/24")
+	acceptVpc := createPeeringVPC(t, v1Client, "192.168.101.0/24")
+
+	peering, err := peerings.Create(v2Client, peerings.CreateOpts{
+		Name:           tools.RandomString("peering-acc-", 3),
+		Description:    "VPC peering acceptance test",
+		RequestVpcInfo: peerings.VpcInfo{VpcID: requestVpc.ID},
+		AcceptVpcInfo:  peerings.VpcInfo{VpcID: acceptVpc.ID},
+	})
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		err := peerings.Delete(v2Client, peering.ID)
+		if _, ok := err.(golangsdk.ErrDefault404); !ok {
+			th.AssertNoErr(t, err)
+		}
+	})
+	th.AssertEquals(t, requestVpc.ID, peering.RequestVpcInfo.VpcID)
+	th.AssertEquals(t, acceptVpc.ID, peering.AcceptVpcInfo.VpcID)
+
+	found, err := peerings.Get(v2Client, peering.ID)
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, peering.ID, found.ID)
+
+	all, err := peerings.List(v2Client, peerings.ListOpts{ID: peering.ID})
+	th.AssertNoErr(t, err)
+	if len(all) != 1 {
+		t.Fatalf("expected one peering, got %d", len(all))
+	}
+	th.AssertEquals(t, peering.ID, all[0].ID)
+
+	updatedName := tools.RandomString("peering-updated-acc-", 3)
+	updated, err := peerings.Update(v2Client, peering.ID, peerings.UpdateOpts{
+		Name: &updatedName,
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, updatedName, updated.Name)
+}
+
+func createPeeringVPC(t *testing.T, client *golangsdk.ServiceClient, cidr string) *vpcs.Vpc {
+	t.Helper()
+	vpc, err := vpcs.Create(client, vpcs.CreateOpts{
+		Name: tools.RandomString("peering-vpc-acc-", 3),
+		CIDR: cidr,
+	})
+	th.AssertNoErr(t, err)
+	t.Cleanup(func() {
+		deleteSecurityGroupVPC(t, client, vpc.ID)
+	})
+	return vpc
+}

--- a/openstack/vpc/v2/peerings/Accept.go
+++ b/openstack/vpc/v2/peerings/Accept.go
@@ -1,0 +1,24 @@
+package peerings
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Accept(client *golangsdk.ServiceClient, peeringID string) (*Peering, error) {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints("vpc", "peerings", peeringID, "accept").Build()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := client.Put(client.ServiceURL(url.String()), nil, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+	var res Peering
+	if err = extract.Into(raw.Body, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}

--- a/openstack/vpc/v2/peerings/Accept_test.go
+++ b/openstack/vpc/v2/peerings/Accept_test.go
@@ -1,0 +1,31 @@
+package peerings_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v2/peerings"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestAccept(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/vpc/peerings/peering-id/accept", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodPut)
+		_, _ = w.Write([]byte(peeringJSON))
+	})
+	actual, err := peerings.Accept(serviceClient(), "peering-id")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "peering-id", actual.ID)
+	th.AssertEquals(t, "ACTIVE", actual.Status)
+}
+
+func TestAcceptInvalidID(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	actual, err := peerings.Accept(serviceClient(), "../peerings/other-id")
+	if err == nil || actual != nil {
+		t.Fatalf("expected nil response and invalid ID error, got %#v, %v", actual, err)
+	}
+}

--- a/openstack/vpc/v2/peerings/Create.go
+++ b/openstack/vpc/v2/peerings/Create.go
@@ -1,0 +1,34 @@
+package peerings
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type CreateOpts struct {
+	Name           string  `json:"name" required:"true"`
+	Description    string  `json:"description,omitempty"`
+	RequestVpcInfo VpcInfo `json:"request_vpc_info" required:"true"`
+	AcceptVpcInfo  VpcInfo `json:"accept_vpc_info" required:"true"`
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) (*Peering, error) {
+	b, err := build.RequestBody(opts, "peering")
+	if err != nil {
+		return nil, err
+	}
+	raw, err := client.Post(client.ServiceURL("vpc", "peerings"), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{201},
+	})
+	if err != nil {
+		return nil, err
+	}
+	var res struct {
+		Peering Peering `json:"peering"`
+	}
+	if err = extract.Into(raw.Body, &res); err != nil {
+		return nil, err
+	}
+	return &res.Peering, nil
+}

--- a/openstack/vpc/v2/peerings/Create_test.go
+++ b/openstack/vpc/v2/peerings/Create_test.go
@@ -1,0 +1,60 @@
+package peerings_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v2/peerings"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/vpc/peerings", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodPost)
+		th.TestJSONRequest(t, r, `{"peering":{"name":"peering-test","description":"peering description","request_vpc_info":{"vpc_id":"request-vpc-id"},"accept_vpc_info":{"vpc_id":"accept-vpc-id","tenant_id":"accept-tenant-id"}}}`)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"peering":` + peeringJSON + `}`))
+	})
+	actual, err := peerings.Create(serviceClient(), peerings.CreateOpts{
+		Name:        "peering-test",
+		Description: "peering description",
+		RequestVpcInfo: peerings.VpcInfo{
+			VpcID: "request-vpc-id",
+		},
+		AcceptVpcInfo: peerings.VpcInfo{
+			VpcID:    "accept-vpc-id",
+			TenantID: "accept-tenant-id",
+		},
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "peering-id", actual.ID)
+	th.AssertEquals(t, "request-tenant-id", actual.RequestVpcInfo.TenantID)
+	th.AssertEquals(t, "2026-09-11T10:00:00", actual.CreatedAt)
+}
+
+func TestCreateMissingRequiredOpts(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	actual, err := peerings.Create(serviceClient(), peerings.CreateOpts{})
+	if err == nil || actual != nil {
+		t.Fatalf("expected nil response and validation error, got %#v, %v", actual, err)
+	}
+}
+
+func TestCreateError(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/vpc/peerings", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	})
+	actual, err := peerings.Create(serviceClient(), peerings.CreateOpts{
+		Name:           "peering-test",
+		RequestVpcInfo: peerings.VpcInfo{VpcID: "request-vpc-id"},
+		AcceptVpcInfo:  peerings.VpcInfo{VpcID: "accept-vpc-id"},
+	})
+	if err == nil || actual != nil {
+		t.Fatalf("expected nil response and request error, got %#v, %v", actual, err)
+	}
+}

--- a/openstack/vpc/v2/peerings/Delete.go
+++ b/openstack/vpc/v2/peerings/Delete.go
@@ -1,0 +1,12 @@
+package peerings
+
+import golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+
+func Delete(client *golangsdk.ServiceClient, peeringID string) error {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints("vpc", "peerings", peeringID).Build()
+	if err != nil {
+		return err
+	}
+	_, err = client.Delete(client.ServiceURL(url.String()), nil)
+	return err
+}

--- a/openstack/vpc/v2/peerings/Delete_test.go
+++ b/openstack/vpc/v2/peerings/Delete_test.go
@@ -1,0 +1,34 @@
+package peerings_test
+
+import (
+	"net/http"
+	"testing"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v2/peerings"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+	"github.com/opentelekomcloud/gophertelekomcloud/testhelper/client"
+)
+
+func serviceClient() *golangsdk.ServiceClient {
+	return client.ServiceClient()
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/vpc/peerings/peering-id", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodDelete)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	err := peerings.Delete(serviceClient(), "peering-id")
+	th.AssertNoErr(t, err)
+}
+
+func TestDeleteInvalidID(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	if err := peerings.Delete(serviceClient(), "../peerings/other-id"); err == nil {
+		t.Fatal("expected invalid peering ID error")
+	}
+}

--- a/openstack/vpc/v2/peerings/Get.go
+++ b/openstack/vpc/v2/peerings/Get.go
@@ -1,0 +1,24 @@
+package peerings
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Get(client *golangsdk.ServiceClient, peeringID string) (*Peering, error) {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints("vpc", "peerings", peeringID).Build()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := client.Get(client.ServiceURL(url.String()), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	var res struct {
+		Peering Peering `json:"peering"`
+	}
+	if err = extract.Into(raw.Body, &res); err != nil {
+		return nil, err
+	}
+	return &res.Peering, nil
+}

--- a/openstack/vpc/v2/peerings/Get_test.go
+++ b/openstack/vpc/v2/peerings/Get_test.go
@@ -1,0 +1,32 @@
+package peerings_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v2/peerings"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/vpc/peerings/peering-id", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodGet)
+		_, _ = w.Write([]byte(`{"peering":` + peeringJSON + `}`))
+	})
+	actual, err := peerings.Get(serviceClient(), "peering-id")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "peering-id", actual.ID)
+	th.AssertEquals(t, "accept-vpc-id", actual.AcceptVpcInfo.VpcID)
+	th.AssertEquals(t, "2026-09-11T10:01:00", actual.UpdatedAt)
+}
+
+func TestGetInvalidID(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	actual, err := peerings.Get(serviceClient(), "../peerings/other-id")
+	if err == nil || actual != nil {
+		t.Fatalf("expected nil response and invalid ID error, got %#v, %v", actual, err)
+	}
+}

--- a/openstack/vpc/v2/peerings/List.go
+++ b/openstack/vpc/v2/peerings/List.go
@@ -1,0 +1,67 @@
+package peerings
+
+import (
+	"bytes"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+	"github.com/opentelekomcloud/gophertelekomcloud/pagination"
+)
+
+type ListOpts struct {
+	ID       string `q:"id,omitempty"`
+	Name     string `q:"name,omitempty"`
+	Status   string `q:"status,omitempty"`
+	TenantID string `q:"tenant_id,omitempty"`
+	VpcID    string `q:"vpc_id,omitempty"`
+	Marker   string `q:"marker,omitempty"`
+	Limit    *int   `q:"limit,omitempty"`
+}
+
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]Peering, error) {
+	url, err := golangsdk.NewURLBuilder().
+		WithEndpoints("vpc", "peerings").
+		WithQueryParams(&opts).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+	pages, err := pagination.Pager{
+		Client:     client,
+		InitialURL: client.ServiceURL(url.String()),
+		CreatePage: func(r pagination.NewPageResult) pagination.NewPage {
+			return PeeringPage{NewPageResult: r}
+		},
+	}.NewAllPages()
+	if err != nil {
+		return nil, err
+	}
+	return ExtractPeerings(pages)
+}
+
+type PeeringPage struct {
+	pagination.NewPageResult
+}
+
+func (p PeeringPage) NewNextPageURL() (string, error) {
+	var res struct {
+		Links []golangsdk.Link `json:"peerings_links"`
+	}
+	if err := extract.Into(bytes.NewReader(p.Body), &res); err != nil {
+		return "", err
+	}
+	return golangsdk.ExtractNextURL(res.Links)
+}
+
+func (p PeeringPage) NewIsEmpty() (bool, error) {
+	peerings, err := ExtractPeerings(p)
+	return len(peerings) == 0, err
+}
+
+func ExtractPeerings(page pagination.NewPage) ([]Peering, error) {
+	var res struct {
+		Peerings []Peering `json:"peerings"`
+	}
+	err := extract.Into(bytes.NewReader(page.(PeeringPage).Body), &res)
+	return res.Peerings, err
+}

--- a/openstack/vpc/v2/peerings/List_test.go
+++ b/openstack/vpc/v2/peerings/List_test.go
@@ -1,0 +1,74 @@
+package peerings_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v2/peerings"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/vpc/peerings", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodGet)
+		query := r.URL.Query()
+		th.AssertEquals(t, "peering-id", query.Get("id"))
+		th.AssertEquals(t, "peering-test", query.Get("name"))
+		th.AssertEquals(t, "ACTIVE", query.Get("status"))
+		th.AssertEquals(t, "tenant-id", query.Get("tenant_id"))
+		th.AssertEquals(t, "vpc-id", query.Get("vpc_id"))
+		th.AssertEquals(t, "marker-id", query.Get("marker"))
+		th.AssertEquals(t, "10", query.Get("limit"))
+		_, _ = w.Write([]byte(`{"peerings":[` + peeringJSON + `]}`))
+	})
+	limit := 10
+	actual, err := peerings.List(serviceClient(), peerings.ListOpts{
+		ID:       "peering-id",
+		Name:     "peering-test",
+		Status:   "ACTIVE",
+		TenantID: "tenant-id",
+		VpcID:    "vpc-id",
+		Marker:   "marker-id",
+		Limit:    &limit,
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 1, len(actual))
+	th.AssertEquals(t, "peering-id", actual[0].ID)
+}
+
+func TestListPagination(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	requests := 0
+	th.Mux.HandleFunc("/vpc/peerings", func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Query().Get("marker") == "" {
+			_, _ = w.Write([]byte(`{
+				"peerings":[` + peeringJSON + `],
+				"peerings_links":[{"href":"` + th.Server.URL + `/vpc/peerings?limit=1&marker=peering-id","rel":"next"}]
+			}`))
+			return
+		}
+		th.AssertEquals(t, "peering-id", r.URL.Query().Get("marker"))
+		_, _ = w.Write([]byte(`{"peerings":[` + peeringJSON + `],"peerings_links":[]}`))
+	})
+	limit := 1
+	actual, err := peerings.List(serviceClient(), peerings.ListOpts{Limit: &limit})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, 2, len(actual))
+	th.AssertEquals(t, 3, requests)
+}
+
+func TestExtractPeeringsInvalidResponse(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/vpc/peerings", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"peerings":`))
+	})
+	actual, err := peerings.List(serviceClient(), peerings.ListOpts{})
+	if err == nil || actual != nil {
+		t.Fatalf("expected nil response and extraction error, got %#v, %v", actual, err)
+	}
+}

--- a/openstack/vpc/v2/peerings/Reject.go
+++ b/openstack/vpc/v2/peerings/Reject.go
@@ -1,0 +1,24 @@
+package peerings
+
+import (
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+func Reject(client *golangsdk.ServiceClient, peeringID string) (*Peering, error) {
+	url, err := golangsdk.NewURLBuilder().WithEndpoints("vpc", "peerings", peeringID, "reject").Build()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := client.Put(client.ServiceURL(url.String()), nil, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+	var res Peering
+	if err = extract.Into(raw.Body, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}

--- a/openstack/vpc/v2/peerings/Reject_test.go
+++ b/openstack/vpc/v2/peerings/Reject_test.go
@@ -1,0 +1,31 @@
+package peerings_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v2/peerings"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestReject(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/vpc/peerings/peering-id/reject", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodPut)
+		_, _ = w.Write([]byte(peeringJSON))
+	})
+	actual, err := peerings.Reject(serviceClient(), "peering-id")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "peering-id", actual.ID)
+	th.AssertEquals(t, "ACTIVE", actual.Status)
+}
+
+func TestRejectInvalidID(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	actual, err := peerings.Reject(serviceClient(), "../peerings/other-id")
+	if err == nil || actual != nil {
+		t.Fatalf("expected nil response and invalid ID error, got %#v, %v", actual, err)
+	}
+}

--- a/openstack/vpc/v2/peerings/Update.go
+++ b/openstack/vpc/v2/peerings/Update.go
@@ -1,0 +1,41 @@
+package peerings
+
+import (
+	"fmt"
+
+	golangsdk "github.com/opentelekomcloud/gophertelekomcloud"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/build"
+	"github.com/opentelekomcloud/gophertelekomcloud/internal/extract"
+)
+
+type UpdateOpts struct {
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+}
+
+func Update(client *golangsdk.ServiceClient, peeringID string, opts UpdateOpts) (*Peering, error) {
+	if opts.Name == nil && opts.Description == nil {
+		return nil, fmt.Errorf("at least one of name or description must be specified")
+	}
+	url, err := golangsdk.NewURLBuilder().WithEndpoints("vpc", "peerings", peeringID).Build()
+	if err != nil {
+		return nil, err
+	}
+	b, err := build.RequestBody(opts, "peering")
+	if err != nil {
+		return nil, err
+	}
+	raw, err := client.Put(client.ServiceURL(url.String()), b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	if err != nil {
+		return nil, err
+	}
+	var res struct {
+		Peering Peering `json:"peering"`
+	}
+	if err = extract.Into(raw.Body, &res); err != nil {
+		return nil, err
+	}
+	return &res.Peering, nil
+}

--- a/openstack/vpc/v2/peerings/Update_test.go
+++ b/openstack/vpc/v2/peerings/Update_test.go
@@ -1,0 +1,46 @@
+package peerings_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/common/pointerto"
+	"github.com/opentelekomcloud/gophertelekomcloud/openstack/vpc/v2/peerings"
+	th "github.com/opentelekomcloud/gophertelekomcloud/testhelper"
+)
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	th.Mux.HandleFunc("/vpc/peerings/peering-id", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, http.MethodPut)
+		th.TestJSONRequest(t, r, `{"peering":{"name":"updated-name","description":""}}`)
+		_, _ = w.Write([]byte(`{"peering":` + peeringJSON + `}`))
+	})
+	actual, err := peerings.Update(serviceClient(), "peering-id", peerings.UpdateOpts{
+		Name:        pointerto.String("updated-name"),
+		Description: pointerto.String(""),
+	})
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "peering-id", actual.ID)
+}
+
+func TestUpdateMissingAttributes(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	actual, err := peerings.Update(serviceClient(), "peering-id", peerings.UpdateOpts{})
+	if err == nil || actual != nil {
+		t.Fatalf("expected nil response and validation error, got %#v, %v", actual, err)
+	}
+}
+
+func TestUpdateInvalidID(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	actual, err := peerings.Update(serviceClient(), "../peerings/other-id", peerings.UpdateOpts{
+		Name: pointerto.String("updated-name"),
+	})
+	if err == nil || actual != nil {
+		t.Fatalf("expected nil response and invalid ID error, got %#v, %v", actual, err)
+	}
+}

--- a/openstack/vpc/v2/peerings/fixtures_test.go
+++ b/openstack/vpc/v2/peerings/fixtures_test.go
@@ -1,0 +1,18 @@
+package peerings_test
+
+const peeringJSON = `{
+	"id":"peering-id",
+	"name":"peering-test",
+	"status":"ACTIVE",
+	"request_vpc_info":{
+		"vpc_id":"request-vpc-id",
+		"tenant_id":"request-tenant-id"
+	},
+	"accept_vpc_info":{
+		"vpc_id":"accept-vpc-id",
+		"tenant_id":"accept-tenant-id"
+	},
+	"description":"peering description",
+	"created_at":"2026-09-11T10:00:00",
+	"updated_at":"2026-09-11T10:01:00"
+}`

--- a/openstack/vpc/v2/peerings/types.go
+++ b/openstack/vpc/v2/peerings/types.go
@@ -1,0 +1,17 @@
+package peerings
+
+type VpcInfo struct {
+	VpcID    string `json:"vpc_id" required:"true"`
+	TenantID string `json:"tenant_id,omitempty"`
+}
+
+type Peering struct {
+	ID             string  `json:"id"`
+	Name           string  `json:"name"`
+	Status         string  `json:"status"`
+	RequestVpcInfo VpcInfo `json:"request_vpc_info"`
+	AcceptVpcInfo  VpcInfo `json:"accept_vpc_info"`
+	Description    string  `json:"description"`
+	CreatedAt      string  `json:"created_at"`
+	UpdatedAt      string  `json:"updated_at"`
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

### What this PR does / why we need it
Implements: [VPC Peering Connection](https://docs.otc.t-systems.com/virtual-private-cloud/api-ref/vpc_apis_v1_v2/vpc_peering_connection/index.html)
### Which issue this PR fixes
<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged -->

### Special notes for your reviewer
```
=== RUN   TestPeeringDeleteNotFound
--- PASS: TestPeeringDeleteNotFound (0.51s)
=== RUN   TestPeeringAcceptNotFound
--- PASS: TestPeeringAcceptNotFound (0.51s)
=== RUN   TestPeeringRejectNotFound
--- PASS: TestPeeringRejectNotFound (0.55s)
=== RUN   TestPeeringLifecycle
--- PASS: TestPeeringLifecycle (8.48s)
PASS

Process finished with the exit code 0
```